### PR TITLE
util: try to fix panic

### DIFF
--- a/pkg/util/cmd/encoder.go
+++ b/pkg/util/cmd/encoder.go
@@ -50,7 +50,7 @@ func (c tidbEncoder) clone() *tidbEncoder {
 }
 
 func (c tidbEncoder) Clone() zapcore.Encoder {
-	return c.Clone()
+	return c.clone()
 }
 
 func (c *tidbEncoder) beginQuoteFiled() {

--- a/pkg/util/cmd/encoder.go
+++ b/pkg/util/cmd/encoder.go
@@ -329,10 +329,11 @@ func (s *tidbEncoder) closeOpenNamespaces() {
 
 /* array encoder part */
 func (s *tidbEncoder) addElementSeparator() {
-	if s.line.Len() <= 0 {
+	length := s.line.Len()
+	if length == 0 {
 		return
 	}
-	switch s.line.Bytes()[s.line.Len()-1] {
+	switch s.line.Bytes()[length-1] {
 	case '{', '[', ':', ',', ' ', '=':
 	default:
 		s.line.AppendByte(',')


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: I don't know how it is produced. `len(xx) >= 0` is expected, thus the judgement should be true forever. Anyway, this is a try.

What is changed and how it works: 

1. `EncodeEntry` will not free the buffer anymore, it is left to zap logger, based on https://github.com/uber-go/zap/blob/4a895a245ab794e3ae965783843a9fbc793083bc/zapcore/core.go#L95-L100
2. `StackTrace` by zap is multiline, this is not compatible with `tidb` format.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
