### PR TITLE
*: fix hang bug

### DIFF
--- a/lib/util/errors/merror.go
+++ b/lib/util/errors/merror.go
@@ -61,12 +61,12 @@ func (e *MError) Error() string {
 	return fmt.Sprintf("%s", e)
 }
 
-func (e *MError) Unwrap() error {
-	return e
-}
-
 func (e *MError) Is(s error) bool {
-	return errors.Is(e.cerr, s)
+	is := errors.Is(e.cerr, s)
+	for _, e := range e.uerr {
+		is  = is || errors.Is(e, s)
+	}
+	return is
 }
 
 func (e *MError) Cause() []error {

--- a/lib/util/errors/merror.go
+++ b/lib/util/errors/merror.go
@@ -65,6 +65,9 @@ func (e *MError) Is(s error) bool {
 	is := errors.Is(e.cerr, s)
 	for _, e := range e.uerr {
 		is  = is || errors.Is(e, s)
+		if is {
+			break
+		}
 	}
 	return is
 }

--- a/lib/util/errors/merror_test.go
+++ b/lib/util/errors/merror_test.go
@@ -28,7 +28,8 @@ func TestCollect(t *testing.T) {
 	e := serr.Collect(e1, e2, e3)
 
 	require.ErrorIsf(t, e, e1, "equal to the external error")
-	require.Equal(t, serr.Unwrap(e), e, "unwrapping is noop")
+	require.Equal(t, nil, serr.Unwrap(e), "unwrapping stops here")
+	require.ErrorIsf(t, e, e1, "but errors.Is works for all errors")
 	require.Equal(t, e.(*serr.MError).Cause(), []error{e2, e3}, "get underlying errors")
 	require.NoError(t, serr.Collect(e3), "nil if there is no underlying error")
 }

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -124,5 +124,10 @@ func (n *NamespaceManager) RedirectConnections() []error {
 }
 
 func (n *NamespaceManager) Close() error {
+	n.RLock()
+	for _, ns := range n.nsm {
+		ns.Close()
+	}
+	n.RUnlock()
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,7 +85,6 @@ func (s *SQLServer) Run(ctx context.Context, onlineProxyConfig <-chan *config.Pr
 	for {
 		select {
 		case <-ctx.Done():
-			s.wg.Wait()
 			return
 		case och := <-onlineProxyConfig:
 			s.mu.Lock()


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Open a client conenction. Close `tiproxy` without interrupting the connection, tiproxy will hang.

What is changed and how it works:

1. `MError` should not have `Unwrap` method. It is unsuitable to unwrap multiple errors into one specific error. But unwrapping to itself may cause infinite recursion, because some functions will unwrap forever if he can.
2. While `router` and `backendObserver` does not inherit the cancel context, we can close `namespaces`, which will try to close routers.
3. No need to `ProxyServer.wg.Wait()`. We already waited at `Close()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
./bin/tiproxy
mycli -u root -P 6000 // in another terminal
type ctrl+c for tiproxy and see it hangs or not
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
