### PR TITLE
security: fix server cert config

### DIFF
--- a/lib/util/security/cert.go
+++ b/lib/util/security/cert.go
@@ -174,14 +174,14 @@ func (ci *CertInfo) buildServerConfig(lg *zap.Logger) (*tls.Config, error) {
 		VerifyPeerCertificate: ci.verifyPeerCertificate,
 	}
 
-	var certPEM, keyPEM, caPEM []byte
+	var certPEM, keyPEM []byte
 	var err error
 	if autoCerts {
 		dur, err := time.ParseDuration(ci.cfg.AutoExpireDuration)
 		if err != nil {
 			dur = DefaultCertExpiration
 		}
-		certPEM, keyPEM, caPEM, err = CreateTempTLS(ci.cfg.RSAKeySize, dur)
+		certPEM, keyPEM, _, err = CreateTempTLS(ci.cfg.RSAKeySize, dur)
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +214,7 @@ func (ci *CertInfo) buildServerConfig(lg *zap.Logger) (*tls.Config, error) {
 		return tcfg, nil
 	}
 
-	caPEM, err = os.ReadFile(ci.cfg.CA)
+	caPEM, err := os.ReadFile(ci.cfg.CA)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -1,0 +1,200 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"crypto/tls"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertServer(t *testing.T) {
+	logger := logger.CreateLoggerForTest(t)
+	tmpdir := t.TempDir()
+	certPath := filepath.Join(tmpdir, "cert")
+	keyPath := filepath.Join(tmpdir, "key")
+	caPath := filepath.Join(tmpdir, "ca")
+
+	require.NoError(t, createTLSCertificates(logger, certPath, keyPath, caPath, 0, time.Hour))
+
+	type certCase struct {
+		config.TLSConfig
+		server  bool
+		checker func(*testing.T, *tls.Config, *CertInfo)
+		err     string
+	}
+
+	cases := []certCase{
+		{
+			server: true,
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.Nil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				CA: caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.Nil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				AutoCerts: true,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+				CA:   caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				AutoCerts: true,
+				CA:        caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.Nil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.Nil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				SkipCA: true,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				SkipCA: true,
+				Cert:   certPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Nil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				CA: caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.NotNil(t, ci.ca.Load())
+				require.Nil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+				CA:   caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+	}
+
+	for _, tc := range cases {
+		ci, tcfg, err := NewCert(logger, tc.TLSConfig, tc.server)
+		if len(tc.err) > 0 {
+			require.Nil(t, ci)
+			require.ErrorContains(t, err, tc.err)
+		} else {
+			require.NotNil(t, ci)
+			require.NoError(t, err)
+		}
+		if tc.checker != nil {
+			tc.checker(t, tcfg, ci)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #162

Problem Summary: Bug introduced by #146. TLS config for server is wrong if ca is not configured but certs.

What is changed and how it works: Added some unit tests to prevent regression.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
