### PR TITLE
*: pass rsa key size correctly

### DIFF
--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -100,8 +100,8 @@ func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, m
 }
 
 func CreateTempTLS(rsaKeySize int, expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
-	if rsaKeySize < 512 {
-		rsaKeySize = 512
+	if rsaKeySize < 1024 {
+		rsaKeySize = 1024
 	}
 
 	// set up our CA certificate

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -66,7 +66,7 @@ func createTLSConfigificates(logger *zap.Logger, certpath, keypath, capath strin
 		}
 	}
 
-	certPEM, keyPEM, caPEM, err := CreateTempTLS(expiration)
+	certPEM, keyPEM, caPEM, err := CreateTempTLS(rsaKeySize, expiration)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,11 @@ func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, m
 	return nil
 }
 
-func CreateTempTLS(expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
+func CreateTempTLS(rsaKeySize int, expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer, error) {
+	if rsaKeySize < 512 {
+		rsaKeySize = 512
+	}
+
 	// set up our CA certificate
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
@@ -120,7 +124,7 @@ func CreateTempTLS(expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *byt
 	}
 
 	// create our private and public key
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -159,7 +163,7 @@ func CreateTempTLS(expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *byt
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
 
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -190,7 +194,7 @@ func CreateTempTLS(expiration time.Duration) (*bytes.Buffer, *bytes.Buffer, *byt
 
 // CreateTLSConfigForTest is from https://gist.github.com/shaneutt/5e1995295cff6721c89a71d13a71c251.
 func CreateTLSConfigForTest() (serverTLSConf *tls.Config, clientTLSConf *tls.Config, err error) {
-	certPEM, keyPEM, caPEM, uerr := CreateTempTLS(DefaultCertExpiration)
+	certPEM, keyPEM, caPEM, uerr := CreateTempTLS(0, DefaultCertExpiration)
 	if uerr != nil {
 		err = uerr
 		return

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -22,7 +22,7 @@ import (
 
 func BenchmarkCreateTLS(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := CreateTempTLS(512)
+		_, _, _, err := CreateTempTLS(0, DefaultCertExpiration)
 		require.Nil(b, err)
 	}
 }

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -1,0 +1,28 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCreateTLS(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _, _, err := CreateTempTLS(512)
+		require.Nil(b, err)
+	}
+}

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -30,10 +30,10 @@ func TestReloadCerts(t *testing.T) {
 	dir := t.TempDir()
 	lg := logger.CreateLoggerForTest(t)
 	sqlCfg := &config.TLSConfig{AutoCerts: true}
-	err := security.AutoTLS(lg, sqlCfg, true, dir, "sql", 1024)
+	err := security.AutoTLS(lg, sqlCfg, true, dir, "sql", 0)
 	require.NoError(t, err)
 	clusterCfg := &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 1024)
+	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 0)
 	require.NoError(t, err)
 
 	cfg := &config.Config{
@@ -80,10 +80,10 @@ func TestReloadCerts(t *testing.T) {
 
 	var before = getAllCertificates(t, certMgr)
 	sqlCfg = &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, sqlCfg, true, dir, "sql", 1024)
+	err = security.AutoTLS(lg, sqlCfg, true, dir, "sql", 0)
 	require.NoError(t, err)
 	clusterCfg = &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 1024)
+	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 0)
 	require.NoError(t, err)
 
 	timer := time.NewTimer(10 * time.Second)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: pass rsa key size

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
