### PR TITLE
backend: fix the bug that the redirection signal may be discarded

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -292,10 +292,8 @@ func (mgr *BackendConnManager) Redirect(newAddr string) {
 	atomic.StorePointer(&mgr.signal, unsafe.Pointer(&signalRedirect{
 		newAddr: newAddr,
 	}))
-	select {
-	case mgr.signalReceived <- struct{}{}:
-	default:
-	}
+	// Generally, it won't wait because the caller won't send another signal because the last one finishes.
+	mgr.signalReceived <- struct{}{}
 }
 
 // GetRedirectingAddr implements RedirectableConn.GetRedirectingAddr interface.

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -88,7 +88,7 @@ func NewBackendConnManager(connectionID uint64) *BackendConnManager {
 		connectionID:   connectionID,
 		cmdProcessor:   NewCmdProcessor(),
 		authenticator:  &Authenticator{},
-		signalReceived: make(chan struct{}),
+		signalReceived: make(chan struct{}, 1),
 		redirectResCh:  make(chan *redirectResult, 1),
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:
Some test cases are unstable, such as `TestNormalRedirect`(https://github.com/pingcap/TiProxy/runs/8181135325?check_suite_focus=true) and `TestRedirectFail`.

Reason:
This is a bug introduced by https://github.com/pingcap/TiProxy/pull/72. It doesn't only happen in testing.
Since `BackendConnManager.processSignals` also handles `mgr.redirectResCh` now, this may happen:
- The process signal goroutine is executing `notifyRedirectResult()` and calls `OnRedirectSucceed()`.
- The router sees that the redirection succeeds and sends another redirection signal immediately.
- The process signal goroutine is just returning from `notifyRedirectResult()` but does not go to the `select-case` yet.
- `BackendConnManager.Redirect` is a non-blocking function but the size of channel `signalReceived` is 0, it discards the signal because it needs to wait.
- The redirection signal is never sent but the router thought it had, thus the connection will never finish redirection.

What is changed and how it works:
Actually, doing one of these modifications is enough, but I modified them both to be more secure:
- Change the size of channel `signalReceived` to 1.
- Never discard the redirection signal.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
