### PR TITLE
server: support custom handler for Server

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -35,12 +35,12 @@ func main() {
 	configFile := rootCmd.PersistentFlags().String("config", "conf/proxy.yaml", "proxy config file path")
 	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "", "log level")
-	clusterName := rootCmd.PersistentFlags().String("cluster_name", "tiproxy", "default cluster name, used to generate node name and differential clusters in dns discovery")
-	nodeName := rootCmd.PersistentFlags().String("node_name", "", "by default, it is generate prefixed by cluster-name")
-	pubAddr := rootCmd.PersistentFlags().String("pub_addr", "127.0.0.1", "IP or domain, will be used as the accessible addr for others")
-	bootstrapClusters := rootCmd.PersistentFlags().StringSlice("bootstrap_clusters", []string{}, "lists of other nodes in the cluster, e.g. 'n1=xxx,n2=xxx', where xx are IPs or domains")
-	bootstrapDiscoveryUrl := rootCmd.PersistentFlags().String("bootstrap_discovery_etcd", "", "etcd discovery service url")
-	bootstrapDiscoveryDNS := rootCmd.PersistentFlags().String("bootstrap_discovery_dns", "", "dns srv discovery")
+	_ = rootCmd.PersistentFlags().String("cluster_name", "tiproxy", "default cluster name, used to generate node name and differential clusters in dns discovery")
+	_ = rootCmd.PersistentFlags().String("node_name", "", "by default, it is generate prefixed by cluster-name")
+	_ = rootCmd.PersistentFlags().String("pub_addr", "127.0.0.1", "IP or domain, will be used as the accessible addr for others")
+	_ = rootCmd.PersistentFlags().StringSlice("bootstrap_clusters", []string{}, "lists of other nodes in the cluster, e.g. 'n1=xxx,n2=xxx', where xx are IPs or domains")
+	_ = rootCmd.PersistentFlags().String("bootstrap_discovery_etcd", "", "etcd discovery service url")
+	_ = rootCmd.PersistentFlags().String("bootstrap_discovery_dns", "", "dns srv discovery")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		proxyConfigData, err := os.ReadFile(*configFile)
@@ -62,14 +62,6 @@ func main() {
 
 		sctx := &sctx.Context{
 			Config: cfg,
-			Cluster: sctx.Cluster{
-				PubAddr:           *pubAddr,
-				ClusterName:       *clusterName,
-				NodeName:          *nodeName,
-				BootstrapDurl:     *bootstrapDiscoveryUrl,
-				BootstrapDdns:     *bootstrapDiscoveryDNS,
-				BootstrapClusters: *bootstrapClusters,
-			},
 		}
 
 		srv, err := server.NewServer(cmd.Context(), sctx)

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -15,11 +15,11 @@
 package backend
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
@@ -57,6 +57,7 @@ type Authenticator struct {
 	collation                   uint8
 	proxyProtocol               bool
 	requireBackendTLS           bool
+	ctxmap sync.Map
 }
 
 func (auth *Authenticator) String() string {
@@ -146,8 +147,8 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO *pnet
 	auth.capability = commonCaps.Uint32()
 
 	resp := pnet.ParseHandshakeResponse(pkt)
-	ctx := context.WithValue(context.Background(), ContextKeyClientAddr, clientIO.SourceAddr().String())
-	if err = handshakeHandler.HandleHandshakeResp(ctx, resp); err != nil {
+	auth.SetValue(ContextKeyClientAddr, clientIO.SourceAddr().String())
+	if err = handshakeHandler.HandleHandshakeResp(auth, resp); err != nil {
 		return err
 	}
 	auth.user = resp.User
@@ -155,7 +156,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO *pnet
 	auth.collation = resp.Collation
 	auth.attrs = resp.Attrs
 
-	backendIO, err := getBackend(ctx, auth, resp)
+	backendIO, err := getBackend(auth, auth, resp)
 	if err != nil {
 		return err
 	}
@@ -346,4 +347,16 @@ func (auth *Authenticator) changeUser(username, db string) {
 // The proxy cannot send the original dbname to TiDB in the second handshake because the original db may be dropped.
 func (auth *Authenticator) updateCurrentDB(db string) {
 	auth.dbname = db
+}
+
+func (auth *Authenticator) SetValue(key, val any) {
+	auth.ctxmap.Store(key, val)
+}
+
+func (auth *Authenticator) Value(key any) any {
+	v, ok := auth.ctxmap.Load(key)
+	if !ok {
+		return nil
+	}
+	return v
 }

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -47,6 +47,7 @@ const SupportedServerCapabilities = pnet.ClientLongPassword | pnet.ClientFoundRo
 // Authenticator handshakes with the client and the backend.
 type Authenticator struct {
 	backendTLSConfig            *tls.Config
+	ctxmap                      sync.Map
 	supportedServerCapabilities pnet.Capability
 	dbname                      string // default database name
 	serverAddr                  string
@@ -57,7 +58,6 @@ type Authenticator struct {
 	collation                   uint8
 	proxyProtocol               bool
 	requireBackendTLS           bool
-	ctxmap sync.Map
 }
 
 func (auth *Authenticator) String() string {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -54,7 +54,7 @@ type redirectResult struct {
 	to   string
 }
 
-type backendIOGetter func(ctx context.Context, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error)
+type backendIOGetter func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error)
 
 // BackendConnManager migrates a session from one BackendConnection to another.
 //
@@ -105,7 +105,7 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 		signalReceived: make(chan struct{}, 1),
 		redirectResCh:  make(chan *redirectResult, 1),
 	}
-	mgr.getBackendIO = func(ctx context.Context, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error) {
+	mgr.getBackendIO = func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error) {
 		router, err := handshakeHandler.GetRouter(ctx, resp)
 		if err != nil {
 			return nil, err

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -116,7 +116,7 @@ func newBackendMgrTester(t *testing.T, cfg ...cfgOverrider) *backendMgrTester {
 	return tester
 }
 
-func (ts *backendMgrTester) getBackendIO(ctx context.Context, auth *Authenticator, _ *pnet.HandshakeResp) (*pnet.PacketIO, error) {
+func (ts *backendMgrTester) getBackendIO(ctx ConnContext, auth *Authenticator, _ *pnet.HandshakeResp) (*pnet.PacketIO, error) {
 	addr := ts.tc.backendListener.Addr().String()
 	ts.mp.backendConn = NewBackendConnection(addr)
 	if err := ts.mp.backendConn.Connect(); err != nil {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -15,7 +15,6 @@
 package backend
 
 import (
-	"context"
 	"crypto/tls"
 	"testing"
 
@@ -65,7 +64,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, mp.handshakeHandler, func(context.Context, *Authenticator, *pnet.HandshakeResp) (*pnet.PacketIO, error) {
+	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, mp.handshakeHandler, func(ConnContext, *Authenticator, *pnet.HandshakeResp) (*pnet.PacketIO, error) {
 		return backendIO, nil
 	}, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err
@@ -108,11 +107,11 @@ type CustomHandshakeHandler struct {
 	outAttrs      map[string]string
 }
 
-func (handler *CustomHandshakeHandler) GetRouter(ctx context.Context, resp *pnet.HandshakeResp) (router.Router, error) {
+func (handler *CustomHandshakeHandler) GetRouter(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error) {
 	return nil, nil
 }
 
-func (handler *CustomHandshakeHandler) HandleHandshakeResp(ctx context.Context, resp *pnet.HandshakeResp) error {
+func (handler *CustomHandshakeHandler) HandleHandshakeResp(ctx ConnContext, resp *pnet.HandshakeResp) error {
 	handler.inUsername = resp.User
 	resp.User = handler.outUsername
 	handler.inAddr = ctx.Value(ContextKeyClientAddr).(string)

--- a/pkg/sctx/context.go
+++ b/pkg/sctx/context.go
@@ -14,18 +14,18 @@
 
 package sctx
 
-import "github.com/pingcap/TiProxy/lib/config"
-
-type Cluster struct {
-	PubAddr           string
-	ClusterName       string
-	NodeName          string
-	BootstrapDurl     string
-	BootstrapDdns     string
-	BootstrapClusters []string
-}
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/pkg/proxy/backend"
+)
 
 type Context struct {
 	Config  *config.Config
-	Cluster Cluster
+	Handler ServerHandler
+}
+
+type ServerHandler interface {
+	backend.HandshakeHandler
+	RegisterHTTP(c *gin.Engine) error
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		}
 
 		if handler != nil {
-			handler.RegisterHTTP(engine)
+			if err := handler.RegisterHTTP(engine); err != nil {
+				return nil, errors.WithStack(err)
+			}
 		}
 
 		srv.wg.Run(func() {


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #136

Problem Summary: With authenticator being a `kvmap`, we can now support passing custom handler through `server.Context`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
