### PR TITLE
*: remove logutil in proxy

### DIFF
--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -16,8 +16,10 @@ package backend
 
 import (
 	"crypto/tls"
+	"testing"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/TiProxy/lib/util/logger"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 )
 
@@ -46,10 +48,10 @@ type mockProxy struct {
 	holdRequest bool
 }
 
-func newMockProxy(cfg *proxyConfig) *mockProxy {
+func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 	mp := &mockProxy{
 		proxyConfig:        cfg,
-		BackendConnManager: NewBackendConnManager(0),
+		BackendConnManager: NewBackendConnManager(logger.CreateLoggerForTest(t), 0),
 	}
 	mp.cmdProcessor.capability = cfg.capability
 	return mp

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -130,7 +130,7 @@ func newTestSuite(t *testing.T, tc *tcpConnSuite, overriders ...cfgOverrider) (*
 		config.clientConfig.tlsConfig = tc.clientTLSConfig
 	})...)
 	ts.mb = newMockBackend(cfg.backendConfig)
-	ts.mp = newMockProxy(cfg.proxyConfig)
+	ts.mp = newMockProxy(t, cfg.proxyConfig)
 	ts.mc = newMockClient(cfg.clientConfig)
 	ts.tc = tc
 	ts.testSuiteConfig = cfg.testSuiteConfig

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/TiProxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )
 
@@ -73,7 +72,7 @@ func (cc *ClientConnection) connectBackend(ctx context.Context) error {
 
 func (cc *ClientConnection) Run(ctx context.Context) {
 	if err := cc.connectBackend(ctx); err != nil {
-		logutil.Logger(ctx).Info("new connection fails", zap.String("remoteAddr", cc.Addr()), zap.Error(err))
+		cc.logger.Info("new connection fails", zap.String("remoteAddr", cc.Addr()), zap.Error(err))
 		return
 	}
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -125,7 +125,7 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn) {
 	connID := s.mu.connID
 	s.mu.connID++
 	logger := s.logger.With(zap.Uint64("connID", connID))
-	clientConn := client.NewClientConnection(logger, conn, s.serverTLSConfig, s.clusterTLSConfig, s.nsmgr, backend.NewBackendConnManager(connID))
+	clientConn := client.NewClientConnection(logger.Named("cliconn"), conn, s.serverTLSConfig, s.clusterTLSConfig, s.nsmgr, backend.NewBackendConnManager(logger.Named("bemgr"), connID))
 	s.mu.clients[connID] = clientConn
 	s.mu.Unlock()
 


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #8 

Problem Summary: Now only `router` have `logutil` logger left.

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
