### PR TITLE
backend: handshake with client first

### DIFF
--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -37,7 +37,6 @@ type backendConfig struct {
 	capability    uint32
 	status        uint16
 	authSucceed   bool
-	switchAuth    bool
 	abnormalExit  bool
 }
 
@@ -46,7 +45,6 @@ func newBackendConfig() *backendConfig {
 		capability:    defaultTestBackendCapability,
 		salt:          mockSalt,
 		authPlugin:    mysql.AuthCachingSha2Password,
-		switchAuth:    true,
 		authSucceed:   true,
 		loops:         1,
 		stmtNum:       1,
@@ -109,7 +107,7 @@ func (mb *mockBackend) authenticate(packetIO *pnet.PacketIO) error {
 }
 
 func (mb *mockBackend) verifyPassword(packetIO *pnet.PacketIO, resp *pnet.HandshakeResp) error {
-	if resp.AuthPlugin != mysql.AuthTiDBSessionToken && mb.switchAuth {
+	if resp.AuthPlugin != mysql.AuthTiDBSessionToken {
 		var err error
 		if err = packetIO.WriteSwitchRequest(mb.authPlugin, mb.salt); err != nil {
 			return err

--- a/pkg/proxy/backend/mock_client_test.go
+++ b/pkg/proxy/backend/mock_client_test.go
@@ -78,16 +78,25 @@ func (mc *mockClient) authenticate(packetIO *pnet.PacketIO) error {
 		return err
 	}
 
-	resp := pnet.MakeHandshakeResponse(mc.username, mc.dbName, mc.authPlugin, mc.collation, mc.authData, mc.attrs, mc.capability)
+	resp := &pnet.HandshakeResp{
+		User:       mc.username,
+		DB:         mc.dbName,
+		AuthPlugin: mc.authPlugin,
+		Attrs:      mc.attrs,
+		AuthData:   mc.authData,
+		Capability: mc.capability,
+		Collation:  mc.collation,
+	}
+	pkt := pnet.MakeHandshakeResponse(resp)
 	if mc.capability&mysql.ClientSSL > 0 {
-		if err := packetIO.WritePacket(resp[:32], true); err != nil {
+		if err := packetIO.WritePacket(pkt[:32], true); err != nil {
 			return err
 		}
 		if err := packetIO.ClientTLSHandshake(mc.tlsConfig); err != nil {
 			return err
 		}
 	}
-	if err := packetIO.WritePacket(resp, true); err != nil {
+	if err := packetIO.WritePacket(pkt, true); err != nil {
 		return err
 	}
 	return mc.writePassword(packetIO)

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -190,8 +190,6 @@ func (ts *testSuite) authenticateFirstTime(t *testing.T, c checker) {
 // The proxy reconnects to the proxy using preserved client data.
 // This must be called after authenticateFirstTime.
 func (ts *testSuite) authenticateSecondTime(t *testing.T, c checker) {
-	// The server won't request switching auth-plugin this time.
-	ts.mb.backendConfig.switchAuth = false
 	ts.mb.backendConfig.authSucceed = true
 	ts.runAndCheck(t, c, nil, ts.mb.authenticate, ts.mp.authenticateSecondTime)
 	if c == nil {

--- a/pkg/proxy/net/packetio_mysql.go
+++ b/pkg/proxy/net/packetio_mysql.go
@@ -97,7 +97,7 @@ func (p *PacketIO) ReadSSLRequestOrHandshakeResp() (pkt []byte, isSSL bool, err 
 		return
 	}
 
-	capability := uint32(binary.LittleEndian.Uint32(pkt[:4]))
+	capability := binary.LittleEndian.Uint32(pkt[:4])
 	isSSL = capability&mysql.ClientSSL != 0
 	return
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref: #109 

Problem Summary:
- With default settings, the client always fails to connect now. The proxy doesn't support CLIENT_SSL by default (auto_tls is false) but the backend does. When the proxy forwards the initial handshake from the backend to the client (without updating the capability), the client thinks the proxy supports CLIENT_SSL and then fails.
- Given that we're going to support HTAP splitting, the proxy needs to handshake with the client first.

What is changed and how it works:
- Handshake with the client first; write the handshake response to the backend by itself. Thus it's more natural to change the capability.
- Always send an invalid auth method to the backend the first time to require another switch request. Otherwise, if the proxy forwards a correct auth method to the backend, the salt doesn't match and auth will fail.
- Require ClientDeprecateEOF from the backend. This is because the proxy always sends this capability to the client at the initial handshake and then the client thinks the backend supports ClientDeprecateEOF. However, this also means the proxy doesn't support TiDB 6.2.0 anymore.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Connect to v6.2.0 and the client cannot connect.
Connect to v6.3.0 and the client can connect and execute SQL.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [x] Other user behavior changes

Doesn't support v6.1.0 and v6.2.0.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
