### PR TITLE
*: compute rev before firing go routines

### DIFF
--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -76,11 +76,12 @@ func (e *ConfigManager) watch(ctx context.Context, ns, key string, f func(*zap.L
 	wkey := []byte(path.Join(e.basePath, ns, key))
 	logger := e.logger.With(zap.String("component", string(wkey)))
 	retryInterval := 5 * time.Second
+	rev := e.kv.Rev()
 	e.wg.Run(func() {
 		wch := e.kv.NewWatchStream()
 		defer wch.Close()
 		for {
-			if _, err := wch.Watch(mvcc.AutoWatchID, wkey, getPrefix(wkey), wch.Rev()); err == nil {
+			if _, err := wch.Watch(mvcc.AutoWatchID, wkey, getPrefix(wkey), rev); err == nil {
 				break
 			}
 			if k := retryInterval * 2; k < e.watchInterval {

--- a/pkg/manager/config/proxy_test.go
+++ b/pkg/manager/config/proxy_test.go
@@ -45,16 +45,14 @@ func TestProxyConfig(t *testing.T) {
 	}
 
 	ch := cfgmgr.GetProxyConfigWatch()
+	require.Equal(t, <-ch, &config.ProxyServerOnline{})
 
 	for _, tc := range cases {
 		require.NoError(t, cfgmgr.SetProxyConfig(ctx, tc))
 		select {
 		case <-time.After(5 * time.Second):
-			t.Fatal("timeout waiting chan")
+			t.Fatalf("\n\ntimeout waiting chan\n\n")
 		case tg := <-ch:
-			for len(ch) > 0 {
-				tg = <-ch
-			}
 			require.Equal(t, tc, tg)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Watch rev is computed after firing the go routine. That said another go routine may race and change `e.kv.Rev()` such that `e.watch()` is not watching the correct revision.

What is changed and how it works: Compute it outside the go routine.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
