### PR TITLE
proxy: rename package `server` to `sqlserver`

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/TiProxy/pkg/proxy/backend"
 	"github.com/pingcap/TiProxy/pkg/proxy/client"
 	"github.com/pingcap/TiProxy/pkg/proxy/driver"
-	"github.com/pingcap/TiProxy/pkg/proxy/server"
+	"github.com/pingcap/TiProxy/pkg/proxy/sqlserver"
 	"github.com/pingcap/TiProxy/pkg/server/api"
 	"github.com/pingcap/TiProxy/pkg/util/waitgroup"
 	"github.com/pingcap/errors"
@@ -52,7 +52,7 @@ type Server struct {
 	Etcd *embed.Etcd
 
 	// L7 proxy
-	Proxy *server.Server
+	Proxy *sqlserver.SQLServer
 }
 
 func NewServer(ctx context.Context, cfg *config.Proxy, logger *zap.Logger, namespaceFiles string) (srv *Server, err error) {
@@ -160,7 +160,7 @@ func NewServer(ctx context.Context, cfg *config.Proxy, logger *zap.Logger, names
 	// setup proxy server
 	{
 		driverImpl := driver.NewDriverImpl(srv.NamespaceManager, client.NewClientConnectionImpl, backend.NewBackendConnManager)
-		srv.Proxy, err = server.NewServer(cfg, driverImpl)
+		srv.Proxy, err = sqlserver.NewSQLServer(cfg, driverImpl)
 		if err != nil {
 			err = errors.WithStack(err)
 			return


### PR DESCRIPTION
<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/tidb-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

<!-- Add the issue link with a summary if it exists. -->
There are 2 `server` packages, `server.go` files, and `Server` class:
- In `pkg/proxy/server`
- In `pkg/server`

This may confuse other developers.

### What is changed and how it works?

- Rename `pkg/proxy/server` to `pkg/proxy/sqlserver`
- Rename `pkg/proxy/server/server.go` to `pkg/proxy/sqlserver/sql_server.go`
- Rename `server/Server` class to `sqlserver/SQLServer`.