### PR TITLE
router: refine BackendObserver and add tests

### DIFF
--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -1,4 +1,3 @@
-// Copyright 2020 Ipalfish, Inc.
 // Copyright 2022 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,19 +16,19 @@ package router
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
+	"net"
 	"strings"
 	"time"
 
 	"github.com/pingcap/TiProxy/pkg/config"
+	"github.com/pingcap/TiProxy/pkg/util/errors"
 	"github.com/pingcap/TiProxy/pkg/util/security"
-	"github.com/pingcap/errors"
+	"github.com/pingcap/TiProxy/pkg/util/waitgroup"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/util/logutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/keepalive"
@@ -52,7 +51,6 @@ func (bs *BackendStatus) String() string {
 const (
 	StatusHealthy BackendStatus = iota
 	StatusCannotConnect
-	StatusServerDown
 	StatusMemoryHigh
 	StatusRunSlow
 	StatusSchemaOutdated
@@ -61,7 +59,6 @@ const (
 var statusNames = map[BackendStatus]string{
 	StatusHealthy:        "healthy",
 	StatusCannotConnect:  "cannot connect",
-	StatusServerDown:     "server down",
 	StatusMemoryHigh:     "memory high",
 	StatusRunSlow:        "run slow",
 	StatusSchemaOutdated: "schema outdated",
@@ -70,7 +67,6 @@ var statusNames = map[BackendStatus]string{
 var statusScores = map[BackendStatus]int{
 	StatusHealthy:        0,
 	StatusCannotConnect:  10000000,
-	StatusServerDown:     10000000,
 	StatusMemoryHigh:     5000,
 	StatusRunSlow:        5000,
 	StatusSchemaOutdated: 10000000,
@@ -79,27 +75,63 @@ var statusScores = map[BackendStatus]int{
 const (
 	healthCheckInterval      = 5 * time.Second
 	healthCheckMaxRetries    = 3
-	healthCheckRetryInterval = 100 * time.Millisecond
-	healthCheckTimeout       = 1 * time.Second
+	healthCheckRetryInterval = 2 * time.Second
+	healthCheckTimeout       = 2 * time.Second
+	tombstoneThreshold       = 10 * time.Minute
+	topologyPathSuffix       = "/ttl"
 )
 
+// HealthCheckConfig contains some configurations for health check.
+// Some general configurations of them may be exposed to users in the future.
+// We can use shorter durations to speed up unit tests.
+type HealthCheckConfig struct {
+	healthCheckInterval      time.Duration
+	healthCheckMaxRetries    int
+	healthCheckRetryInterval time.Duration
+	healthCheckTimeout       time.Duration
+	tombstoneThreshold       time.Duration
+}
+
+func newDefaultHealthCheckConfig() *HealthCheckConfig {
+	return &HealthCheckConfig{
+		healthCheckInterval:      healthCheckInterval,
+		healthCheckMaxRetries:    healthCheckMaxRetries,
+		healthCheckRetryInterval: healthCheckRetryInterval,
+		healthCheckTimeout:       healthCheckTimeout,
+		tombstoneThreshold:       tombstoneThreshold,
+	}
+}
+
+// BackendEventReceiver receives the event of backend status change.
 type BackendEventReceiver interface {
-	OnBackendChanged(backends map[string]*BackendInfo)
+	// OnBackendChanged is called when the backend list changes.
+	OnBackendChanged(backends map[string]BackendStatus)
 }
 
-type BackendInfo struct {
-	*infosync.TopologyInfo
-	status BackendStatus
+// BackendTTLInfo stores the ttl info of each backend.
+type BackendTTLInfo struct {
+	// The TTL time in the topology info.
+	ttl []byte
+	// Last time the TTL time is refreshed.
+	// If the TTL stays unchanged for a long time, the backend might be a tombstone.
+	lastUpdate time.Time
 }
 
+// BackendObserver refreshes backend list and notifies BackendEventReceiver.
 type BackendObserver struct {
-	backendInfo   map[string]*BackendInfo
-	client        *clientv3.Client
-	staticAddrs   []string
-	eventReceiver BackendEventReceiver
-	cancelFunc    context.CancelFunc
+	config *HealthCheckConfig
+	// The current backend status sent to the receiver.
+	curBackendInfo map[string]BackendStatus
+	// All the backend info in the topology, including tombstones.
+	allBackendInfo map[string]*BackendTTLInfo
+	client         *clientv3.Client
+	staticAddrs    []string
+	eventReceiver  BackendEventReceiver
+	wg             waitgroup.WaitGroup
+	cancelFunc     context.CancelFunc
 }
 
+// InitEtcdClient initializes an etcd client that fetches TiDB instance topology from PD.
 func InitEtcdClient(cfg *config.Config) (*clientv3.Client, error) {
 	pdAddr := cfg.Proxy.PDAddrs
 	if len(pdAddr) == 0 {
@@ -138,23 +170,42 @@ func InitEtcdClient(cfg *config.Config) (*clientv3.Client, error) {
 			}),
 		},
 	})
-	return etcdClient, errors.Annotate(err, "init etcd client failed")
+	return etcdClient, errors.Wrapf(err, "init etcd client failed")
 }
 
-func NewBackendObserver(eventReceiver BackendEventReceiver, client *clientv3.Client, staticAddrs []string) (*BackendObserver, error) {
+// StartBackendObserver creates a BackendObserver and starts watching.
+func StartBackendObserver(eventReceiver BackendEventReceiver, client *clientv3.Client, config *HealthCheckConfig, staticAddrs []string) (*BackendObserver, error) {
+	bo, err := NewBackendObserver(eventReceiver, client, config, staticAddrs)
+	if err != nil {
+		return nil, err
+	}
+	bo.Start()
+	return bo, nil
+}
+
+// NewBackendObserver creates a BackendObserver.
+func NewBackendObserver(eventReceiver BackendEventReceiver, client *clientv3.Client, config *HealthCheckConfig, staticAddrs []string) (*BackendObserver, error) {
 	if client == nil && len(staticAddrs) == 0 {
 		return nil, ErrNoInstanceToSelect
 	}
 	bo := &BackendObserver{
-		backendInfo:   make(map[string]*BackendInfo),
-		client:        client,
-		staticAddrs:   staticAddrs,
-		eventReceiver: eventReceiver,
+		config:         config,
+		curBackendInfo: make(map[string]BackendStatus),
+		allBackendInfo: make(map[string]*BackendTTLInfo),
+		client:         client,
+		staticAddrs:    staticAddrs,
+		eventReceiver:  eventReceiver,
 	}
+	return bo, nil
+}
+
+// Start starts watching.
+func (bo *BackendObserver) Start() {
 	childCtx, cancelFunc := context.WithCancel(context.Background())
 	bo.cancelFunc = cancelFunc
-	go bo.observe(childCtx)
-	return bo, nil
+	bo.wg.Run(func() {
+		bo.observe(childCtx)
+	})
 }
 
 func (bo *BackendObserver) observe(ctx context.Context) {
@@ -171,15 +222,13 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 func (bo *BackendObserver) observeStaticAddrs(ctx context.Context) {
 	for ctx.Err() == nil {
 		select {
-		case <-time.After(healthCheckInterval):
+		case <-time.After(bo.config.healthCheckInterval):
 		case <-ctx.Done():
 			return
 		}
-		backendInfo := make(map[string]*BackendInfo)
+		backendInfo := make(map[string]BackendStatus)
 		for _, addr := range bo.staticAddrs {
-			backendInfo[addr] = &BackendInfo{
-				status: StatusHealthy,
-			}
+			backendInfo[addr] = StatusHealthy
 		}
 		// The status port is not configured, so we skip checking health now.
 		//bo.checkHealth(ctx, backendInfo)
@@ -190,27 +239,54 @@ func (bo *BackendObserver) observeStaticAddrs(ctx context.Context) {
 // If the PD address is configured, we watch the TiDB addresses on the ETCD.
 func (bo *BackendObserver) observeDynamicAddrs(ctx context.Context) {
 	watchCh := bo.client.Watch(ctx, infosync.TopologyInformationPath, clientv3.WithPrefix())
+	// Initialize the backends after watching so that new backends started between watching and refreshing
+	// will be fetched immediately.
+	bo.refreshBackends(ctx)
+	ticker := time.NewTicker(bo.config.healthCheckInterval)
+	defer ticker.Stop()
 	for ctx.Err() == nil {
+		needRefresh := false
 		select {
-		case _, ok := <-watchCh:
+		case resp, ok := <-watchCh:
 			if !ok {
 				// The etcdClient is closed.
 				return
 			}
-		case <-time.After(healthCheckInterval):
+			if resp.Canceled {
+				logutil.Logger(ctx).Warn("watch backend list is canceled, will retry later")
+				watchCh = bo.client.Watch(ctx, infosync.TopologyInformationPath, clientv3.WithPrefix())
+				time.Sleep(bo.config.healthCheckRetryInterval)
+				break
+			}
+			for _, ev := range resp.Events {
+				if strings.HasSuffix(string(ev.Kv.Key), topologyPathSuffix) {
+					needRefresh = true
+					break
+				}
+			}
+		case <-ticker.C:
+			needRefresh = true
 		case <-ctx.Done():
 			return
 		}
-		backendInfo, err := bo.fetchBackendList(ctx)
-		if err != nil {
+		if !needRefresh {
 			continue
 		}
-		bo.checkHealth(ctx, backendInfo)
-		bo.notifyIfChanged(backendInfo)
+		ticker.Reset(bo.config.healthCheckInterval)
+		bo.refreshBackends(ctx)
 	}
 }
 
-func (bo *BackendObserver) fetchBackendList(ctx context.Context) (map[string]*BackendInfo, error) {
+func (bo *BackendObserver) refreshBackends(ctx context.Context) {
+	backendInfo, err := bo.fetchBackendList(ctx)
+	if err != nil {
+		return
+	}
+	bo.checkHealth(ctx, backendInfo)
+	bo.notifyIfChanged(backendInfo)
+}
+
+func (bo *BackendObserver) fetchBackendList(ctx context.Context) (map[string]BackendStatus, error) {
 	var response *clientv3.GetResponse
 	var err error
 	// It's a critical problem if the proxy cannot connect to the server, so we always retry.
@@ -218,96 +294,106 @@ func (bo *BackendObserver) fetchBackendList(ctx context.Context) (map[string]*Ba
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		childCtx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+		childCtx, cancel := context.WithTimeout(ctx, bo.config.healthCheckTimeout)
 		response, err = bo.client.Get(childCtx, infosync.TopologyInformationPath, clientv3.WithPrefix())
 		cancel()
 		if err == nil {
 			break
 		}
-		logutil.Logger(ctx).Error("fetch backend list failed", zap.Error(err))
-		time.Sleep(healthCheckRetryInterval)
-	}
-	if err != nil {
-		return nil, err
+		logutil.Logger(ctx).Error("fetch backend list failed, will retry later", zap.Error(err))
+		time.Sleep(bo.config.healthCheckRetryInterval)
 	}
 
-	backendInfo := make(map[string]*BackendInfo)
+	curBackendInfo := make(map[string]BackendStatus, len(response.Kvs))
+	allBackendInfo := make(map[string]*BackendTTLInfo, len(response.Kvs))
+	now := time.Now()
 	for _, kv := range response.Kvs {
 		key := string(kv.Key)
-		if !strings.HasSuffix(key, "/info") {
+		if !strings.HasSuffix(key, topologyPathSuffix) {
 			continue
 		}
-		var topo *infosync.TopologyInfo
-		if err = json.Unmarshal(kv.Value, &topo); err != nil {
-			logutil.Logger(ctx).Error("unmarshal topology info failed", zap.String("key", string(kv.Key)),
-				zap.ByteString("value", kv.Value), zap.Error(err))
-			return nil, err
+		addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len(topologyPathSuffix)]
+		info, ok := bo.allBackendInfo[addr]
+		isTombstone := false
+		if ok {
+			if slices.Compare(info.ttl, kv.Value) != 0 {
+				// The TTL is updated this time.
+				info.lastUpdate = now
+				info.ttl = kv.Value
+			} else if info.lastUpdate.Add(bo.config.tombstoneThreshold).Before(now) {
+				// The TTL has not been updated for a long time.
+				isTombstone = true
+			}
+		} else {
+			// A new backend.
+			info = &BackendTTLInfo{
+				lastUpdate: now,
+				ttl:        kv.Value,
+			}
 		}
-		addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len("/info")]
-		backendInfo[addr] = &BackendInfo{
-			TopologyInfo: topo,
-			status:       StatusHealthy,
+		// After running for a long time, there might be many tombstones because failed TiDB instances
+		// don't delete themselves from the Etcd. Checking their health is a waste of time, leading to
+		// longer and longer checking interval. So tombstones won't be added to curBackendInfo.
+		if !isTombstone {
+			curBackendInfo[addr] = StatusHealthy
 		}
+		allBackendInfo[addr] = info
 	}
-	return backendInfo, nil
+	bo.allBackendInfo = allBackendInfo
+	return curBackendInfo, nil
 }
 
-func (bo *BackendObserver) checkHealth(ctx context.Context, backendInfo map[string]*BackendInfo) {
-	for _, info := range backendInfo {
-		url := fmt.Sprintf("http://%s:%d/status", info.TopologyInfo.IP, info.TopologyInfo.StatusPort)
-		var resp *http.Response
+func (bo *BackendObserver) checkHealth(ctx context.Context, backendInfo map[string]BackendStatus) {
+	for addr := range backendInfo {
 		var err error
-		for i := 0; i < healthCheckMaxRetries; i++ {
+		for i := 0; i < bo.config.healthCheckMaxRetries; i++ {
 			if ctx.Err() != nil {
 				return
 			}
-			if resp, err = http.Get(url); err == nil {
+			var conn net.Conn
+			conn, err = net.DialTimeout("tcp", addr, bo.config.healthCheckTimeout)
+			if err == nil {
+				_ = conn.Close()
 				break
 			}
-			if i < healthCheckMaxRetries-1 {
-				time.Sleep(healthCheckRetryInterval)
+			if i < bo.config.healthCheckMaxRetries-1 {
+				time.Sleep(bo.config.healthCheckRetryInterval)
 			}
 		}
 		if err != nil {
-			info.status = StatusCannotConnect
-			continue
-		} else if resp.StatusCode != http.StatusOK {
-			info.status = StatusServerDown
-		} else {
-			info.status = StatusHealthy
-		}
-		if err = resp.Body.Close(); err != nil {
-			logutil.Logger(ctx).Warn("close http response failed", zap.Error(err))
+			backendInfo[addr] = StatusCannotConnect
 		}
 	}
 }
 
-func (bo *BackendObserver) notifyIfChanged(backendInfo map[string]*BackendInfo) {
-	backends := make(map[string]*BackendInfo)
-	for addr, originalInfo := range bo.backendInfo {
-		if originalInfo.status == StatusHealthy {
-			newInfo, ok := backendInfo[addr]
-			if !ok || newInfo.status != StatusHealthy {
-				backends[addr] = newInfo
+func (bo *BackendObserver) notifyIfChanged(backendInfo map[string]BackendStatus) {
+	updatedBackends := make(map[string]BackendStatus)
+	for addr, lastStatus := range bo.curBackendInfo {
+		if lastStatus == StatusHealthy {
+			if newStatus, ok := backendInfo[addr]; !ok {
+				updatedBackends[addr] = StatusCannotConnect
+			} else if newStatus != StatusHealthy {
+				updatedBackends[addr] = newStatus
 			}
 		}
 	}
-	for addr, newInfo := range backendInfo {
-		if newInfo.status == StatusHealthy {
-			originalInfo, ok := bo.backendInfo[addr]
-			if !ok || originalInfo.status != StatusHealthy {
-				backends[addr] = newInfo
+	for addr, newStatus := range backendInfo {
+		if newStatus == StatusHealthy {
+			if lastStatus, ok := bo.curBackendInfo[addr]; !ok || lastStatus != StatusHealthy {
+				updatedBackends[addr] = newStatus
 			}
 		}
 	}
-	if len(backends) > 0 {
-		bo.eventReceiver.OnBackendChanged(backends)
+	if len(updatedBackends) > 0 {
+		bo.eventReceiver.OnBackendChanged(updatedBackends)
 	}
-	bo.backendInfo = backendInfo
+	bo.curBackendInfo = backendInfo
 }
 
+// Close releases all resources.
 func (bo *BackendObserver) Close() {
 	if bo.cancelFunc != nil {
 		bo.cancelFunc()
 	}
+	bo.wg.Wait()
 }

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -1,0 +1,247 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"github.com/pingcap/TiProxy/pkg/config"
+	"github.com/pingcap/tidb/domain/infosync"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"net"
+	"net/url"
+	"path"
+	"testing"
+	"time"
+)
+
+type mockEventReceiver struct {
+	backendChan chan map[string]BackendStatus
+}
+
+func (mer *mockEventReceiver) OnBackendChanged(backends map[string]BackendStatus) {
+	mer.backendChan <- backends
+}
+
+func newMockEventReceiver(backendChan chan map[string]BackendStatus) *mockEventReceiver {
+	return &mockEventReceiver{
+		backendChan: backendChan,
+	}
+}
+
+func newHealthCheckConfigForTest() *HealthCheckConfig {
+	return &HealthCheckConfig{
+		healthCheckInterval:      500 * time.Millisecond,
+		healthCheckMaxRetries:    healthCheckMaxRetries,
+		healthCheckRetryInterval: 100 * time.Millisecond,
+		healthCheckTimeout:       100 * time.Millisecond,
+		tombstoneThreshold:       tombstoneThreshold,
+	}
+}
+
+func createEtcdServer(t *testing.T, addr string) *embed.Etcd {
+	serverURL, err := url.Parse(fmt.Sprintf("http://%s", addr))
+	require.NoError(t, err)
+	cfg := embed.NewConfig()
+	cfg.Dir = t.TempDir()
+	cfg.LCUrls = []url.URL{*serverURL}
+	cfg.LPUrls = []url.URL{*serverURL}
+	cfg.LogLevel = "fatal"
+	etcd, err := embed.StartEtcd(cfg)
+	require.NoError(t, err)
+	<-etcd.Server.ReadyNotify()
+	t.Cleanup(etcd.Close)
+	return etcd
+}
+
+func createEtcdClient(t *testing.T, etcd *embed.Etcd) *clientv3.Client {
+	cfg := &config.Config{
+		Proxy: config.ProxyServer{
+			PDAddrs: etcd.Clients[0].Addr().String(),
+		},
+	}
+	client, err := InitEtcdClient(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+	return client
+}
+
+// Test that the notified backend status is correct when the backend starts or shuts down.
+func TestObserveBackends(t *testing.T) {
+	etcd := createEtcdServer(t, "127.0.0.1:0")
+	client := createEtcdClient(t, etcd)
+	backendChan := make(chan map[string]BackendStatus, 1)
+	mer := newMockEventReceiver(backendChan)
+	bo, err := StartBackendObserver(mer, client, newHealthCheckConfigForTest(), nil)
+	require.NoError(t, err)
+	kv := clientv3.NewKV(client)
+
+	listener1, addr1 := checkAddBackend(t, kv, backendChan)
+	addFakeTopology(t, kv, addr1)
+	listener2, addr2 := checkAddBackend(t, kv, backendChan)
+	checkBackendUnavailable(t, backendChan, listener1, addr1)
+	checkRemoveBackend(t, kv, backendChan, listener2, addr2)
+	listener1 = checkRestart(t, backendChan, addr1)
+	bo.Close()
+}
+
+func newListener(t *testing.T, addr string) (net.Listener, string) {
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	addr = listener.Addr().String()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				// listener is closed
+				break
+			}
+			_ = conn.Close()
+		}
+	}()
+	return listener, addr
+}
+
+// A new healthy backend is added.
+func checkAddBackend(t *testing.T, kv clientv3.KV, backendChan chan map[string]BackendStatus) (net.Listener, string) {
+	listener, addr := newListener(t, "127.0.0.1:0")
+	updateTTL(t, kv, addr, "123456789")
+	checkStatus(t, backendChan, addr, StatusHealthy)
+	return listener, addr
+}
+
+// Update the path prefix but it doesn't affect the topology.
+func addFakeTopology(t *testing.T, kv clientv3.KV, addr string) {
+	_, err := kv.Put(context.Background(), path.Join(infosync.TopologyInformationPath, addr, "/info"), "{}")
+	require.NoError(t, err)
+}
+
+// The backend is still in Etcd but it's actually unavailable.
+func checkBackendUnavailable(t *testing.T, backendChan chan map[string]BackendStatus, listener net.Listener, addr string) {
+	require.NoError(t, listener.Close())
+	checkStatus(t, backendChan, addr, StatusCannotConnect)
+}
+
+// Restart a backend that was alive.
+func checkRestart(t *testing.T, backendChan chan map[string]BackendStatus, addr string) net.Listener {
+	listener, _ := newListener(t, addr)
+	checkStatus(t, backendChan, addr, StatusHealthy)
+	return listener
+}
+
+// A backend is removed from Etcd.
+func checkRemoveBackend(t *testing.T, kv clientv3.KV, backendChan chan map[string]BackendStatus, listener net.Listener, addr string) {
+	_, err := kv.Delete(context.Background(), path.Join(infosync.TopologyInformationPath, addr, topologyPathSuffix))
+	require.NoError(t, err)
+	checkStatus(t, backendChan, addr, StatusCannotConnect)
+	require.NoError(t, listener.Close())
+}
+
+func checkStatus(t *testing.T, backendChan chan map[string]BackendStatus, addr string, expectedStatus BackendStatus) {
+	backends := <-backendChan
+	require.Equal(t, 1, len(backends))
+	status, ok := backends[addr]
+	require.True(t, ok)
+	require.Equal(t, expectedStatus, status)
+}
+
+// Update the TTL for a backend.
+func updateTTL(t *testing.T, kv clientv3.KV, addr, ttl string) {
+	_, err := kv.Put(context.Background(), path.Join(infosync.TopologyInformationPath, addr, topologyPathSuffix), ttl)
+	require.NoError(t, err)
+}
+
+// Test that the health of tombstone backends won't be checked.
+func TestTombstoneBackends(t *testing.T) {
+	etcd := createEtcdServer(t, "127.0.0.1:0")
+	client := createEtcdClient(t, etcd)
+	backendChan := make(chan map[string]BackendStatus, 1)
+	mer := newMockEventReceiver(backendChan)
+	bo, err := NewBackendObserver(mer, client, newHealthCheckConfigForTest(), nil)
+	require.NoError(t, err)
+	kv := clientv3.NewKV(client)
+
+	// Do not start observer to avoid data race, just mock data.
+	now := time.Now()
+	bo.allBackendInfo = map[string]*BackendTTLInfo{
+		"dead_addr": {
+			ttl:        []byte("123456789"),
+			lastUpdate: now.Add(-bo.config.tombstoneThreshold * 2),
+		},
+		"restart_addr": {
+			ttl:        []byte("123456789"),
+			lastUpdate: now.Add(-bo.config.tombstoneThreshold * 2),
+		},
+		"removed_addr": {
+			ttl:        []byte("123456789"),
+			lastUpdate: now,
+		},
+		"alive_addr": {
+			ttl:        []byte("123456789"),
+			lastUpdate: now,
+		},
+	}
+	bo.curBackendInfo = map[string]BackendStatus{
+		"dead_addr":    StatusCannotConnect,
+		"removed_addr": StatusHealthy,
+		"alive_addr":   StatusHealthy,
+	}
+
+	updateTTL(t, kv, "dead_addr", "123456789")
+	updateTTL(t, kv, "restart_addr", "999999999")
+	updateTTL(t, kv, "alive_addr", "999999999")
+	updateTTL(t, kv, "new_addr", "999999999")
+
+	backendsToBeChecked, err := bo.fetchBackendList(context.Background())
+	require.NoError(t, err)
+	// dead_addr and removed_addr won't be checked.
+	require.Equal(t, map[string]BackendStatus{
+		"restart_addr": StatusHealthy,
+		"alive_addr":   StatusHealthy,
+		"new_addr":     StatusHealthy,
+	}, backendsToBeChecked)
+	// All backends exist except removed_addr.
+	require.Equal(t, 4, len(bo.allBackendInfo))
+	checkAddrAndTTL := func(addr, ttl string) {
+		info, ok := bo.allBackendInfo[addr]
+		require.True(t, ok)
+		require.Equal(t, []byte(ttl), info.ttl)
+	}
+	checkAddrAndTTL("dead_addr", "123456789")
+	checkAddrAndTTL("restart_addr", "999999999")
+	checkAddrAndTTL("alive_addr", "999999999")
+	checkAddrAndTTL("new_addr", "999999999")
+}
+
+// Test that it won't hang or panic when the Etcd server fails.
+func TestEtcdUnavailable(t *testing.T) {
+	etcd := createEtcdServer(t, "127.0.0.1:0")
+	client := createEtcdClient(t, etcd)
+	backendChan := make(chan map[string]BackendStatus, 1)
+	mer := newMockEventReceiver(backendChan)
+	bo, err := StartBackendObserver(mer, client, newHealthCheckConfigForTest(), nil)
+	require.NoError(t, err)
+	etcd.Server.Stop()
+	<-etcd.Server.StopNotify()
+	// The observer will retry indefinitely. We verify it won't panic or hang here.
+	// There's no other way than modifying the code or just sleeping.
+	time.Sleep(bo.config.healthCheckInterval + bo.config.healthCheckTimeout + bo.config.healthCheckRetryInterval)
+	require.Equal(t, 0, len(backendChan))
+	bo.Close()
+}


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #58

Problem Summary:
- The status port cannot stand for the real status of the SQL server.
- Lack of tests

What is changed and how it works:
- Also fetch `/topology/tidb/ip:port/ttl` to filter tombstone backends
- Dial both the status port and the MySQL protocol port to check the health
- Add tests

I also proposed 2 enhancements for TiDB graceful shutdown: https://github.com/pingcap/tidb/issues/37471

TODO:
- Expose some configurations, such as health check interval, just like HAProxy https://github.com/pingcap/TiProxy/issues/60
- Split BackendStatus to a separate file
- Add TLS options to the HTTP status and etcd client connections

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Scale out and scale in the TiDB cluster during running sysbench.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
