### PR TITLE
backend: update db in the handshake

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,9 +18,6 @@ issues:
       linters:
         - gosec
       text: "G402:"
-    - linters:
-        - unused
-      source: "updateAuthInfoFromSessionStates"
 
 linters:
   enable:

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/TiProxy/pkg/manager/router"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/siddontang/go/hack"
 	"go.uber.org/zap"
 )
 
@@ -263,6 +264,9 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 	}()
 	var sessionStates, sessionToken string
 	if sessionStates, sessionToken, rs.err = mgr.querySessionStates(); rs.err != nil {
+		return
+	}
+	if rs.err = mgr.updateAuthInfoFromSessionStates(hack.Slice(sessionStates)); rs.err != nil {
 		return
 	}
 

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -484,42 +484,13 @@ func TestSpecialCmds(t *testing.T) {
 				return nil
 			},
 			backend: func(packetIO *pnet.PacketIO) error {
+				ts.mb.sessionStates = "{\"current-db\":\"session_db\"}"
 				require.NoError(t, ts.redirectSucceed4Backend(packetIO))
 				require.Equal(t, "another_user", ts.mb.username)
-				require.Equal(t, "another_db", ts.mb.db)
+				require.Equal(t, "session_db", ts.mb.db)
 				expectCap := pnet.Capability(ts.mp.authenticator.supportedServerCapabilities.Uint32() &^ (mysql.ClientMultiStatements | mysql.ClientPluginAuthLenencClientData))
 				gotCap := pnet.Capability(ts.mb.clientCapability &^ mysql.ClientPluginAuthLenencClientData)
 				require.Equal(t, expectCap, gotCap, "expected=%s,got=%s", expectCap, gotCap)
-				return nil
-			},
-		},
-	}
-	ts.runTests(runners)
-}
-
-func TestUpdateCurrentDB(t *testing.T) {
-	ts := newBackendMgrTester(t)
-	runners := []runner{
-		// 1st handshake
-		{
-			client:  ts.mc.authenticate,
-			proxy:   ts.firstHandshake4Proxy,
-			backend: ts.handshake4Backend,
-		},
-		// 2nd handshake
-		{
-			client: nil,
-			proxy: func(_, _ *pnet.PacketIO) error {
-				backend1 := ts.mp.backendConn
-				ts.mp.Redirect(ts.tc.backendListener.Addr().String())
-				ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(t, eventSucceed)
-				require.NotEqual(t, backend1, ts.mp.backendConn)
-				return nil
-			},
-			backend: func(packetIO *pnet.PacketIO) error {
-				ts.mb.sessionStates = "{\"current-db\":\"another_db\"}"
-				require.NoError(t, ts.redirectSucceed4Backend(packetIO))
-				require.Equal(t, "another_db", ts.mb.db)
 				return nil
 			},
 		},

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -24,33 +24,33 @@ import (
 )
 
 type backendConfig struct {
-	// for auth
-	tlsConfig   *tls.Config
-	authPlugin  string
-	salt        []byte
-	columns     int
-	loops       int
-	params      int
-	rows        int
-	respondType respondType // for cmd
-	stmtNum     int
-	capability  uint32
-	status      uint16
-	authSucceed bool
-	switchAuth  bool
-	// for both auth and cmd
-	abnormalExit bool
+	tlsConfig     *tls.Config
+	authPlugin    string
+	sessionStates string
+	salt          []byte
+	columns       int
+	loops         int
+	params        int
+	rows          int
+	respondType   respondType
+	stmtNum       int
+	capability    uint32
+	status        uint16
+	authSucceed   bool
+	switchAuth    bool
+	abnormalExit  bool
 }
 
 func newBackendConfig() *backendConfig {
 	return &backendConfig{
-		capability:  defaultTestBackendCapability,
-		salt:        mockSalt,
-		authPlugin:  mysql.AuthCachingSha2Password,
-		switchAuth:  true,
-		authSucceed: true,
-		loops:       1,
-		stmtNum:     1,
+		capability:    defaultTestBackendCapability,
+		salt:          mockSalt,
+		authPlugin:    mysql.AuthCachingSha2Password,
+		switchAuth:    true,
+		authSucceed:   true,
+		loops:         1,
+		stmtNum:       1,
+		sessionStates: mockSessionStates,
 	}
 }
 
@@ -372,7 +372,7 @@ func (mb *mockBackend) respondSessionStates(packetIO *pnet.PacketIO) error {
 	names := []string{sessionStatesCol, sessionTokenCol}
 	values := [][]any{
 		{
-			mockSessionStates, mockCmdStr,
+			mb.sessionStates, mockCmdStr,
 		},
 	}
 	return mb.writeResultSet(packetIO, names, values)


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:

In this case:
- The client handshakes with TiDB with default db `A`
- The client `use B` and `drop database A`
- The proxy migrates the session

Previously, the migration with fail because `B` is dropped.

What is changed and how it works:

Update the current DB in the authenticator to the one in the session states.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has weirctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
