### PR TITLE
*: change user

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -31,6 +31,7 @@ var (
 	ErrCapabilityNegotiation = errors.New("capability negotiation failed")
 )
 
+const unknownAuthPlugin = "auth_unknown_plugin"
 const requiredFrontendCaps = pnet.ClientProtocol41
 const defRequiredBackendCaps = pnet.ClientDeprecateEOF
 
@@ -180,7 +181,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO *pnet
 	}
 
 	// Send an unknown auth plugin so that the backend will request the auth data again.
-	resp.AuthPlugin = "auth_unknown_plugin"
+	resp.AuthPlugin = unknownAuthPlugin
 	resp.Capability = auth.capability
 
 	if backendCapability&pnet.ClientSSL != 0 && backendTLSConfig != nil {

--- a/pkg/proxy/backend/cmd_processor_exec.go
+++ b/pkg/proxy/backend/cmd_processor_exec.go
@@ -282,8 +282,6 @@ func (cp *CmdProcessor) forwardSendLongDataCmd(request []byte) error {
 }
 
 func (cp *CmdProcessor) forwardChangeUserCmd(clientIO, backendIO *pnet.PacketIO, request []byte) error {
-	// Currently, TiDB responses with an OK or Err packet. But according to the MySQL doc, the server may send a
-	// switch auth request.
 	for {
 		response, err := forwardOnePacket(clientIO, backendIO, true)
 		if err != nil {

--- a/pkg/proxy/backend/mock_client_test.go
+++ b/pkg/proxy/backend/mock_client_test.go
@@ -169,7 +169,7 @@ func (mc *mockClient) request(packetIO *pnet.PacketIO) error {
 }
 
 func (mc *mockClient) requestChangeUser(packetIO *pnet.PacketIO) error {
-	data := pnet.MakeChangeUser(mc.username, mc.dbName, mc.authData)
+	data := pnet.MakeChangeUser(mc.username, mc.dbName, mysql.AuthNativePassword, mc.authData)
 	if err := packetIO.WritePacket(data, true); err != nil {
 		return err
 	}

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -216,7 +216,7 @@ func MakeHandshakeResponse(resp *HandshakeResp) []byte {
 }
 
 // MakeChangeUser creates the data of COM_CHANGE_USER. It's only used for testing.
-func MakeChangeUser(username, db string, authData []byte) []byte {
+func MakeChangeUser(username, db, authPlugin string, authData []byte) []byte {
 	length := 1 + len(username) + 1 + len(authData) + 1 + len(db) + 1
 	data := make([]byte, 0, length)
 	data = append(data, mysql.ComChangeUser)
@@ -225,6 +225,13 @@ func MakeChangeUser(username, db string, authData []byte) []byte {
 	data = append(data, byte(len(authData)))
 	data = append(data, authData...)
 	data = append(data, []byte(db)...)
+	data = append(data, 0x00)
+
+	// character set
+	data = append(data, 0x00)
+	data = append(data, 0x00)
+
+	data = append(data, []byte(authPlugin)...)
 	data = append(data, 0x00)
 	return data
 }


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #127

Problem Summary: Minimal effort to support switch auth request when it is change user command. A little bit ugly.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tiup --db.binpath ./tidb-server
./bin/tiproxy
mvn "-Dcom.mysql.jdbc.testsuite.url=jdbc:mysql://127.0.0.1:6000/test?user=root&password=&useSSL=false&useServerPrepStmts=true" '-Dtest=ConnectionRegressionTest#testBug19354014' test
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
