### PR TITLE
utils: new error package

### DIFF
--- a/pkg/util/errors/stacktrace.go
+++ b/pkg/util/errors/stacktrace.go
@@ -1,0 +1,72 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var (
+	_ fmt.Formatter = stacktrace(nil)
+)
+
+// formatFrame will print frame according to fmt.Formatter states. It is extracted to keep `stacktrace.Format` clean.
+func formatFrame(s fmt.State, fr runtime.Frame, verb rune) {
+	fn := fr.Function
+	if fn == "" {
+		fn = "unknown"
+	}
+	switch verb {
+	case 'v':
+		fallthrough
+	case 's':
+		io.WriteString(s, fn)
+		io.WriteString(s, "\n\t")
+		io.WriteString(s, fr.File)
+		if s.Flag('+') {
+			io.WriteString(s, ":")
+			formatFrame(s, fr, 'd')
+		}
+	case 'd':
+		io.WriteString(s, strconv.Itoa(fr.Line))
+	case 'n':
+		i := strings.LastIndex(fn, "/")
+		fn = fn[i+1:]
+		i = strings.Index(fn, ".")
+		io.WriteString(s, fn[i+1:])
+	}
+}
+
+// stacktrace only stores the pointers, infomation will be queried as need.
+type stacktrace []uintptr
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+func (st stacktrace) Format(s fmt.State, verb rune) {
+	frames := runtime.CallersFrames(st)
+	for {
+		fr, more := frames.Next()
+
+		io.WriteString(s, "\n")
+		formatFrame(s, fr, verb)
+
+		if !more {
+			break
+		}
+	}
+}


### PR DESCRIPTION
A simpler error package to replace `pingcap/errors`

Signed-off-by: xhe <xw897002528@gmail.com>

<!--
Thank you for working on Weir! Please read Weir's [CONTRIBUTING](https://github.com/tidb-incubator/weir/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->

### What problem does this PR solve?

Ref #8. A rewritten of the old package. If we don't process SQL statements, then neither `terror` nor `pingcap/errors` is necessary. This small wrapper package is enough.

### Check List

<!-- Remove the items that are not applicable. -->

Tests

<!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has persistent data change


### Release note

<!-- A bugfix or a new feature needs a release note. If there is no need release note, just uncomment the below line. -->

- No release note
