### PR TITLE
manager: auto reload certs

### DIFF
--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -87,13 +87,13 @@ func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath strin
 	return nil
 }
 
-func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, mod string, keySize int, expiration time.Duration) error {
+func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, mod string, keySize int) error {
 	scfg.Cert = filepath.Join(workdir, mod, "cert.pem")
 	scfg.Key = filepath.Join(workdir, mod, "key.pem")
 	if autoca {
 		scfg.CA = filepath.Join(workdir, mod, "ca.pem")
 	}
-	if err := createTLSConfigificates(logger, scfg.Cert, scfg.Key, scfg.CA, keySize, expiration); err != nil {
+	if err := createTLSConfigificates(logger, scfg.Cert, scfg.Key, scfg.CA, keySize, DefaultCertExpiration); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -34,7 +34,9 @@ import (
 	"go.uber.org/zap"
 )
 
-func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int) error {
+const DefaultCertExpiration = 10 * 365 * 24 * time.Hour
+
+func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
 	logger = logger.With(zap.String("cert", certpath), zap.String("key", keypath), zap.String("ca", capath), zap.Int("rsaKeySize", rsaKeySize))
 
 	_, e1 := os.Stat(certpath)
@@ -64,7 +66,7 @@ func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath strin
 		}
 	}
 
-	certPEM, keyPEM, caPEM, err := CreateTempTLS()
+	certPEM, keyPEM, caPEM, err := CreateTempTLS(expiration)
 	if err != nil {
 		return err
 	}
@@ -85,21 +87,19 @@ func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath strin
 	return nil
 }
 
-func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, mod string, keySize int) error {
-	if !scfg.HasCert() && scfg.AutoCerts {
-		scfg.Cert = filepath.Join(workdir, mod, "cert.pem")
-		scfg.Key = filepath.Join(workdir, mod, "key.pem")
-		if autoca {
-			scfg.CA = filepath.Join(workdir, mod, "ca.pem")
-		}
-		if err := createTLSConfigificates(logger, scfg.Cert, scfg.Key, scfg.CA, keySize); err != nil {
-			return errors.WithStack(err)
-		}
+func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, mod string, keySize int, expiration time.Duration) error {
+	scfg.Cert = filepath.Join(workdir, mod, "cert.pem")
+	scfg.Key = filepath.Join(workdir, mod, "key.pem")
+	if autoca {
+		scfg.CA = filepath.Join(workdir, mod, "ca.pem")
+	}
+	if err := createTLSConfigificates(logger, scfg.Cert, scfg.Key, scfg.CA, keySize, expiration); err != nil {
+		return errors.WithStack(err)
 	}
 	return nil
 }
 
-func CreateTempTLS() (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
+func CreateTempTLS(expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 	// set up our CA certificate
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
@@ -112,7 +112,7 @@ func CreateTempTLS() (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 			PostalCode:    []string{"94016"},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
+		NotAfter:              time.Now().Add(expiration),
 		IsCA:                  true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -153,7 +153,7 @@ func CreateTempTLS() (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 		},
 		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(10, 0, 0),
+		NotAfter:     time.Now().Add(expiration),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -190,7 +190,7 @@ func CreateTempTLS() (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
 
 // CreateTLSConfigForTest is from https://gist.github.com/shaneutt/5e1995295cff6721c89a71d13a71c251.
 func CreateTLSConfigForTest() (serverTLSConf *tls.Config, clientTLSConf *tls.Config, err error) {
-	certPEM, keyPEM, caPEM, uerr := CreateTempTLS()
+	certPEM, keyPEM, caPEM, uerr := CreateTempTLS(DefaultCertExpiration)
 	if uerr != nil {
 		err = uerr
 		return

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -35,16 +35,15 @@ const (
 // Security configurations don't support dynamically updating now.
 type certInfo struct {
 	cfg         config.TLSConfig
-	tlsConfig   atomic.Pointer[tls.Config]
+	tlsConfig   *tls.Config
 	certificate atomic.Pointer[tls.Certificate]
 	autoCert    bool
 	autoCertExp time.Time
 }
 
 func (ci *certInfo) getTLS() *tls.Config {
-	tlsConfig := ci.tlsConfig.Load()
-	if tlsConfig != nil {
-		return tlsConfig.Clone()
+	if ci.tlsConfig != nil {
+		return ci.tlsConfig.Clone()
 	}
 	return nil
 }
@@ -64,7 +63,7 @@ func (ci *certInfo) setTLS(tlsConfig *tls.Config) {
 			tlsConfig.Certificates = nil
 		}
 	}
-	ci.tlsConfig.Store(tlsConfig)
+	ci.tlsConfig = tlsConfig
 }
 
 func (ci *certInfo) setAutoCertExp(exp time.Time) {

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -1,0 +1,250 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/errors"
+	"github.com/pingcap/TiProxy/lib/util/security"
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultReloadAhead   = 12 * time.Hour
+	defaultRetryInterval = 1 * time.Hour
+)
+
+// Security configurations don't support dynamically updating now.
+type certInfo struct {
+	cfg       config.TLSConfig
+	tlsConfig atomic.Pointer[tls.Config]
+	autoCert  bool
+	expTime   time.Time
+}
+
+func (ci *certInfo) getTLS() *tls.Config {
+	tlsConfig := ci.tlsConfig.Load()
+	if tlsConfig != nil {
+		return tlsConfig.Clone()
+	}
+	return nil
+}
+
+func (ci *certInfo) setTLS(tlsConfig *tls.Config) {
+	ci.tlsConfig.Store(tlsConfig)
+	ci.expTime = ci.getExpTime()
+}
+
+func (ci *certInfo) getExpTime() time.Time {
+	var minTime time.Time
+	tlsConfig := ci.tlsConfig.Load()
+	if tlsConfig == nil {
+		return minTime
+	}
+	for i := range tlsConfig.Certificates {
+		var parsedCert *x509.Certificate
+		if tlsConfig.Certificates[i].Leaf == nil {
+			var err error
+			if parsedCert, err = x509.ParseCertificate(tlsConfig.Certificates[i].Certificate[0]); err != nil {
+				continue
+			}
+		} else {
+			parsedCert = tlsConfig.Certificates[i].Leaf
+		}
+		t := parsedCert.NotAfter
+		if minTime.Equal(time.Time{}) {
+			minTime = t
+		} else if minTime.After(t) {
+			minTime = t
+		}
+	}
+	return minTime
+}
+
+func (ci *certInfo) needReload(now time.Time, reloadAhead time.Duration) bool {
+	if ci.expTime.Equal(time.Time{}) {
+		return false
+	}
+	return now.Add(reloadAhead).After(ci.expTime)
+}
+
+// CertManager reloads certs and offers interfaces for fetching TLS configs.
+// Currently, all the namespaces share the same certs but there might be per-namespace
+// certs in the future.
+type CertManager struct {
+	serverTLS     certInfo // client / proxyctl -> proxy
+	peerTLS       certInfo // proxy -> proxy
+	clusterTLS    certInfo // proxy -> pd / tidb status port
+	sqlTLS        certInfo // proxy -> tidb sql port
+	autoCertDir   string
+	cancel        context.CancelFunc
+	wg            waitgroup.WaitGroup
+	retryInterval atomic.Int64
+	reloadAhead   atomic.Int64
+	autoExp       atomic.Int64
+	cfg           *config.Security
+	logger        *zap.Logger
+}
+
+// NewCertManager creates a new CertManager.
+func NewCertManager() *CertManager {
+	cm := &CertManager{}
+	cm.SetRetryInterval(defaultRetryInterval)
+	cm.SetReloadAhead(defaultReloadAhead)
+	cm.SetAutoExp(security.DefaultCertExpiration)
+	return cm
+}
+
+func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger) error {
+	cm.cfg = &cfg.Security
+	cm.logger = logger
+	cm.autoCertDir = cfg.Workdir
+	cm.serverTLS = certInfo{
+		cfg:      cfg.Security.ServerTLS,
+		autoCert: !cfg.Security.ServerTLS.HasCert() && cfg.Security.ServerTLS.AutoCerts,
+	}
+	cm.peerTLS = certInfo{
+		cfg:      cfg.Security.PeerTLS,
+		autoCert: !cfg.Security.PeerTLS.HasCert() && cfg.Security.PeerTLS.AutoCerts,
+	}
+	cm.clusterTLS = certInfo{
+		cfg: cfg.Security.ClusterTLS,
+	}
+	cm.sqlTLS = certInfo{
+		cfg: cfg.Security.SQLTLS,
+	}
+
+	if err := cm.load(true); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cm.wg.Run(func() {
+		cm.reloadLoop(ctx)
+	})
+	cm.cancel = cancel
+	return nil
+}
+
+func (cm *CertManager) SetRetryInterval(interval time.Duration) {
+	cm.retryInterval.Store(int64(interval))
+}
+
+func (cm *CertManager) SetReloadAhead(ahead time.Duration) {
+	cm.reloadAhead.Store(int64(ahead))
+}
+
+func (cm *CertManager) SetAutoExp(exp time.Duration) {
+	cm.autoExp.Store(int64(exp))
+}
+
+func (cm *CertManager) ServerTLS() *tls.Config {
+	return cm.serverTLS.getTLS()
+}
+
+func (cm *CertManager) ClusterTLS() *tls.Config {
+	return cm.clusterTLS.getTLS()
+}
+
+func (cm *CertManager) SQLTLS() *tls.Config {
+	return cm.sqlTLS.getTLS()
+}
+
+// The proxy is supposed to be always online, so it should reload certs automatically,
+// rather than reloading it by restarting the proxy.
+// The proxy checks expiration time periodically and reloads certs in advance. If reloading
+// fails or the cert is not replaced, it will retry in the next round.
+func (cm *CertManager) reloadLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(cm.retryInterval.Load())):
+			_ = cm.load(false)
+		}
+	}
+}
+
+func (cm *CertManager) load(init bool) error {
+	errs := make([]error, 0, 4)
+	now := time.Now()
+	if init || cm.serverTLS.needReload(now, time.Duration(cm.reloadAhead.Load())) {
+		var err error
+		if cm.serverTLS.autoCert {
+			if err = security.AutoTLS(cm.logger, &cm.serverTLS.cfg, false, cm.autoCertDir, "server",
+				cm.cfg.RSAKeySize, time.Duration(cm.autoExp.Load())); err != nil {
+				cm.logger.Error("creating server certs failed", zap.Error(err))
+				errs = append(errs, err)
+			}
+		}
+		if err == nil {
+			var tlsConfig *tls.Config
+			if tlsConfig, err = security.BuildServerTLSConfig(cm.logger, cm.serverTLS.cfg); err != nil {
+				cm.logger.Error("loading server certs failed", zap.Error(err))
+				errs = append(errs, err)
+			} else {
+				cm.serverTLS.setTLS(tlsConfig)
+			}
+		}
+	}
+
+	// Peer tls is only used in creating etcd config and doesn't need rotation.
+	if init {
+		if cm.peerTLS.autoCert {
+			if err := security.AutoTLS(cm.logger, &cm.peerTLS.cfg, true, cm.autoCertDir, "peer",
+				cm.cfg.RSAKeySize, time.Duration(cm.autoExp.Load())); err != nil {
+				cm.logger.Error("creating peer certs failed", zap.Error(err))
+				errs = append(errs, err)
+			}
+		}
+	}
+
+	if init || cm.sqlTLS.needReload(now, time.Duration(cm.reloadAhead.Load())) {
+		if tlsConfig, err := security.BuildClientTLSConfig(cm.logger, cm.sqlTLS.cfg); err != nil {
+			cm.logger.Error("loading sql certs failed", zap.Error(err))
+			errs = append(errs, err)
+		} else {
+			cm.sqlTLS.setTLS(tlsConfig)
+		}
+	}
+
+	if init || cm.clusterTLS.needReload(now, time.Duration(cm.reloadAhead.Load())) {
+		if tlsConfig, err := security.BuildClientTLSConfig(cm.logger, cm.clusterTLS.cfg); err != nil {
+			cm.logger.Error("loading cluster certs failed", zap.Error(err))
+			errs = append(errs, err)
+		} else {
+			cm.clusterTLS.setTLS(tlsConfig)
+		}
+	}
+
+	if len(errs) != 0 {
+		return errors.Collect(errors.New("loading certs"), errs...)
+	}
+	return nil
+}
+
+func (cm *CertManager) Close() {
+	if cm.cancel != nil {
+		cm.cancel()
+	}
+	cm.wg.Wait()
+}

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -1,0 +1,113 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/logger"
+	"github.com/pingcap/TiProxy/lib/util/security"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that the certs are automatically created and reloaded.
+func TestReloadCerts(t *testing.T) {
+	dir := t.TempDir()
+	lg := logger.CreateLoggerForTest(t)
+	sqlCfg := &config.TLSConfig{AutoCerts: true}
+	err := security.AutoTLS(lg, sqlCfg, true, dir, "sql", 4096, 240*time.Hour)
+	require.NoError(t, err)
+	clusterCfg := &config.TLSConfig{AutoCerts: true}
+	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 4096, 240*time.Hour)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Workdir: dir,
+		Security: config.Security{
+			ServerTLS: config.TLSConfig{
+				AutoCerts: true,
+			},
+			PeerTLS: config.TLSConfig{
+				AutoCerts: true,
+			},
+			SQLTLS:     *sqlCfg,
+			ClusterTLS: *clusterCfg,
+		},
+	}
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(100 * time.Millisecond)
+	certMgr.SetAutoExp(240 * time.Hour)
+	err = certMgr.Init(cfg, lg)
+	require.NoError(t, err)
+	t.Cleanup(certMgr.Close)
+
+	var before = [3]time.Time{
+		certMgr.serverTLS.expTime,
+		certMgr.sqlTLS.expTime,
+		certMgr.clusterTLS.expTime,
+	}
+
+	sqlCfg = &config.TLSConfig{AutoCerts: true}
+	err = security.AutoTLS(lg, sqlCfg, true, dir, "sql", 4096, 480*time.Hour)
+	require.NoError(t, err)
+	clusterCfg = &config.TLSConfig{AutoCerts: true}
+	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 4096, 480*time.Hour)
+	require.NoError(t, err)
+	certMgr.SetReloadAhead(360 * time.Hour)
+	certMgr.SetAutoExp(480 * time.Hour)
+
+	timer := time.NewTimer(10 * time.Second)
+	for {
+		select {
+		case <-timer.C:
+			t.Fatal("timeout")
+		case <-time.After(100 * time.Millisecond):
+			var after = [3]time.Time{
+				certMgr.serverTLS.expTime,
+				certMgr.sqlTLS.expTime,
+				certMgr.clusterTLS.expTime,
+			}
+			if after[0] != before[0] && after[1] != before[1] && after[2] != before[2] {
+				return
+			}
+		}
+	}
+}
+
+// Test that configuring no certs still works.
+func TestReloadEmptyCerts(t *testing.T) {
+	dir := t.TempDir()
+	lg := logger.CreateLoggerForTest(t)
+	cfg := &config.Config{
+		Workdir: dir,
+		Security: config.Security{
+			ServerTLS:  config.TLSConfig{},
+			PeerTLS:    config.TLSConfig{},
+			SQLTLS:     config.TLSConfig{},
+			ClusterTLS: config.TLSConfig{},
+		},
+	}
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(100 * time.Millisecond)
+	err := certMgr.Init(cfg, lg)
+	require.NoError(t, err)
+	t.Cleanup(certMgr.Close)
+
+	require.Equal(t, certMgr.serverTLS.expTime, time.Time{})
+	require.Equal(t, certMgr.sqlTLS.expTime, time.Time{})
+	require.Equal(t, certMgr.clusterTLS.expTime, time.Time{})
+}

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/errors"
-	"github.com/pingcap/TiProxy/lib/util/security"
 	"github.com/pingcap/TiProxy/pkg/manager/router"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
@@ -39,6 +38,7 @@ type NamespaceManager struct {
 func NewNamespaceManager() *NamespaceManager {
 	return &NamespaceManager{}
 }
+
 func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, error) {
 	logger := mgr.logger.With(zap.String("namespace", cfg.Namespace))
 
@@ -46,22 +46,10 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	if err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}
-	r := &Namespace{
+	return &Namespace{
 		name:   cfg.Namespace,
 		router: rt,
-	}
-
-	r.frontendTLS, err = security.BuildServerTLSConfig(logger, cfg.Frontend.Security)
-	if err != nil {
-		return nil, errors.Errorf("build frontend TLS error: %w", err)
-	}
-
-	r.backendTLS, err = security.BuildClientTLSConfig(logger, cfg.Backend.Security)
-	if err != nil {
-		return nil, errors.Errorf("build backend TLS error: %w", err)
-	}
-
-	return r, nil
+	}, nil
 }
 
 func (mgr *NamespaceManager) CommitNamespaces(nss []*config.Namespace, nss_delete []bool) error {

--- a/pkg/manager/namespace/namespace.go
+++ b/pkg/manager/namespace/namespace.go
@@ -16,28 +16,16 @@
 package namespace
 
 import (
-	"crypto/tls"
-
 	"github.com/pingcap/TiProxy/pkg/manager/router"
 )
 
 type Namespace struct {
-	name        string
-	router      router.Router
-	frontendTLS *tls.Config
-	backendTLS  *tls.Config
+	name   string
+	router router.Router
 }
 
 func (n *Namespace) Name() string {
 	return n.name
-}
-
-func (n *Namespace) FrontendTLSConfig() *tls.Config {
-	return n.frontendTLS
-}
-
-func (n *Namespace) BackendTLSConfig() *tls.Config {
-	return n.backendTLS
 }
 
 func (n *Namespace) GetRouter() router.Router {

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
+	"github.com/pingcap/TiProxy/pkg/manager/cert"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -243,7 +244,10 @@ func createEtcdClient(t *testing.T, etcd *embed.Etcd) *clientv3.Client {
 			PDAddrs: etcd.Clients[0].Addr().String(),
 		},
 	}
-	client, err := InitEtcdClient(logger.CreateLoggerForTest(t), cfg)
+	certMgr := cert.NewCertManager()
+	err := certMgr.Init(cfg, logger.CreateLoggerForTest(t))
+	require.NoError(t, err)
+	client, err := InitEtcdClient(logger.CreateLoggerForTest(t), cfg, certMgr)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, client.Close())


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:
The proxy is supposed to be always online, so it should reload certs automatically, rather than reloading it by restarting the proxy.

What is changed and how it works:
- All the TLS configs are created and managed by CertManager.
- The CertManager reloads certs periodically.
- For auto-created certs, the CertManager recreates it periodically.
- The peer certs are not reloaded. The ETCD should reload it when it expires.

Currently, the CertManager reloads certificates periodically. Some alternatives:
- Check expiration time by reading the `NotAfter` field of the certs, but the rotation may not respect the expiration time.
- Check the modification time of the cert files periodically. If it changes, load it.
- When the operator replaces a cert, it sends a command to the status port to tell the proxy to reload the certs.

The CA is not rotated in this PR. It will be implemented in a future PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

A simple test: the proxy works well with default settings.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
