### PR TITLE
*: replace old encoder with new encoder

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	configFile := rootCmd.PersistentFlags().String("config", "conf/proxy.yaml", "proxy config file path")
-	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "", "log in format of tidb, console, or json")
+	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "", "log level")
 	clusterName := rootCmd.PersistentFlags().String("cluster_name", "tiproxy", "default cluster name, used to generate node name and differential clusters in dns discovery")
 	nodeName := rootCmd.PersistentFlags().String("node_name", "", "by default, it is generate prefixed by cluster-name")

--- a/lib/util/cmd/encoder_test.go
+++ b/lib/util/cmd/encoder_test.go
@@ -47,6 +47,6 @@ func TestEncoder(t *testing.T) {
 
 	// test append reflected
 	enc = enc.clone(false)
-	enc.AddReflected("ff", struct{ A string }{"\""})
+	require.NoError(t, enc.AddReflected("ff", struct{ A string }{"\""}))
 	require.Equal(t, "[ff=\"{\\\"A\\\":\\\"\\\\\"\\\"}\"]", enc.line.String())
 }

--- a/lib/util/cmd/logger.go
+++ b/lib/util/cmd/logger.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"github.com/pingcap/TiProxy/lib/config"
-	"github.com/pingcap/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -24,10 +23,10 @@ import (
 func buildEncoder(cfg *config.Log) (zapcore.Encoder, error) {
 	encfg := zap.NewProductionEncoderConfig()
 	switch cfg.Encoder {
-	case "tidb":
-		return log.NewTextEncoder(&log.Config{})
-	case "newtidb":
-		fallthrough
+	case "json":
+		return zapcore.NewJSONEncoder(encfg), nil
+	case "console":
+		return zapcore.NewConsoleEncoder(encfg), nil
 	default:
 		return NewTiDBEncoder(encfg), nil
 	}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #8

Problem Summary: Apply the new encoder.

What is changed and how it works:

1. Remove `pingcap/log` and the old encoder
2. Fix lint since #92 is too old that it is merged without linting.
3. Also escape tab character
4. Print escaped characters as `%04x` instead of `%4x`, i.e. fill with extra 0 instead of spaces.
5. Apply json and console encoder, which is removed in #88 and #99

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
/bin/tiproxy should now use the new encoder
/bin/tiproxy --log_encoder json should out put json logs
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
