### PR TITLE
*: fix static backends & support route by user

### DIFF
--- a/conf/namespace/test.yaml
+++ b/conf/namespace/test.yaml
@@ -1,0 +1,9 @@
+namespace: "ns2"
+frontend:
+  user: "xhe"
+  security:
+backend:
+  instances:
+    - "127.0.0.1:7000"
+  selector-type: "random"
+  security:

--- a/conf/proxy.yaml
+++ b/conf/proxy.yaml
@@ -3,8 +3,8 @@ proxy:
   addr: "0.0.0.0:6000"
   tcp-keep-alive: true
   max-connections: 1000
-  pd-addrs: "127.0.0.1:2379"
   # require-backend-tls: true
+  # pd-addrs: "127.0.0.1:2379"
   # proxy-protocol: "v2"
 metrics:
 api:

--- a/conf/proxy.yaml
+++ b/conf/proxy.yaml
@@ -3,8 +3,8 @@ proxy:
   addr: "0.0.0.0:6000"
   tcp-keep-alive: true
   max-connections: 1000
+  pd-addrs: "127.0.0.1:2379"
   # require-backend-tls: true
-  # pd-addrs: "127.0.0.1:2379"
   # proxy-protocol: "v2"
 metrics:
 api:

--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -22,6 +22,7 @@ type Namespace struct {
 }
 
 type FrontendNamespace struct {
+	User     string    `yaml:"user" json:"user" toml:"user"`
 	Security TLSConfig `yaml:"security" json:"security" toml:"security"`
 }
 

--- a/lib/config/namespace_test.go
+++ b/lib/config/namespace_test.go
@@ -24,6 +24,7 @@ import (
 var testNamespaceConfig = Namespace{
 	Namespace: "test_ns",
 	Frontend: FrontendNamespace{
+		User: "xx",
 		Security: TLSConfig{
 			CA:        "t",
 			Cert:      "t",

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -48,6 +48,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	}
 	return &Namespace{
 		name:   cfg.Namespace,
+		user:   cfg.Frontend.User,
 		router: rt,
 	}, nil
 }
@@ -95,6 +96,18 @@ func (n *NamespaceManager) GetNamespace(nm string) (*Namespace, bool) {
 
 	ns, ok := n.nsm[nm]
 	return ns, ok
+}
+
+func (n *NamespaceManager) GetNamespaceByUser(user string) (*Namespace, bool) {
+	n.RLock()
+	defer n.RUnlock()
+
+	for _, ns := range n.nsm {
+		if ns.User() == user {
+			return ns, true
+		}
+	}
+	return nil, false
 }
 
 func (n *NamespaceManager) RedirectConnections() []error {

--- a/pkg/manager/namespace/namespace.go
+++ b/pkg/manager/namespace/namespace.go
@@ -21,11 +21,16 @@ import (
 
 type Namespace struct {
 	name   string
+	user   string
 	router router.Router
 }
 
 func (n *Namespace) Name() string {
 	return n.name
+}
+
+func (n *Namespace) User() string {
+	return n.user
 }
 
 func (n *Namespace) GetRouter() router.Router {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -54,14 +54,16 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 	mp := &mockProxy{
 		proxyConfig:        cfg,
 		logger:             logger.CreateLoggerForTest(t).Named("mockProxy"),
-		BackendConnManager: NewBackendConnManager(logger.CreateLoggerForTest(t), 0, false, false),
+		BackendConnManager: NewBackendConnManager(logger.CreateLoggerForTest(t), nil, 0, false, false),
 	}
 	mp.cmdProcessor.capability = cfg.capability
 	return mp
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	return mp.authenticator.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.frontendTLSConfig, mp.backendTLSConfig)
+	return mp.authenticator.handshakeFirstTime(mp.logger, clientIO, func(_ *Authenticator) (*pnet.PacketIO, error) {
+		return backendIO, nil
+	}, mp.frontendTLSConfig, mp.backendTLSConfig)
 }
 
 func (mp *mockProxy) authenticateSecondTime(clientIO, backendIO *pnet.PacketIO) error {


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #15

Problem Summary: Minimal effort to support multi-namespace routing by user. Also fixed broken static routing. It is initially coded for hackathon, but mergeable anyway.

It also reveals  some problems:

1. The abstraction `client -> backend -> auth` is a little bit redundant, or too ideal: we need to pass options back and forth. In fact, we only need one class to handle connection with seperated files for readability.
2. It can not be well tested with the current `mockProxy`: `mp` will construct a fixed backend with `connectionID = 0, proxy = false, require-backend-tls = false` and also `namespaceManager = nil` now.
We probably will add more and more options. Yet `clientConn` and `proxyServer` is not tested. Need something more flexible than `mp/mb/mc`: a better API easier for testing instead of more helpers to target different cases.

The next step would be PD and TLS per namespace. Then we can possibly combine client/backend to enable more unit testing on these codes.

What is changed and how it works:

1. Add `GetNamespaceByUser` and `getBackendIO` hook.
2. Handle EOF in both handshake and packet relay in `clientConn`.
3. Do not fail it no instances are specified for the static backend. Instead, report errors on connection.
4. Check health first for static backends, then sleep.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Comment PD addrs to enable static backends first.
```
tiproxyctl namespace import conf/namespace
tiproxyctl namespace commit default ns2

mycli -u xhe -P 6000
mycli -u root -P 6000
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
