### PR TITLE
backend: remove getBackendIO

### DIFF
--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -16,29 +16,32 @@ package router
 
 import (
 	"container/list"
-	"context"
-	"net/http"
-	"sync"
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
-	"github.com/pingcap/TiProxy/lib/util/waitgroup"
-	"go.uber.org/zap"
 )
+
+var (
+	ErrNoInstanceToSelect = errors.New("no instances to route")
+)
+
+// ConnEventReceiver receives connection events.
+type ConnEventReceiver interface {
+	OnRedirectSucceed(from, to string, conn RedirectableConn) error
+	OnRedirectFail(from, to string, conn RedirectableConn) error
+	OnConnClosed(addr string, conn RedirectableConn) error
+}
 
 // Router routes client connections to backends.
 type Router interface {
+	// Router will handle connection events to balance connections if possible.
+	ConnEventReceiver
+
 	Route(RedirectableConn) (string, error)
 	RedirectConnections() error
 	ConnCount() int
 	Close()
 }
-
-var _ Router = &ScoreBasedRouter{}
-
-var (
-	ErrNoInstanceToSelect = errors.New("no instances to route")
-)
 
 type connPhase int
 
@@ -66,13 +69,6 @@ const (
 	// Limit its redirection interval to avoid unnecessary retrial to reduce latency jitter.
 	redirectFailMinInterval = 3 * time.Second
 )
-
-// ConnEventReceiver receives connection events.
-type ConnEventReceiver interface {
-	OnRedirectSucceed(from, to string, conn RedirectableConn) error
-	OnRedirectFail(from, to string, conn RedirectableConn) error
-	OnConnClosed(addr string, conn RedirectableConn) error
-}
 
 // RedirectableConn indicates a redirect-able connection.
 type RedirectableConn interface {
@@ -103,345 +99,4 @@ type connWrapper struct {
 	phase connPhase
 	// Last redirect start time of this connection.
 	lastRedirect time.Time
-}
-
-// ScoreBasedRouter is an implementation of Router interface.
-// It routes a connection based on score.
-type ScoreBasedRouter struct {
-	sync.Mutex
-	logger     *zap.Logger
-	observer   *BackendObserver
-	cancelFunc context.CancelFunc
-	wg         waitgroup.WaitGroup
-	// A list of *backendWrapper. The backends are in descending order of scores.
-	backends *list.List
-}
-
-// NewScoreBasedRouter creates a ScoreBasedRouter.
-func NewScoreBasedRouter(logger *zap.Logger, httpCli *http.Client, fetcher BackendFetcher) (*ScoreBasedRouter, error) {
-	router := &ScoreBasedRouter{
-		logger:   logger,
-		backends: list.New(),
-	}
-	router.Lock()
-	defer router.Unlock()
-	observer, err := StartBackendObserver(logger.Named("observer"), router, httpCli, NewDefaultHealthCheckConfig(), fetcher)
-	if err != nil {
-		return nil, err
-	}
-	router.observer = observer
-	childCtx, cancelFunc := context.WithCancel(context.Background())
-	router.cancelFunc = cancelFunc
-	router.wg.Run(func() {
-		router.rebalanceLoop(childCtx)
-	})
-	return router, nil
-}
-
-// Route implements Router.Route interface.
-func (router *ScoreBasedRouter) Route(conn RedirectableConn) (string, error) {
-	router.Lock()
-	defer router.Unlock()
-	be := router.backends.Back()
-	if be == nil {
-		return "", ErrNoInstanceToSelect
-	}
-	backend := be.Value.(*backendWrapper)
-	switch backend.status {
-	case StatusCannotConnect, StatusSchemaOutdated:
-		return "", ErrNoInstanceToSelect
-	}
-	connWrapper := &connWrapper{
-		RedirectableConn: conn,
-		phase:            phaseNotRedirected,
-	}
-	router.addConn(be, connWrapper)
-	addBackendConnMetrics(backend.addr)
-	conn.SetEventReceiver(router)
-	return backend.addr, nil
-}
-
-func (router *ScoreBasedRouter) removeConn(be *list.Element, ce *list.Element) {
-	backend := be.Value.(*backendWrapper)
-	conn := ce.Value.(*connWrapper)
-	backend.connList.Remove(ce)
-	delete(backend.connMap, conn.ConnectionID())
-	if !router.removeBackendIfEmpty(be) {
-		router.adjustBackendList(be)
-	}
-}
-
-func (router *ScoreBasedRouter) addConn(be *list.Element, conn *connWrapper) {
-	backend := be.Value.(*backendWrapper)
-	ce := backend.connList.PushBack(conn)
-	backend.connMap[conn.ConnectionID()] = ce
-	router.adjustBackendList(be)
-}
-
-// adjustBackendList moves `be` after the score of `be` changes to keep the list ordered.
-func (router *ScoreBasedRouter) adjustBackendList(be *list.Element) {
-	backend := be.Value.(*backendWrapper)
-	curScore := backend.score()
-	var mark *list.Element
-	for ele := be.Prev(); ele != nil; ele = ele.Prev() {
-		b := ele.Value.(*backendWrapper)
-		if b.score() >= curScore {
-			break
-		}
-		mark = ele
-	}
-	if mark != nil {
-		router.backends.MoveBefore(be, mark)
-		return
-	}
-	for ele := be.Next(); ele != nil; ele = ele.Next() {
-		b := ele.Value.(*backendWrapper)
-		if b.score() <= curScore {
-			break
-		}
-		mark = ele
-	}
-	if mark != nil {
-		router.backends.MoveAfter(be, mark)
-	}
-}
-
-// RedirectConnections implements Router.RedirectConnections interface.
-// It redirects all connections compulsively. It's only used for testing.
-func (router *ScoreBasedRouter) RedirectConnections() error {
-	router.Lock()
-	defer router.Unlock()
-	for be := router.backends.Front(); be != nil; be = be.Next() {
-		backend := be.Value.(*backendWrapper)
-		for ce := backend.connList.Front(); ce != nil; ce = ce.Next() {
-			// This is only for test, so we allow it to reconnect to the same backend.
-			connWrapper := ce.Value.(*connWrapper)
-			if connWrapper.phase != phaseRedirectNotify {
-				connWrapper.phase = phaseRedirectNotify
-				connWrapper.Redirect(backend.addr)
-			}
-		}
-	}
-	return nil
-}
-
-// forward is a hint to speed up searching.
-func (router *ScoreBasedRouter) lookupBackend(addr string, forward bool) *list.Element {
-	if forward {
-		for be := router.backends.Front(); be != nil; be = be.Next() {
-			backend := be.Value.(*backendWrapper)
-			if backend.addr == addr {
-				return be
-			}
-		}
-	} else {
-		for be := router.backends.Back(); be != nil; be = be.Prev() {
-			backend := be.Value.(*backendWrapper)
-			if backend.addr == addr {
-				return be
-			}
-		}
-	}
-	return nil
-}
-
-// OnRedirectSucceed implements ConnEventReceiver.OnRedirectSucceed interface.
-func (router *ScoreBasedRouter) OnRedirectSucceed(from, to string, conn RedirectableConn) error {
-	router.Lock()
-	defer router.Unlock()
-	be := router.lookupBackend(to, false)
-	if be == nil {
-		return errors.WithStack(errors.Errorf("backend %s is not found in the router", to))
-	}
-	toBackend := be.Value.(*backendWrapper)
-	e, ok := toBackend.connMap[conn.ConnectionID()]
-	if !ok {
-		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), to))
-	}
-	connWrapper := e.Value.(*connWrapper)
-	connWrapper.phase = phaseRedirectEnd
-	addMigrateMetrics(from, to, true, connWrapper.lastRedirect)
-	subBackendConnMetrics(from)
-	addBackendConnMetrics(to)
-	return nil
-}
-
-// OnRedirectFail implements ConnEventReceiver.OnRedirectFail interface.
-func (router *ScoreBasedRouter) OnRedirectFail(from, to string, conn RedirectableConn) error {
-	router.Lock()
-	defer router.Unlock()
-	be := router.lookupBackend(to, false)
-	if be == nil {
-		return errors.WithStack(errors.Errorf("backend %s is not found in the router", to))
-	}
-	toBackend := be.Value.(*backendWrapper)
-	ce, ok := toBackend.connMap[conn.ConnectionID()]
-	if !ok {
-		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), to))
-	}
-	router.removeConn(be, ce)
-
-	be = router.lookupBackend(from, true)
-	// The backend may have been removed because it's empty. Add it back.
-	if be == nil {
-		be = router.backends.PushBack(&backendWrapper{
-			status:   StatusCannotConnect,
-			addr:     from,
-			connList: list.New(),
-			connMap:  make(map[uint64]*list.Element),
-		})
-	}
-	connWrapper := ce.Value.(*connWrapper)
-	connWrapper.phase = phaseRedirectFail
-	addMigrateMetrics(from, to, false, connWrapper.lastRedirect)
-	router.addConn(be, connWrapper)
-	return nil
-}
-
-// OnConnClosed implements ConnEventReceiver.OnConnClosed interface.
-func (router *ScoreBasedRouter) OnConnClosed(addr string, conn RedirectableConn) error {
-	router.Lock()
-	defer router.Unlock()
-	// Get the redirecting address in the lock, rather than letting the connection pass it in.
-	// While the connection closes, the router may also send a new redirection signal concurrently
-	// and move it to another backendWrapper.
-	if toAddr := conn.GetRedirectingAddr(); len(toAddr) > 0 {
-		addr = toAddr
-	}
-	be := router.lookupBackend(addr, true)
-	if be == nil {
-		return errors.WithStack(errors.Errorf("backend %s is not found in the router", addr))
-	}
-	backend := be.Value.(*backendWrapper)
-	ce, ok := backend.connMap[conn.ConnectionID()]
-	if !ok {
-		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), addr))
-	}
-	router.removeConn(be, ce)
-	subBackendConnMetrics(addr)
-	return nil
-}
-
-// OnBackendChanged implements BackendEventReceiver.OnBackendChanged interface.
-func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStatus) {
-	router.Lock()
-	defer router.Unlock()
-	for addr, status := range backends {
-		be := router.lookupBackend(addr, true)
-		if be == nil && status != StatusCannotConnect {
-			router.logger.Info("find new backend", zap.String("addr", addr),
-				zap.String("status", status.String()))
-			be = router.backends.PushBack(&backendWrapper{
-				status:   status,
-				addr:     addr,
-				connList: list.New(),
-				connMap:  make(map[uint64]*list.Element),
-			})
-		} else {
-			backend := be.Value.(*backendWrapper)
-			router.logger.Info("update backend", zap.String("addr", addr),
-				zap.String("prev_status", backend.status.String()), zap.String("cur_status", status.String()))
-			backend.status = status
-		}
-		if !router.removeBackendIfEmpty(be) {
-			router.adjustBackendList(be)
-		}
-	}
-}
-
-func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
-	for {
-		router.rebalance(rebalanceConnsPerLoop)
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(rebalanceInterval):
-		}
-	}
-}
-
-func (router *ScoreBasedRouter) rebalance(maxNum int) {
-	curTime := time.Now()
-	router.Lock()
-	defer router.Unlock()
-	for i := 0; i < maxNum; i++ {
-		var busiestEle *list.Element
-		for be := router.backends.Front(); be != nil; be = be.Next() {
-			backend := be.Value.(*backendWrapper)
-			if backend.connList.Len() > 0 {
-				busiestEle = be
-				break
-			}
-		}
-		if busiestEle == nil {
-			break
-		}
-		busiestBackend := busiestEle.Value.(*backendWrapper)
-		idlestEle := router.backends.Back()
-		idlestBackend := idlestEle.Value.(*backendWrapper)
-		if float64(busiestBackend.score())/float64(idlestBackend.score()+1) < rebalanceMaxScoreRatio {
-			break
-		}
-		var ce *list.Element
-		for ele := busiestBackend.connList.Front(); ele != nil; ele = ele.Next() {
-			conn := ele.Value.(*connWrapper)
-			switch conn.phase {
-			case phaseRedirectNotify:
-				// A connection cannot be redirected again when it has not finished redirecting.
-				continue
-			case phaseRedirectFail:
-				// If it failed recently, it will probably fail this time.
-				if conn.lastRedirect.Add(redirectFailMinInterval).After(curTime) {
-					continue
-				}
-			}
-			ce = ele
-			break
-		}
-		if ce == nil {
-			break
-		}
-		router.removeConn(busiestEle, ce)
-		conn := ce.Value.(*connWrapper)
-		conn.phase = phaseRedirectNotify
-		conn.lastRedirect = curTime
-		router.addConn(idlestEle, conn)
-		conn.Redirect(idlestBackend.addr)
-	}
-}
-
-func (router *ScoreBasedRouter) removeBackendIfEmpty(be *list.Element) bool {
-	backend := be.Value.(*backendWrapper)
-	if backend.status == StatusCannotConnect && backend.connList.Len() == 0 {
-		router.backends.Remove(be)
-		return true
-	}
-	return false
-}
-
-func (router *ScoreBasedRouter) ConnCount() int {
-	router.Lock()
-	defer router.Unlock()
-	j := 0
-	for be := router.backends.Front(); be != nil; be = be.Next() {
-		backend := be.Value.(*backendWrapper)
-		j += backend.connList.Len()
-	}
-	return j
-}
-
-// Close implements Router.Close interface.
-func (router *ScoreBasedRouter) Close() {
-	router.Lock()
-	defer router.Unlock()
-	if router.cancelFunc != nil {
-		router.cancelFunc()
-		router.cancelFunc = nil
-	}
-	if router.observer != nil {
-		router.observer.Close()
-		router.observer = nil
-	}
-	router.wg.Wait()
-	// Router only refers to RedirectableConn, it doesn't manage RedirectableConn.
 }

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -1,0 +1,370 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"container/list"
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/util/errors"
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
+	"go.uber.org/zap"
+)
+
+var _ Router = &ScoreBasedRouter{}
+
+// ScoreBasedRouter is an implementation of Router interface.
+// It routes a connection based on score.
+type ScoreBasedRouter struct {
+	sync.Mutex
+	logger     *zap.Logger
+	observer   *BackendObserver
+	cancelFunc context.CancelFunc
+	wg         waitgroup.WaitGroup
+	// A list of *backendWrapper. The backends are in descending order of scores.
+	backends *list.List
+}
+
+// NewScoreBasedRouter creates a ScoreBasedRouter.
+func NewScoreBasedRouter(logger *zap.Logger, httpCli *http.Client, fetcher BackendFetcher) (*ScoreBasedRouter, error) {
+	router := &ScoreBasedRouter{
+		logger:   logger,
+		backends: list.New(),
+	}
+	router.Lock()
+	defer router.Unlock()
+	observer, err := StartBackendObserver(logger.Named("observer"), router, httpCli, NewDefaultHealthCheckConfig(), fetcher)
+	if err != nil {
+		return nil, err
+	}
+	router.observer = observer
+	childCtx, cancelFunc := context.WithCancel(context.Background())
+	router.cancelFunc = cancelFunc
+	router.wg.Run(func() {
+		router.rebalanceLoop(childCtx)
+	})
+	return router, nil
+}
+
+// Route implements Router.Route interface.
+func (router *ScoreBasedRouter) Route(conn RedirectableConn) (string, error) {
+	router.Lock()
+	defer router.Unlock()
+	be := router.backends.Back()
+	if be == nil {
+		return "", ErrNoInstanceToSelect
+	}
+	backend := be.Value.(*backendWrapper)
+	switch backend.status {
+	case StatusCannotConnect, StatusSchemaOutdated:
+		return "", ErrNoInstanceToSelect
+	}
+	connWrapper := &connWrapper{
+		RedirectableConn: conn,
+		phase:            phaseNotRedirected,
+	}
+	router.addConn(be, connWrapper)
+	addBackendConnMetrics(backend.addr)
+	conn.SetEventReceiver(router)
+	return backend.addr, nil
+}
+
+func (router *ScoreBasedRouter) removeConn(be *list.Element, ce *list.Element) {
+	backend := be.Value.(*backendWrapper)
+	conn := ce.Value.(*connWrapper)
+	backend.connList.Remove(ce)
+	delete(backend.connMap, conn.ConnectionID())
+	if !router.removeBackendIfEmpty(be) {
+		router.adjustBackendList(be)
+	}
+}
+
+func (router *ScoreBasedRouter) addConn(be *list.Element, conn *connWrapper) {
+	backend := be.Value.(*backendWrapper)
+	ce := backend.connList.PushBack(conn)
+	backend.connMap[conn.ConnectionID()] = ce
+	router.adjustBackendList(be)
+}
+
+// adjustBackendList moves `be` after the score of `be` changes to keep the list ordered.
+func (router *ScoreBasedRouter) adjustBackendList(be *list.Element) {
+	backend := be.Value.(*backendWrapper)
+	curScore := backend.score()
+	var mark *list.Element
+	for ele := be.Prev(); ele != nil; ele = ele.Prev() {
+		b := ele.Value.(*backendWrapper)
+		if b.score() >= curScore {
+			break
+		}
+		mark = ele
+	}
+	if mark != nil {
+		router.backends.MoveBefore(be, mark)
+		return
+	}
+	for ele := be.Next(); ele != nil; ele = ele.Next() {
+		b := ele.Value.(*backendWrapper)
+		if b.score() <= curScore {
+			break
+		}
+		mark = ele
+	}
+	if mark != nil {
+		router.backends.MoveAfter(be, mark)
+	}
+}
+
+// RedirectConnections implements Router.RedirectConnections interface.
+// It redirects all connections compulsively. It's only used for testing.
+func (router *ScoreBasedRouter) RedirectConnections() error {
+	router.Lock()
+	defer router.Unlock()
+	for be := router.backends.Front(); be != nil; be = be.Next() {
+		backend := be.Value.(*backendWrapper)
+		for ce := backend.connList.Front(); ce != nil; ce = ce.Next() {
+			// This is only for test, so we allow it to reconnect to the same backend.
+			connWrapper := ce.Value.(*connWrapper)
+			if connWrapper.phase != phaseRedirectNotify {
+				connWrapper.phase = phaseRedirectNotify
+				connWrapper.Redirect(backend.addr)
+			}
+		}
+	}
+	return nil
+}
+
+// forward is a hint to speed up searching.
+func (router *ScoreBasedRouter) lookupBackend(addr string, forward bool) *list.Element {
+	if forward {
+		for be := router.backends.Front(); be != nil; be = be.Next() {
+			backend := be.Value.(*backendWrapper)
+			if backend.addr == addr {
+				return be
+			}
+		}
+	} else {
+		for be := router.backends.Back(); be != nil; be = be.Prev() {
+			backend := be.Value.(*backendWrapper)
+			if backend.addr == addr {
+				return be
+			}
+		}
+	}
+	return nil
+}
+
+// OnRedirectSucceed implements ConnEventReceiver.OnRedirectSucceed interface.
+func (router *ScoreBasedRouter) OnRedirectSucceed(from, to string, conn RedirectableConn) error {
+	router.Lock()
+	defer router.Unlock()
+	be := router.lookupBackend(to, false)
+	if be == nil {
+		return errors.WithStack(errors.Errorf("backend %s is not found in the router", to))
+	}
+	toBackend := be.Value.(*backendWrapper)
+	e, ok := toBackend.connMap[conn.ConnectionID()]
+	if !ok {
+		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), to))
+	}
+	connWrapper := e.Value.(*connWrapper)
+	connWrapper.phase = phaseRedirectEnd
+	addMigrateMetrics(from, to, true, connWrapper.lastRedirect)
+	subBackendConnMetrics(from)
+	addBackendConnMetrics(to)
+	return nil
+}
+
+// OnRedirectFail implements ConnEventReceiver.OnRedirectFail interface.
+func (router *ScoreBasedRouter) OnRedirectFail(from, to string, conn RedirectableConn) error {
+	router.Lock()
+	defer router.Unlock()
+	be := router.lookupBackend(to, false)
+	if be == nil {
+		return errors.WithStack(errors.Errorf("backend %s is not found in the router", to))
+	}
+	toBackend := be.Value.(*backendWrapper)
+	ce, ok := toBackend.connMap[conn.ConnectionID()]
+	if !ok {
+		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), to))
+	}
+	router.removeConn(be, ce)
+
+	be = router.lookupBackend(from, true)
+	// The backend may have been removed because it's empty. Add it back.
+	if be == nil {
+		be = router.backends.PushBack(&backendWrapper{
+			status:   StatusCannotConnect,
+			addr:     from,
+			connList: list.New(),
+			connMap:  make(map[uint64]*list.Element),
+		})
+	}
+	connWrapper := ce.Value.(*connWrapper)
+	connWrapper.phase = phaseRedirectFail
+	addMigrateMetrics(from, to, false, connWrapper.lastRedirect)
+	router.addConn(be, connWrapper)
+	return nil
+}
+
+// OnConnClosed implements ConnEventReceiver.OnConnClosed interface.
+func (router *ScoreBasedRouter) OnConnClosed(addr string, conn RedirectableConn) error {
+	router.Lock()
+	defer router.Unlock()
+	// Get the redirecting address in the lock, rather than letting the connection pass it in.
+	// While the connection closes, the router may also send a new redirection signal concurrently
+	// and move it to another backendWrapper.
+	if toAddr := conn.GetRedirectingAddr(); len(toAddr) > 0 {
+		addr = toAddr
+	}
+	be := router.lookupBackend(addr, true)
+	if be == nil {
+		return errors.WithStack(errors.Errorf("backend %s is not found in the router", addr))
+	}
+	backend := be.Value.(*backendWrapper)
+	ce, ok := backend.connMap[conn.ConnectionID()]
+	if !ok {
+		return errors.WithStack(errors.Errorf("connection %d is not found on the backend %s", conn.ConnectionID(), addr))
+	}
+	router.removeConn(be, ce)
+	subBackendConnMetrics(addr)
+	return nil
+}
+
+// OnBackendChanged implements BackendEventReceiver.OnBackendChanged interface.
+func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStatus) {
+	router.Lock()
+	defer router.Unlock()
+	for addr, status := range backends {
+		be := router.lookupBackend(addr, true)
+		if be == nil && status != StatusCannotConnect {
+			router.logger.Info("find new backend", zap.String("addr", addr),
+				zap.String("status", status.String()))
+			be = router.backends.PushBack(&backendWrapper{
+				status:   status,
+				addr:     addr,
+				connList: list.New(),
+				connMap:  make(map[uint64]*list.Element),
+			})
+		} else {
+			backend := be.Value.(*backendWrapper)
+			router.logger.Info("update backend", zap.String("addr", addr),
+				zap.String("prev_status", backend.status.String()), zap.String("cur_status", status.String()))
+			backend.status = status
+		}
+		if !router.removeBackendIfEmpty(be) {
+			router.adjustBackendList(be)
+		}
+	}
+}
+
+func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
+	for {
+		router.rebalance(rebalanceConnsPerLoop)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(rebalanceInterval):
+		}
+	}
+}
+
+func (router *ScoreBasedRouter) rebalance(maxNum int) {
+	curTime := time.Now()
+	router.Lock()
+	defer router.Unlock()
+	for i := 0; i < maxNum; i++ {
+		var busiestEle *list.Element
+		for be := router.backends.Front(); be != nil; be = be.Next() {
+			backend := be.Value.(*backendWrapper)
+			if backend.connList.Len() > 0 {
+				busiestEle = be
+				break
+			}
+		}
+		if busiestEle == nil {
+			break
+		}
+		busiestBackend := busiestEle.Value.(*backendWrapper)
+		idlestEle := router.backends.Back()
+		idlestBackend := idlestEle.Value.(*backendWrapper)
+		if float64(busiestBackend.score())/float64(idlestBackend.score()+1) < rebalanceMaxScoreRatio {
+			break
+		}
+		var ce *list.Element
+		for ele := busiestBackend.connList.Front(); ele != nil; ele = ele.Next() {
+			conn := ele.Value.(*connWrapper)
+			switch conn.phase {
+			case phaseRedirectNotify:
+				// A connection cannot be redirected again when it has not finished redirecting.
+				continue
+			case phaseRedirectFail:
+				// If it failed recently, it will probably fail this time.
+				if conn.lastRedirect.Add(redirectFailMinInterval).After(curTime) {
+					continue
+				}
+			}
+			ce = ele
+			break
+		}
+		if ce == nil {
+			break
+		}
+		router.removeConn(busiestEle, ce)
+		conn := ce.Value.(*connWrapper)
+		conn.phase = phaseRedirectNotify
+		conn.lastRedirect = curTime
+		router.addConn(idlestEle, conn)
+		conn.Redirect(idlestBackend.addr)
+	}
+}
+
+func (router *ScoreBasedRouter) removeBackendIfEmpty(be *list.Element) bool {
+	backend := be.Value.(*backendWrapper)
+	if backend.status == StatusCannotConnect && backend.connList.Len() == 0 {
+		router.backends.Remove(be)
+		return true
+	}
+	return false
+}
+
+func (router *ScoreBasedRouter) ConnCount() int {
+	router.Lock()
+	defer router.Unlock()
+	j := 0
+	for be := router.backends.Front(); be != nil; be = be.Next() {
+		backend := be.Value.(*backendWrapper)
+		j += backend.connList.Len()
+	}
+	return j
+}
+
+// Close implements Router.Close interface.
+func (router *ScoreBasedRouter) Close() {
+	router.Lock()
+	defer router.Unlock()
+	if router.cancelFunc != nil {
+		router.cancelFunc()
+		router.cancelFunc = nil
+	}
+	if router.observer != nil {
+		router.observer.Close()
+		router.observer = nil
+	}
+	router.wg.Wait()
+	// Router only refers to RedirectableConn, it doesn't manage RedirectableConn.
+}

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -1,0 +1,55 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+var _ Router = &StaticRouter{}
+
+type StaticRouter struct {
+	addr string
+	cnt  int
+}
+
+func NewStaticRouter(addr string) *StaticRouter {
+	return &StaticRouter{addr: addr}
+}
+
+func (r *StaticRouter) Route(c RedirectableConn) (string, error) {
+	return r.addr, nil
+}
+
+func (r *StaticRouter) RedirectConnections() error {
+	return nil
+}
+
+func (r *StaticRouter) ConnCount() int {
+	r.cnt++
+	return r.cnt
+}
+
+func (r *StaticRouter) Close() {
+}
+
+func (r *StaticRouter) OnRedirectSucceed(from, to string, conn RedirectableConn) error {
+	return nil
+}
+
+func (r *StaticRouter) OnRedirectFail(from, to string, conn RedirectableConn) error {
+	return nil
+}
+
+func (r *StaticRouter) OnConnClosed(addr string, conn RedirectableConn) error {
+	r.cnt--
+	return nil
+}

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -106,7 +106,6 @@ type backendIOGetter func(ctx ConnContext, auth *Authenticator, resp *pnet.Hands
 func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO, backendIO *pnet.PacketIO, handshakeHandler HandshakeHandler,
 	getBackendIO backendIOGetter, frontendTLSConfig, backendTLSConfig *tls.Config) error {
 	clientIO.ResetSequence()
-	auth.serverAddr = backendIO.SourceAddr().String()
 	auth.clientAddr = clientIO.SourceAddr().String()
 
 	proxyCapability := auth.supportedServerCapabilities

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -103,7 +103,7 @@ func (auth *Authenticator) verifyBackendCaps(logger *zap.Logger, backendCapabili
 
 type backendIOGetter func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error)
 
-func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO, backendIO *pnet.PacketIO, handshakeHandler HandshakeHandler,
+func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO *pnet.PacketIO, handshakeHandler HandshakeHandler,
 	getBackendIO backendIOGetter, frontendTLSConfig, backendTLSConfig *tls.Config) error {
 	clientIO.ResetSequence()
 	auth.clientAddr = clientIO.SourceAddr().String()
@@ -160,11 +160,9 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, clientIO, back
 	auth.attrs = resp.Attrs
 
 	// In case of testing, backendIO is passed manually that we don't want to bother with the routing logic.
-	if backendIO == nil {
-		backendIO, err = getBackendIO(auth, auth, resp)
-		if err != nil {
-			return err
-		}
+	backendIO, err := getBackendIO(auth, auth, resp)
+	if err != nil {
+		return err
 	}
 	backendIO.ResetSequence()
 

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -162,6 +162,7 @@ func (mgr *BackendConnManager) handshakeFirstTime(logger *zap.Logger, clientIO, 
 	auth.collation = resp.Collation
 	auth.attrs = resp.Attrs
 
+	// In case of testing, backendIO is passed manually that we don't want to bother with the routing logic.
 	if backendIO == nil {
 		r, err := handshakeHandler.GetRouter(auth, resp)
 		if err != nil {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -139,7 +139,7 @@ func (mgr *BackendConnManager) Connect(ctx context.Context, clientIO *pnet.Packe
 	mgr.processLock.Lock()
 	defer mgr.processLock.Unlock()
 
-	err := mgr.authenticator.handshakeFirstTime(mgr.logger.Named("authenticator"), clientIO, nil, mgr.handshakeHandler, mgr.getBackendIO, frontendTLSConfig, backendTLSConfig)
+	err := mgr.authenticator.handshakeFirstTime(mgr.logger.Named("authenticator"), clientIO, mgr.handshakeHandler, mgr.getBackendIO, frontendTLSConfig, backendTLSConfig)
 	mgr.handshakeHandler.OnHandshake(mgr.authenticator, mgr.authenticator.serverAddr, err)
 	if err != nil {
 		return err

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -94,7 +94,7 @@ type backendMgrTester struct {
 func newBackendMgrTester(t *testing.T, cfg ...cfgOverrider) *backendMgrTester {
 	tc := newTCPConnSuite(t)
 	cfg = append(cfg, func(cfg *testConfig) {
-		cfg.testSuiteConfig.initBackendConn = false
+		cfg.testSuiteConfig.enableRouteLogic = true
 	})
 	ts, clean := newTestSuite(t, tc, cfg...)
 	tester := &backendMgrTester{

--- a/pkg/proxy/backend/common_test.go
+++ b/pkg/proxy/backend/common_test.go
@@ -55,9 +55,9 @@ func newTCPConnSuite(t *testing.T) *tcpConnSuite {
 	return r
 }
 
-func (tc *tcpConnSuite) newConn(t *testing.T, withBackend bool) func() {
+func (tc *tcpConnSuite) newConn(t *testing.T, enableRoute bool) func() {
 	var wg waitgroup.WaitGroup
-	if withBackend {
+	if !enableRoute {
 		wg.Run(func() {
 			conn, err := tc.backendListener.Accept()
 			require.NoError(t, err)
@@ -65,7 +65,7 @@ func (tc *tcpConnSuite) newConn(t *testing.T, withBackend bool) func() {
 		})
 	}
 	wg.Run(func() {
-		if withBackend {
+		if !enableRoute {
 			backendConn, err := net.Dial("tcp", tc.backendListener.Addr().String())
 			require.NoError(t, err)
 			tc.proxyBIO = pnet.NewPacketIO(backendConn)

--- a/pkg/proxy/backend/common_test.go
+++ b/pkg/proxy/backend/common_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/pingcap/TiProxy/lib/util/security"
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
-	"github.com/pingcap/tidb/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,7 +56,7 @@ func newTCPConnSuite(t *testing.T) *tcpConnSuite {
 }
 
 func (tc *tcpConnSuite) newConn(t *testing.T, withBackend bool) func() {
-	var wg util.WaitGroupWrapper
+	var wg waitgroup.WaitGroup
 	if withBackend {
 		wg.Run(func() {
 			conn, err := tc.backendListener.Accept()
@@ -92,7 +92,7 @@ func (tc *tcpConnSuite) newConn(t *testing.T, withBackend bool) func() {
 }
 
 func (tc *tcpConnSuite) run(clientRunner, backendRunner func(*pnet.PacketIO) error, proxyRunner func(*pnet.PacketIO, *pnet.PacketIO) error) (cerr, berr, perr error) {
-	var wg util.WaitGroupWrapper
+	var wg waitgroup.WaitGroup
 	if clientRunner != nil {
 		wg.Run(func() {
 			cerr = clientRunner(tc.clientIO)

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -108,13 +108,6 @@ func (h *CustomHandshakeHandler) HandleHandshakeResp(ctx ConnContext, resp *pnet
 		return h.handleHandshakeResp(ctx, resp)
 	}
 	return nil
-	/*
-	h.inUsername = resp.User
-	resp.User = h.outUsername
-	h.inAddr = ctx.ClientAddr()
-	resp.Attrs = h.outAttrs
-	return nil
-	*/
 }
 
 func (h *CustomHandshakeHandler) GetCapability() pnet.Capability {

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -74,3 +74,52 @@ func (handler *DefaultHandshakeHandler) OnConnClose(ConnContext) error {
 func (handler *DefaultHandshakeHandler) GetCapability() pnet.Capability {
 	return SupportedServerCapabilities
 }
+
+type CustomHandshakeHandler struct {
+	getRouter           func(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error)
+	onHandshake         func(ConnContext, string, error)
+	onConnClose         func(ConnContext) error
+	handleHandshakeResp func(ctx ConnContext, resp *pnet.HandshakeResp) error
+	getCapability       func() pnet.Capability
+}
+
+func (h *CustomHandshakeHandler) GetRouter(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error) {
+	if h.getRouter != nil {
+		return h.getRouter(ctx, resp)
+	}
+	return nil, errors.New("no router")
+}
+
+func (h *CustomHandshakeHandler) OnHandshake(ctx ConnContext, addr string, err error) {
+	if h.onHandshake != nil {
+		h.onHandshake(ctx, addr, err)
+	}
+}
+
+func (h *CustomHandshakeHandler) OnConnClose(ctx ConnContext) error {
+	if h.onConnClose != nil {
+		return h.onConnClose(ctx)
+	}
+	return nil
+}
+
+func (h *CustomHandshakeHandler) HandleHandshakeResp(ctx ConnContext, resp *pnet.HandshakeResp) error {
+	if h.handleHandshakeResp != nil {
+		return h.handleHandshakeResp(ctx, resp)
+	}
+	return nil
+	/*
+	h.inUsername = resp.User
+	resp.User = h.outUsername
+	h.inAddr = ctx.ClientAddr()
+	resp.Attrs = h.outAttrs
+	return nil
+	*/
+}
+
+func (h *CustomHandshakeHandler) GetCapability() pnet.Capability {
+	if h.getCapability != nil {
+		return h.getCapability()
+	}
+	return SupportedServerCapabilities
+}

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -20,7 +20,6 @@ import (
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/TiProxy/lib/util/logger"
-	"github.com/pingcap/TiProxy/pkg/manager/router"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"go.uber.org/zap"
 )
@@ -28,7 +27,7 @@ import (
 type proxyConfig struct {
 	frontendTLSConfig *tls.Config
 	backendTLSConfig  *tls.Config
-	handler           HandshakeHandler
+	handler           *CustomHandshakeHandler
 	sessionToken      string
 	capability        uint32
 	waitRedirect      bool
@@ -36,7 +35,7 @@ type proxyConfig struct {
 
 func newProxyConfig() *proxyConfig {
 	return &proxyConfig{
-		handler:      NewDefaultHandshakeHandler(nil),
+		handler:      &CustomHandshakeHandler{},
 		capability:   defaultTestBackendCapability,
 		sessionToken: mockToken,
 	}
@@ -64,9 +63,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, mp.handshakeHandler, func(ConnContext, *Authenticator, *pnet.HandshakeResp) (*pnet.PacketIO, error) {
-		return backendIO, nil
-	}, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
+	if err := mp.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.handshakeHandler, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err
 	}
 	mp.cmdProcessor.capability = mp.authenticator.capability
@@ -97,35 +94,4 @@ func (mp *mockProxy) directQuery(_, backendIO *pnet.PacketIO) error {
 	rs, _, err := mp.cmdProcessor.query(backendIO, mockCmdStr)
 	mp.rs = rs
 	return err
-}
-
-type CustomHandshakeHandler struct {
-	inUsername    string
-	inAddr        string
-	outCapability pnet.Capability
-	outUsername   string
-	outAttrs      map[string]string
-}
-
-func (handler *CustomHandshakeHandler) GetRouter(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error) {
-	return nil, nil
-}
-
-func (handler *CustomHandshakeHandler) OnHandshake(ctx ConnContext, _ string, _ error) {
-}
-
-func (handler *CustomHandshakeHandler) OnConnClose(ctx ConnContext) error {
-	return nil
-}
-
-func (handler *CustomHandshakeHandler) HandleHandshakeResp(ctx ConnContext, resp *pnet.HandshakeResp) error {
-	handler.inUsername = resp.User
-	resp.User = handler.outUsername
-	handler.inAddr = ctx.ClientAddr()
-	resp.Attrs = handler.outAttrs
-	return nil
-}
-
-func (handler *CustomHandshakeHandler) GetCapability() pnet.Capability {
-	return handler.outCapability
 }

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -63,7 +63,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
+	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.handshakeHandler, nil, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err
 	}
 	mp.cmdProcessor.capability = mp.authenticator.capability

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -63,7 +63,9 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.handshakeHandler, nil, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
+	if err := mp.authenticator.handshakeFirstTime(mp.logger, clientIO, mp.handshakeHandler, func(ConnContext, *Authenticator, *pnet.HandshakeResp) (*pnet.PacketIO, error) {
+		return backendIO, nil
+	}, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err
 	}
 	mp.cmdProcessor.capability = mp.authenticator.capability

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -63,7 +63,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.handshakeHandler, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
+	if err := mp.handshakeFirstTime(mp.logger, clientIO, backendIO, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err
 	}
 	mp.cmdProcessor.capability = mp.authenticator.capability

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/TiProxy/pkg/manager/router"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/stretchr/testify/require"
@@ -127,6 +128,9 @@ func newTestSuite(t *testing.T, tc *tcpConnSuite, overriders ...cfgOverrider) (*
 		config.proxyConfig.backendTLSConfig = tc.clientTLSConfig
 		config.proxyConfig.frontendTLSConfig = tc.backendTLSConfig
 		config.clientConfig.tlsConfig = tc.clientTLSConfig
+		config.proxyConfig.handler.getRouter = func(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error) {
+			return router.NewStaticRouter(ts.tc.backendListener.Addr().String()), nil
+		}
 	})...)
 	ts.mb = newMockBackend(cfg.backendConfig)
 	ts.mp = newMockProxy(t, cfg.proxyConfig)

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -110,13 +110,13 @@ type testSuite struct {
 }
 
 type testSuiteConfig struct {
-	initBackendConn bool
+	// When true, routing logic in handshakeFirstTime is enabled.
+	// When false, a manual created backendIO is passed to handler to skip the routing logic.
+	enableRouteLogic bool
 }
 
 func newTestSuiteConfig() *testSuiteConfig {
-	return &testSuiteConfig{
-		initBackendConn: true,
-	}
+	return &testSuiteConfig{}
 }
 
 type checker func(t *testing.T, ts *testSuite)
@@ -137,7 +137,7 @@ func newTestSuite(t *testing.T, tc *tcpConnSuite, overriders ...cfgOverrider) (*
 	ts.mc = newMockClient(cfg.clientConfig)
 	ts.tc = tc
 	ts.testSuiteConfig = cfg.testSuiteConfig
-	clean := tc.newConn(t, ts.initBackendConn)
+	clean := tc.newConn(t, ts.enableRouteLogic)
 	return ts, clean
 }
 

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -61,7 +61,7 @@ func (cc *ClientConnection) Run(ctx context.Context) {
 	var err error
 	var msg string
 
-	if err = cc.connMgr.Connect(ctx, cc.pkt, nil, cc.frontendTLSConfig, cc.backendTLSConfig); err != nil {
+	if err = cc.connMgr.Connect(ctx, cc.pkt, cc.frontendTLSConfig, cc.backendTLSConfig); err != nil {
 		msg = "new connection failed"
 		goto clean
 	}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Another refactor to clean the code. `getBackendIO` is added to do namespace routing. Now it is done in `HandshakeHandler` by returning the correct router. So it is completely fine to remove `getBackendIO` now.

What is changed and how it works:

1. Split `ScoreBasedRouter` into a separate file.
2. Add `StaticRouter` for tests.
3. Add `ConnEventReceiver` interface as parts of `Router`
4. `getBackendIO` is moved into `handshakeFirstTime`
5. `handshakeFirstTime` is now a method of `BackendConnMgr` due to dependency problems.(handler is stored in the manager, not the authenticator)
6. Replace `github.com/pingcap/tidb/util.WaitGroupWrapper` with `github.com/pingcap/TiProxy/lib/util/waitgroup.WaitGroup`
7. `CustomHandshakeHandler` moved into `handshake_handler.go`. Minor refactored.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
