### PR TITLE
*: fix log format

### DIFF
--- a/lib/util/cmd/logger.go
+++ b/lib/util/cmd/logger.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/pingcap/TiProxy/lib/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -22,6 +24,12 @@ import (
 
 func buildEncoder(cfg *config.Log) (zapcore.Encoder, error) {
 	encfg := zap.NewProductionEncoderConfig()
+	encfg.EncodeTime = func(t time.Time, pae zapcore.PrimitiveArrayEncoder) {
+		pae.AppendString(t.Format("2006/01/02 15:04:05.000 -07:00"))
+	}
+	encfg.EncodeLevel = func(l zapcore.Level, pae zapcore.PrimitiveArrayEncoder) {
+		pae.AppendString(l.CapitalString())
+	}
 	switch cfg.Encoder {
 	case "json":
 		return zapcore.NewJSONEncoder(encfg), nil
@@ -57,5 +65,5 @@ func BuildLogger(cfg *config.Log) (*zap.Logger, *AtomicWriteSyncer, zap.AtomicLe
 	if err != nil {
 		return nil, nil, level, err
 	}
-	return zap.New(zapcore.NewCore(encoder, syncer, level), zap.ErrorOutput(syncer), zap.AddStacktrace(zapcore.FatalLevel)), syncer, level, nil
+	return zap.New(zapcore.NewCore(encoder, syncer, level), zap.ErrorOutput(syncer), zap.AddStacktrace(zapcore.FatalLevel), zap.AddCaller()), syncer, level, nil
 }


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Since we switched to manual creation of `zapcore.Core`, we lost some default configuration that is present in `zap.NewProductionLogger`, causing the new encode behave differently with the old log format.

What is changed and how it works:

1. correct time format
2. all upper case level
3. add `xxx.go:xxx`, i.e. caller information

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
