### PR TITLE
*: fix cli stdin

### DIFF
--- a/lib/cli/config.go
+++ b/lib/cli/config.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 
@@ -40,15 +39,14 @@ func getConfigCmd(ctx *Context, pathSuffix string) *cobra.Command {
 		}
 		input := setProxy.Flags().String("input", "", "specify the input json file for proxy config")
 		setProxy.RunE = func(cmd *cobra.Command, args []string) error {
-			var b io.Reader
+			b := cmd.InOrStdin()
 			if *input != "" {
 				f, err := os.Open(*input)
 				if err != nil {
 					return err
 				}
 				defer f.Close()
-			} else {
-				b = os.Stdin
+				b = f
 			}
 
 			resp, err := doRequest(cmd.Context(), ctx, http.MethodPut, path, b)

--- a/lib/cli/namespace.go
+++ b/lib/cli/namespace.go
@@ -130,10 +130,10 @@ func GetNamespaceCmd(ctx *Context) *cobra.Command {
 		putNamespace := &cobra.Command{
 			Use: "put",
 		}
-		ns := putNamespace.Flags().String("ns", "-", "file")
+		ns := putNamespace.Flags().String("ns", "", "file, or stdin")
 		putNamespace.RunE = func(cmd *cobra.Command, _ []string) error {
 			in := cmd.InOrStdin()
-			if *ns != "-" {
+			if *ns != "" {
 				f, err := os.Open(*ns)
 				if err != nil {
 					return err


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Use empty string to indicate stdin. Also use `cmd.InOrStdin` for `config set` as `namespace put`.

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
