### PR TITLE
*: fix newtidb encoder

### DIFF
--- a/lib/util/cmd/encoder.go
+++ b/lib/util/cmd/encoder.go
@@ -71,10 +71,9 @@ func (c *tidbEncoder) endQuoteFiled() {
 	c.line.AppendByte(']')
 }
 func (e *tidbEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
-	// save fields attached to the encoder
-	oldFields := e.line.String()
-
-	// clone here to ensure concurrent safe
+	// clone here to ensure concurrent safety, note that:
+	// 1. the buffer will be used/freed by caller
+	// 2. we want to start with time format.. etc, so we don't copy old fields
 	c := e.clone(false)
 	if c.TimeKey != "" {
 		c.beginQuoteFiled()
@@ -122,7 +121,7 @@ func (e *tidbEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*b
 	}
 
 	// append old fields
-	c.line.AppendString(oldFields)
+	c.line.AppendString(e.line.String())
 
 	for _, f := range fields {
 		f.AddTo(c)

--- a/lib/util/cmd/encoder_test.go
+++ b/lib/util/cmd/encoder_test.go
@@ -1,0 +1,52 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestEncoder(t *testing.T) {
+	enc := NewTiDBEncoder(zapcore.EncoderConfig{})
+
+	// test escape
+	enc.AddString("ff", "\n\r\"")
+	require.Equal(t, "[ff=\"\\n\\r\\\"\"]", enc.line.String())
+
+	// test quotes
+	for _, ch := range []rune{'\\', '"', '[', ']', '='} {
+		enc = enc.clone()
+		enc.AddString("ff", fmt.Sprintf("ff%c", ch))
+		escape := ""
+		if ch == '"' {
+			escape = "\\"
+		}
+		require.Equal(t, fmt.Sprintf("[ff=\"ff%s%c\"]", escape, ch), enc.line.String())
+	}
+
+	// test append bytes
+	enc = enc.clone()
+	enc.AddByteString("ff", []byte{0x33, 0x22})
+	require.Equal(t, "[ff=0x3322]", enc.line.String())
+
+	// test append reflected
+	enc = enc.clone()
+	enc.AddReflected("ff", struct{A string}{"\""})
+	require.Equal(t, "[ff=\"{\\\"A\\\":\\\"\\\\\"\\\"}\"]", enc.line.String())
+}

--- a/lib/util/cmd/encoder_test.go
+++ b/lib/util/cmd/encoder_test.go
@@ -31,7 +31,7 @@ func TestEncoder(t *testing.T) {
 
 	// test quotes
 	for _, ch := range []rune{'\\', '"', '[', ']', '='} {
-		enc = enc.clone()
+		enc = enc.clone(false)
 		enc.AddString("ff", fmt.Sprintf("ff%c", ch))
 		escape := ""
 		if ch == '"' {
@@ -41,12 +41,12 @@ func TestEncoder(t *testing.T) {
 	}
 
 	// test append bytes
-	enc = enc.clone()
+	enc = enc.clone(false)
 	enc.AddByteString("ff", []byte{0x33, 0x22})
 	require.Equal(t, "[ff=0x3322]", enc.line.String())
 
 	// test append reflected
-	enc = enc.clone()
-	enc.AddReflected("ff", struct{A string}{"\""})
+	enc = enc.clone(false)
+	enc.AddReflected("ff", struct{ A string }{"\""})
 	require.Equal(t, "[ff=\"{\\\"A\\\":\\\"\\\\\"\\\"}\"]", enc.line.String())
 }


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #8, `pingcap/log` section

Problem Summary: I made some mistakes when porting the encoder of `pingcap/log`. This PR should hopefully fix these issues.

What is changed and how it works:

1. Correctly escape characters, but not all characters as `pingcap/log`. The requirements are: first, double quotes if needed; second, one message one line, no wrapping.
2. Also escape `AppendReflected` and `AddString`, it is missed in my previous PR.
3. `AppendByteString` will encode to hex automatically. This does not violate the RFC. It actually makes more sense. In tikv, `[]byte` are mostly `keys`, which will be encoded into a human readable format. But that is not true in go or other components. Just convert all `[]byte` to hex. If you need custom encoding, use `zap.Stringer`.
4. remove `encodeError`. This workaround is already fixed by #80 
5. fix problems with `logger.With`... etc, commented the reason for changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
