### PR TITLE
backend: add tests for transaction status

### DIFF
--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -37,6 +37,18 @@ type backendConfig struct {
 	rows        int
 	params      int
 	status      uint16
+	loops       int
+}
+
+func newBackendConfig() *backendConfig {
+	return &backendConfig{
+		capability:  defaultBackendCapability,
+		salt:        mockSalt,
+		authPlugin:  mysql.AuthCachingSha2Password,
+		switchAuth:  true,
+		authSucceed: true,
+		loops:       1,
+	}
 }
 
 type mockBackend struct {
@@ -120,6 +132,15 @@ func (mb *mockBackend) verifyPassword(packetIO *pnet.PacketIO) error {
 }
 
 func (mb *mockBackend) respond(packetIO *pnet.PacketIO) error {
+	for i := 0; i < mb.loops; i++ {
+		if err := mb.respondOnce(packetIO); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mb *mockBackend) respondOnce(packetIO *pnet.PacketIO) error {
 	packetIO.ResetSequence()
 	if _, err := packetIO.ReadPacket(); err != nil {
 		return err

--- a/pkg/proxy/backend/mock_client_test.go
+++ b/pkg/proxy/backend/mock_client_test.go
@@ -36,6 +36,19 @@ type clientConfig struct {
 	cmd        byte
 	filePkts   int
 	prepStmtID int
+	sql        string
+}
+
+func newClientConfig() *clientConfig {
+	return &clientConfig{
+		capability: defaultClientCapability,
+		username:   mockUsername,
+		dbName:     mockDBName,
+		authPlugin: mysql.AuthCachingSha2Password,
+		authData:   mockAuthData,
+		attrs:      make([]byte, 0),
+		sql:        mockCmdStr,
+	}
 }
 
 type mockClient struct {
@@ -163,9 +176,9 @@ func (mc *mockClient) requestChangeUser(packetIO *pnet.PacketIO) error {
 }
 
 func (mc *mockClient) requestPrepare(packetIO *pnet.PacketIO) error {
-	data := make([]byte, 0, len(mockCmdStr)+1)
+	data := make([]byte, 0, len(mc.sql)+1)
 	data = append(data, mysql.ComStmtPrepare)
-	data = append(data, []byte(mockCmdStr)...)
+	data = append(data, []byte(mc.sql)...)
 	if err := packetIO.WritePacket(data, true); err != nil {
 		return err
 	}
@@ -258,9 +271,9 @@ func (mc *mockClient) requestProcessInfo(packetIO *pnet.PacketIO) error {
 }
 
 func (mc *mockClient) query(packetIO *pnet.PacketIO) error {
-	data := make([]byte, 0, len(mockCmdStr)+1)
+	data := make([]byte, 0, len(mc.sql)+1)
 	data = append(data, mysql.ComQuery)
-	data = append(data, []byte(mockCmdStr)...)
+	data = append(data, []byte(mc.sql)...)
 	if err := packetIO.WritePacket(data, true); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34

Problem Summary:
Add tests for transaction status.

What is changed and how it works:
- `TestTxnStatus`: test whether the session is redirect-able when it has an active transaction.
- `TestMixPrepAndTxnStatus`: test whether the session is redirect-able for mixed prepared statement status and txn status.
- `TestHoldRequest`: test that the BEGIN statement will be held when the session is waiting for redirection.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
