### PR TITLE
*: add pingcap/log encoder as the default encoder

### DIFF
--- a/cmd/weirctl/main.go
+++ b/cmd/weirctl/main.go
@@ -31,7 +31,7 @@ func main() {
 	ctx := &Context{}
 
 	curls := rootCmd.PersistentFlags().StringArray("curls", []string{"localhost:3080"}, "API gateway addresses")
-	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, newtidb, console, or json")
+	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "info", "log level")
 	rootCmd.PersistentFlags().Bool("indent", true, "whether indent the returned json")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/weirctl/main.go
+++ b/cmd/weirctl/main.go
@@ -31,7 +31,7 @@ func main() {
 	ctx := &Context{}
 
 	curls := rootCmd.PersistentFlags().StringArray("curls", []string{"localhost:3080"}, "API gateway addresses")
-	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
+	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, newtidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "info", "log level")
 	rootCmd.PersistentFlags().Bool("indent", true, "whether indent the returned json")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/weirproxy/main.go
+++ b/cmd/weirproxy/main.go
@@ -57,6 +57,7 @@ func main() {
 
 		zapcfg := zap.NewDevelopmentConfig()
 		zapcfg.Encoding = cfg.Log.Encoder
+		zapcfg.DisableStacktrace = true
 		if level, err := zap.ParseAtomicLevel(cfg.Log.Level); err == nil {
 			zapcfg.Level = level
 		}

--- a/cmd/weirproxy/main.go
+++ b/cmd/weirproxy/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	configFile := rootCmd.PersistentFlags().String("config", "conf/weirproxy.yaml", "weir proxy config file path")
-	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "", "log in format of tidb, newtidb, console, or json")
+	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "", "log level")
 	namespaceFiles := rootCmd.PersistentFlags().String("namespaces", "", "import namespace from dir")
 

--- a/cmd/weirproxy/main.go
+++ b/cmd/weirproxy/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	configFile := rootCmd.PersistentFlags().String("config", "conf/weirproxy.yaml", "weir proxy config file path")
-	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "", "log in format of tidb, console, or json")
+	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "", "log in format of tidb, newtidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "", "log level")
 	namespaceFiles := rootCmd.PersistentFlags().String("namespaces", "", "import namespace from dir")
 

--- a/pkg/util/cmd/cmd.go
+++ b/pkg/util/cmd/cmd.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/pingcap/log"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -32,6 +33,9 @@ var registerEncoders sync.Once
 func RunRootCommand(rootCmd *cobra.Command) {
 	registerEncoders.Do(func() {
 		zap.RegisterEncoder("tidb", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
+			return log.NewTextEncoder(&log.Config{})
+		})
+		zap.RegisterEncoder("newtidb", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
 			return NewTiDBEncoder(cfg), nil
 		})
 	})


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: To reduce the risk of GA, the old encoder is brought back as the default.

What is changed and how it works: `StackTrace` by zap is multiline, this is not compatible with `tidb` format.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
