### PR TITLE
backend: update handshakeHandler interface

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -107,6 +107,9 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 	}
 	mgr.getBackendIO = func(auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error) {
 		router, err := handshakeHandler.GetRouter(resp)
+		if err != nil {
+			return nil, err
+		}
 		addr, err := router.Route(mgr)
 		if err != nil {
 			return nil, err

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -106,16 +106,12 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 		redirectResCh:  make(chan *redirectResult, 1),
 	}
 	mgr.getBackendIO = func(auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error) {
-		ns, err := handshakeHandler.GetNamespace(resp)
-		if err != nil {
-			return nil, err
-		}
-		router := ns.GetRouter()
+		router, err := handshakeHandler.GetRouter(resp)
 		addr, err := router.Route(mgr)
 		if err != nil {
 			return nil, err
 		}
-		mgr.logger.Info("found", zap.String("namespace", ns.Name()), zap.String("addr", addr))
+		mgr.logger.Info("found", zap.String("addr", addr))
 		mgr.backendConn = NewBackendConnection(addr)
 		if err := mgr.backendConn.Connect(); err != nil {
 			return nil, err

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/pkg/manager/namespace"
+	"github.com/pingcap/TiProxy/pkg/manager/router"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 )
 
@@ -25,7 +26,7 @@ var _ HandshakeHandler = (*DefaultHandshakeHandler)(nil)
 type HandshakeHandler interface {
 	HandleHandshakeResp(resp *pnet.HandshakeResp, sourceAddr string) error
 	GetCapability() pnet.Capability
-	GetNamespace(resp *pnet.HandshakeResp) (*namespace.Namespace, error)
+	GetRouter(resp *pnet.HandshakeResp) (router.Router, error)
 }
 
 type DefaultHandshakeHandler struct {
@@ -46,7 +47,7 @@ func (handler *DefaultHandshakeHandler) GetCapability() pnet.Capability {
 	return SupportedServerCapabilities
 }
 
-func (handler *DefaultHandshakeHandler) GetNamespace(resp *pnet.HandshakeResp) (*namespace.Namespace, error) {
+func (handler *DefaultHandshakeHandler) GetRouter(resp *pnet.HandshakeResp) (router.Router, error) {
 	ns, ok := handler.nsManager.GetNamespaceByUser(resp.User)
 	if !ok {
 		ns, ok = handler.nsManager.GetNamespace("default")
@@ -54,5 +55,5 @@ func (handler *DefaultHandshakeHandler) GetNamespace(resp *pnet.HandshakeResp) (
 	if !ok {
 		return nil, errors.New("failed to find a namespace")
 	}
-	return ns, nil
+	return ns.GetRouter(), nil
 }

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -20,7 +20,7 @@ import (
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/TiProxy/lib/util/logger"
-	"github.com/pingcap/TiProxy/pkg/manager/namespace"
+	"github.com/pingcap/TiProxy/pkg/manager/router"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"go.uber.org/zap"
 )
@@ -107,8 +107,8 @@ type CustomHandshakeHandler struct {
 	outAttrs      map[string]string
 }
 
-func (handler *CustomHandshakeHandler) GetNamespace(resp *pnet.HandshakeResp) (*namespace.Namespace, error) {
-	return &namespace.Namespace{}, nil
+func (handler *CustomHandshakeHandler) GetRouter(resp *pnet.HandshakeResp) (router.Router, error) {
+	return nil, nil
 }
 
 func (handler *CustomHandshakeHandler) HandleHandshakeResp(resp *pnet.HandshakeResp, addr string) error {


### PR DESCRIPTION
### What problem does this PR solve?
change method `GetNamespace` to `GetRouter` so that custom handler can work without construct a `namespace.Namespace` struct.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

```release-note
None
```
