### PR TITLE
*: add back salt

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -50,6 +50,7 @@ type Authenticator struct {
 	serverAddr                  string
 	user                        string
 	attrs                       []byte // no need to parse
+	salt                        []byte
 	capability                  uint32 // client capability
 	collation                   uint8
 	proxyProtocol               bool
@@ -104,7 +105,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO *pnet
 		proxyCapability ^= pnet.ClientSSL
 	}
 
-	if err := clientIO.WriteInitialHandshake(proxyCapability.Uint32(), make([]byte, 20), mysql.AuthNativePassword); err != nil {
+	if err := clientIO.WriteInitialHandshake(proxyCapability.Uint32(), auth.salt, mysql.AuthNativePassword); err != nil {
 		return err
 	}
 	pkt, isSSL, err := clientIO.ReadSSLRequestOrHandshakeResp()

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -90,11 +90,16 @@ type BackendConnManager struct {
 // NewBackendConnManager creates a BackendConnManager.
 func NewBackendConnManager(logger *zap.Logger, nsmgr *namespace.NamespaceManager, connectionID uint64, proxyProtocol, requireBackendTLS bool) *BackendConnManager {
 	mgr := &BackendConnManager{
-		logger:         logger,
-		connectionID:   connectionID,
-		cmdProcessor:   NewCmdProcessor(),
-		nsmgr:          nsmgr,
-		authenticator:  &Authenticator{supportedServerCapabilities: supportedServerCapabilities, proxyProtocol: proxyProtocol, requireBackendTLS: requireBackendTLS},
+		logger:       logger,
+		connectionID: connectionID,
+		cmdProcessor: NewCmdProcessor(),
+		nsmgr:        nsmgr,
+		authenticator: &Authenticator{
+			supportedServerCapabilities: supportedServerCapabilities,
+			proxyProtocol:               proxyProtocol,
+			requireBackendTLS:           requireBackendTLS,
+			salt:                        GenerateSalt(20),
+		},
 		signalReceived: make(chan struct{}, 1),
 		redirectResCh:  make(chan *redirectResult, 1),
 	}

--- a/pkg/proxy/backend/util.go
+++ b/pkg/proxy/backend/util.go
@@ -1,0 +1,33 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import _ "unsafe"
+
+//go:linkname Uint32N runtime.fastrandn
+func Uint32N(a uint64) uint64
+
+// Buf generates a random string using ASCII characters but avoid separator character.
+// Ref https://github.com/mysql/mysql-server/blob/5.7/mysys_ssl/crypt_genhash_impl.cc#L435.
+func GenerateSalt(size int) []byte {
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte(Uint32N(127))
+		for buf[i] == 0 || buf[i] == byte('$') {
+			buf[i] = byte(Uint32N(127))
+		}
+	}
+	return buf
+}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: The fake salt does not have any usage. But client will still send the computed passwords with the fake salt in the response. In cases of non-TLS, all-zero salt will let client send a fixed auth string(sha1 three times with fixed input), which is highly insecure. Thus we should still send random salt instead.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
