### PR TITLE
server: use json for API and internal storage

### DIFF
--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/pingcap/TiProxy/pkg/util/errors"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -51,11 +52,11 @@ func NewNamespacesFromDir(nsdir string) (*NamespaceDir, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfg, err := NewNamespaceConfig(fileData)
-		if err != nil {
+		var cfg Namespace
+		if err := yaml.Unmarshal(fileData, &cfg); err != nil {
 			return nil, err
 		}
-		c.cfgs[cfg.Namespace] = cfg
+		c.cfgs[cfg.Namespace] = &cfg
 		c.nspath[cfg.Namespace] = yamlFile
 	}
 

--- a/pkg/config/namespace.go
+++ b/pkg/config/namespace.go
@@ -15,44 +15,18 @@
 
 package config
 
-import (
-	"io/ioutil"
-
-	"github.com/goccy/go-yaml"
-)
-
 type Namespace struct {
-	Namespace string            `yaml:"namespace"`
-	Frontend  FrontendNamespace `yaml:"frontend"`
-	Backend   BackendNamespace  `yaml:"backend"`
+	Namespace string            `yaml:"namespace" json:"namespace" toml:"namespace"`
+	Frontend  FrontendNamespace `yaml:"frontend" json:"frontend" toml:"frontend"`
+	Backend   BackendNamespace  `yaml:"backend" json:"backend" toml:"backend"`
 }
 
 type FrontendNamespace struct {
-	Security TLSCert `yaml:"security"`
+	Security TLSCert `yaml:"security" json:"security" toml:"security"`
 }
 
 type BackendNamespace struct {
-	Instances    []string `yaml:"instances"`
-	SelectorType string   `yaml:"selector_type"`
-	Security     TLSCert  `yaml:"security"`
-}
-
-func NewNamespaceConfig(data []byte) (*Namespace, error) {
-	var cfg Namespace
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, err
-	}
-	return &cfg, nil
-}
-
-func NewNamespaceConfigFile(path string) (*Namespace, error) {
-	fileData, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	return NewNamespaceConfig(fileData)
-}
-
-func (cfg *Namespace) ToBytes() ([]byte, error) {
-	return yaml.Marshal(cfg)
+	Instances    []string `yaml:"instances" json:"instances" toml:"instances"`
+	SelectorType string   `yaml:"selector_type" json:"selector_type" toml:"selector_type"`
+	Security     TLSCert  `yaml:"security" json:"security" toml:"security"`
 }

--- a/pkg/config/namespace_test.go
+++ b/pkg/config/namespace_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 var testNamespaceConfig = Namespace{
@@ -27,9 +28,9 @@ var testNamespaceConfig = Namespace{
 }
 
 func TestNamespaceConfig(t *testing.T) {
-	data, err := testNamespaceConfig.ToBytes()
+	data, err := yaml.Marshal(testNamespaceConfig)
 	require.NoError(t, err)
-	cfg, err := NewNamespaceConfig(data)
-	require.NoError(t, err)
-	require.Equal(t, testNamespaceConfig, *cfg)
+	var cfg Namespace
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Equal(t, testNamespaceConfig, cfg)
 }

--- a/pkg/server/api/config.go
+++ b/pkg/server/api/config.go
@@ -31,16 +31,16 @@ type configHttpHandler struct {
 func (h *configHttpHandler) HandleSetProxyConfig(c *gin.Context) {
 	pco := &config.ProxyServerOnline{}
 	if c.ShouldBindJSON(pco) != nil {
-		c.String(http.StatusBadRequest, "bad proxy config json")
+		c.JSON(http.StatusBadRequest, "bad proxy config json")
 		return
 	}
 
 	if err := h.cfgmgr.SetProxyConfig(c, pco); err != nil {
-		c.String(http.StatusInternalServerError, "can not update proxy config")
+		c.JSON(http.StatusInternalServerError, "can not update proxy config")
 		return
 	}
 
-	c.String(http.StatusOK, "")
+	c.JSON(http.StatusOK, "")
 }
 
 func registerConfig(group *gin.RouterGroup, logger *zap.Logger, mgrcfg *mgrcfg.ConfigManager) {

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -39,9 +39,9 @@ func (h *debugHttpHandler) Redirect(c *gin.Context) {
 		}
 		h.logger.Error(errMsg, err_fields...)
 
-		c.String(http.StatusInternalServerError, errMsg)
+		c.JSON(http.StatusInternalServerError, errMsg)
 	} else {
-		c.String(http.StatusOK, "")
+		c.JSON(http.StatusOK, "")
 	}
 }
 

--- a/pkg/server/api/namespace.go
+++ b/pkg/server/api/namespace.go
@@ -33,55 +33,55 @@ type namespaceHttpHandler struct {
 func (h *namespaceHttpHandler) HandleGetNamespace(c *gin.Context) {
 	ns := c.Param("namespace")
 	if ns == "" {
-		c.String(http.StatusBadRequest, "bad namespace parameter")
+		c.JSON(http.StatusBadRequest, "bad namespace parameter")
 		return
 	}
 
 	nsc, err := h.cfgmgr.GetNamespace(c, ns)
 	if err != nil {
 		h.logger.Error("can not get namespace", zap.String("namespace", ns), zap.Error(err))
-		c.String(http.StatusInternalServerError, "can not get namespace")
+		c.JSON(http.StatusInternalServerError, "can not get namespace")
 		return
 	}
 
-	c.YAML(http.StatusOK, nsc)
+	c.JSON(http.StatusOK, nsc)
 }
 
 func (h *namespaceHttpHandler) HandleUpsertNamesapce(c *gin.Context) {
 	ns := c.Param("namespace")
 	if ns == "" {
-		c.String(http.StatusBadRequest, "bad namespace parameter")
+		c.JSON(http.StatusBadRequest, "bad namespace parameter")
 		return
 	}
 
 	nsc := &config.Namespace{}
 
-	if c.ShouldBindYAML(nsc) != nil {
-		c.String(http.StatusBadRequest, "bad namespace json")
+	if c.ShouldBindJSON(nsc) != nil {
+		c.JSON(http.StatusBadRequest, "bad namespace json")
 		return
 	}
 
 	if err := h.cfgmgr.SetNamespace(c, nsc.Namespace, nsc); err != nil {
-		c.String(http.StatusInternalServerError, "can not update config")
+		c.JSON(http.StatusInternalServerError, "can not update config")
 		return
 	}
 
-	c.String(http.StatusOK, "")
+	c.JSON(http.StatusOK, "")
 }
 
 func (h *namespaceHttpHandler) HandleRemoveNamespace(c *gin.Context) {
 	ns := c.Param("namespace")
 	if ns == "" {
-		c.String(http.StatusBadRequest, "bad namespace parameter")
+		c.JSON(http.StatusBadRequest, "bad namespace parameter")
 		return
 	}
 
 	if err := h.cfgmgr.DelNamespace(c, ns); err != nil {
-		c.String(http.StatusInternalServerError, "can not update config")
+		c.JSON(http.StatusInternalServerError, "can not update config")
 		return
 	}
 
-	c.String(http.StatusOK, "")
+	c.JSON(http.StatusOK, "")
 }
 
 func (h *namespaceHttpHandler) HandleCommit(c *gin.Context) {
@@ -109,11 +109,11 @@ func (h *namespaceHttpHandler) HandleCommit(c *gin.Context) {
 	if err := h.nsmgr.CommitNamespaces(nss, nss_delete); err != nil {
 		errMsg := "commit reload namespace error"
 		h.logger.Error(errMsg, zap.Error(err), zap.Any("namespaces", nss))
-		c.String(http.StatusInternalServerError, errMsg)
+		c.JSON(http.StatusInternalServerError, errMsg)
 		return
 	}
 
-	c.String(http.StatusOK, "")
+	c.JSON(http.StatusOK, "")
 }
 
 func (h *namespaceHttpHandler) HandleList(c *gin.Context) {
@@ -121,11 +121,11 @@ func (h *namespaceHttpHandler) HandleList(c *gin.Context) {
 	if err != nil {
 		errMsg := "failed to list namespaces"
 		h.logger.Error(errMsg, zap.Error(err))
-		c.String(http.StatusInternalServerError, errMsg)
+		c.JSON(http.StatusInternalServerError, errMsg)
 		return
 	}
 
-	c.YAML(http.StatusOK, nscs)
+	c.JSON(http.StatusOK, nscs)
 }
 
 func registerNamespace(group *gin.RouterGroup, logger *zap.Logger, mgrcfg *mgrcfg.ConfigManager, mgrns *mgrns.NamespaceManager) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,7 +73,7 @@ func NewServer(ctx context.Context, cfg *config.Config, logger *zap.Logger, name
 			func(c *gin.Context) {
 				if !ready.Load() {
 					c.Abort()
-					c.String(http.StatusInternalServerError, "service not ready")
+					c.JSON(http.StatusInternalServerError, "service not ready")
 				}
 			},
 		)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #11

Problem Summary: Reduce assumption on what format the server will return or store.

What is changed and how it works:  The server will process json only now. The cli is resposible to convert it from yaml to json or vice versa.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
./bin/weirctl namespace list
./bin/weirctl namespace get default
./bin/weirctl namespace put
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
