### PR TITLE
*: handle more nil error cases

### DIFF
--- a/lib/util/errors/error.go
+++ b/lib/util/errors/error.go
@@ -35,6 +35,9 @@ type Error struct {
 
 // WithStack will wrapping an error with stacktrace, given a default stack depth.
 func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
 	e := &Error{err: err}
 	e.withStackDepth(1, defaultStackDepth)
 	return e

--- a/lib/util/errors/error_test.go
+++ b/lib/util/errors/error_test.go
@@ -29,6 +29,8 @@ func TestStacktrace(t *testing.T) {
 	require.Contains(t, fmt.Sprintf("%+v", e), t.Name(), "stacktrace must contain test name")
 	require.Contains(t, fmt.Sprintf("%v", e), t.Name(), "stacktrace must contain test name")
 	require.Contains(t, fmt.Sprintf("%+s", e), t.Name(), "stacktrace must contain test name")
+
+	require.Nil(t, serr.WithStack(nil), "wrap nil got nil")
 }
 
 func TestUnwrap(t *testing.T) {

--- a/lib/util/errors/werror.go
+++ b/lib/util/errors/werror.go
@@ -69,6 +69,9 @@ func (e *WError) Unwrap() error {
 // Note that wrap nil error will get nil error.
 func Wrap(cerr error, uerr error) error {
 	if cerr == nil {
+		return uerr
+	}
+	if uerr == nil {
 		return nil
 	}
 	return &WError{

--- a/lib/util/errors/werror_test.go
+++ b/lib/util/errors/werror_test.go
@@ -28,7 +28,8 @@ func TestWrap(t *testing.T) {
 	require.ErrorIsf(t, e, e1, "equal to the external error")
 	require.ErrorAsf(t, e, &e2, "unwrapping to the internal error")
 
-	require.Nil(t, serr.Wrap(nil, e2), "wrap nil got nil")
+	require.Equal(t, e2, serr.Wrap(nil, e2), "wrap with nil got the original")
+	require.Nil(t, serr.Wrap(e2, nil), "wrap nil got nil")
 }
 
 func TestWrapf(t *testing.T) {

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -103,12 +103,7 @@ func NewPacketIO(conn net.Conn, opts ...PacketIOption) *PacketIO {
 }
 
 func (p *PacketIO) wrapErr(err error) error {
-	e := err
-	if p.wrap != nil {
-		e = errors.Wrap(p.wrap, err)
-	}
-	e = errors.WithStack(e)
-	return e
+	return errors.WithStack(errors.Wrap(p.wrap, err))
 }
 
 // Proxy returned parsed proxy header from clients if any.
@@ -248,9 +243,6 @@ func (p *PacketIO) Flush() error {
 
 func (p *PacketIO) Close() error {
 	var errs []error
-	if p.wrap != nil {
-		errs = append(errs, p.wrap)
-	}
 	/*
 		TODO: flush when we want to smoothly exit
 		if err := p.Flush(); err != nil {
@@ -262,5 +254,5 @@ func (p *PacketIO) Close() error {
 			errs = append(errs, err)
 		}
 	}
-	return errors.Collect(ErrCloseConn, errs...)
+	return p.wrapErr(errors.Collect(ErrCloseConn, errs...))
 }


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: There are two problems.

1. `p.wrap` is an error intended to wrap other errors, it should be appended to the error list of `pnet.Conn.Close()`.
2.  Change how `errors.Wrap` handles nil.

This fixes `[1.667360865291243e+09] [error] [main.proxy] [close connection fails] [connID=0] [remoteAddr="[::1]:51379"] [error="failed to close client connection:\n\tfailed to close the connection:\n\tthis is an error from client"]`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
