### PR TITLE
proxy: optional server-side verification

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -38,11 +38,11 @@ rsa-key-size = 4_096
 #   skip-ca = trure
 # client object:
 #   1. requires: ca or skip-ca(skip verify server certs)
-#   2. optionally: cert/key will be used if server asks
+#   2. optionally: cert/key will be used if server asks, i.e. server-side client verification
 #   3. useless/forbid: auto-certs
 # server object:
 #   1. requires: cert/key or auto-certs(generate a temporary cert, mostly for testing)
-#   2. optional1: ca will enable server-side client verification. If skip-ca is true with non-empty ca, server will only verify clients if it can provide any cert. Otherwise, clients must provide a cert.
+#   2. optionally: ca will enable server-side client verification. If skip-ca is true with non-empty ca, server will only verify clients if it can provide any cert. Otherwise, clients must provide a cert.
 # peer object:
 #   1. requires: cert/key/ca or auto-certs
 #   2. useless/forbid: skip-ca

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -42,8 +42,7 @@ rsa-key-size = 4_096
 #   3. useless/forbid: auto-certs
 # server object:
 #   1. requires: cert/key or auto-certs(generate a temporary cert, mostly for testing)
-#   2. optionally: ca will enable server-side client verification.
-#   3. useless/forbid: skip-ca
+#   2. optional1: ca will enable server-side client verification. If skip-ca is true with non-empty ca, server will only verify clients if it can provide any cert. Otherwise, clients must provide a cert.
 # peer object:
 #   1. requires: cert/key/ca or auto-certs
 #   2. useless/forbid: skip-ca

--- a/lib/util/security/cert.go
+++ b/lib/util/security/cert.go
@@ -181,7 +181,7 @@ func (ci *CertInfo) buildServerConfig(lg *zap.Logger) (*tls.Config, error) {
 		if err != nil {
 			dur = DefaultCertExpiration
 		}
-		certPEM, keyPEM, _, err = CreateTempTLS(ci.cfg.RSAKeySize, dur)
+		certPEM, keyPEM, _, err = createTempTLS(ci.cfg.RSAKeySize, dur)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -97,6 +97,23 @@ func TestCertServer(t *testing.T) {
 			},
 			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
 				require.NotNil(t, c)
+				require.Equal(t, tls.RequireAnyClientCert, c.ClientAuth)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				Cert:   certPath,
+				Key:    keyPath,
+				CA:     caPath,
+				SkipCA: true,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Equal(t, tls.VerifyClientCertIfGiven, c.ClientAuth)
 				require.NotNil(t, ci.ca.Load())
 				require.NotNil(t, ci.cert.Load())
 			},
@@ -110,6 +127,7 @@ func TestCertServer(t *testing.T) {
 			},
 			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
 				require.NotNil(t, c)
+				require.Equal(t, tls.RequireAnyClientCert, c.ClientAuth)
 				require.NotNil(t, ci.ca.Load())
 				require.NotNil(t, ci.cert.Load())
 			},

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -32,7 +32,7 @@ func TestCertServer(t *testing.T) {
 	keyPath := filepath.Join(tmpdir, "key")
 	caPath := filepath.Join(tmpdir, "ca")
 
-	require.NoError(t, createTLSCertificates(logger, certPath, keyPath, caPath, 0, time.Hour))
+	require.NoError(t, CreateTLSCertificates(logger, certPath, keyPath, caPath, 0, time.Hour))
 
 	type certCase struct {
 		config.TLSConfig

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -36,7 +36,7 @@ import (
 
 const DefaultCertExpiration = 10 * 365 * 24 * time.Hour
 
-func createTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
+func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
 	logger = logger.With(zap.String("cert", certpath), zap.String("key", keypath), zap.String("ca", capath), zap.Int("rsaKeySize", rsaKeySize))
 
 	_, e1 := os.Stat(certpath)
@@ -66,7 +66,7 @@ func createTLSCertificates(logger *zap.Logger, certpath, keypath, capath string,
 		}
 	}
 
-	certPEM, keyPEM, caPEM, err := CreateTempTLS(rsaKeySize, expiration)
+	certPEM, keyPEM, caPEM, err := createTempTLS(rsaKeySize, expiration)
 	if err != nil {
 		return err
 	}
@@ -87,19 +87,7 @@ func createTLSCertificates(logger *zap.Logger, certpath, keypath, capath string,
 	return nil
 }
 
-func AutoTLS(logger *zap.Logger, scfg *config.TLSConfig, autoca bool, workdir, mod string, keySize int) error {
-	scfg.Cert = filepath.Join(workdir, mod, "cert.pem")
-	scfg.Key = filepath.Join(workdir, mod, "key.pem")
-	if autoca {
-		scfg.CA = filepath.Join(workdir, mod, "ca.pem")
-	}
-	if err := createTLSCertificates(logger, scfg.Cert, scfg.Key, scfg.CA, keySize, DefaultCertExpiration); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
-func CreateTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []byte, error) {
+func createTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []byte, error) {
 	if rsaKeySize < 1024 {
 		rsaKeySize = 1024
 	}
@@ -194,7 +182,7 @@ func CreateTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []
 
 // CreateTLSConfigForTest is from https://gist.github.com/shaneutt/5e1995295cff6721c89a71d13a71c251.
 func CreateTLSConfigForTest() (serverTLSConf *tls.Config, clientTLSConf *tls.Config, err error) {
-	certPEM, keyPEM, caPEM, uerr := CreateTempTLS(0, DefaultCertExpiration)
+	certPEM, keyPEM, caPEM, uerr := createTempTLS(0, DefaultCertExpiration)
 	if uerr != nil {
 		err = uerr
 		return

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -22,7 +22,7 @@ import (
 
 func BenchmarkCreateTLS(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := CreateTempTLS(0, DefaultCertExpiration)
+		_, _, _, err := createTempTLS(0, DefaultCertExpiration)
 		require.Nil(b, err)
 	}
 }

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	defaultRetryInterval    = 1 * time.Hour
-	defaultAutoCertInterval = 30 * 24 * time.Hour
+	defaultRetryInterval = 1 * time.Hour
 )
 
 // CertManager reloads certs and offers interfaces for fetching TLS configs.
@@ -45,18 +44,16 @@ type CertManager struct {
 	sqlTLS           *security.CertInfo // proxy -> tidb sql port
 	sqlTLSConfig     *tls.Config
 
-	cancel           context.CancelFunc
-	wg               waitgroup.WaitGroup
-	retryInterval    atomic.Int64
-	autoCertInterval atomic.Int64
-	logger           *zap.Logger
+	cancel        context.CancelFunc
+	wg            waitgroup.WaitGroup
+	retryInterval atomic.Int64
+	logger        *zap.Logger
 }
 
 // NewCertManager creates a new CertManager.
 func NewCertManager() *CertManager {
 	cm := &CertManager{}
 	cm.SetRetryInterval(defaultRetryInterval)
-	cm.SetAutoCertInterval(defaultAutoCertInterval)
 	return cm
 }
 
@@ -88,10 +85,6 @@ func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger) error {
 
 func (cm *CertManager) SetRetryInterval(interval time.Duration) {
 	cm.retryInterval.Store(int64(interval))
-}
-
-func (cm *CertManager) SetAutoCertInterval(interval time.Duration) {
-	cm.autoCertInterval.Store(int64(interval))
 }
 
 func (cm *CertManager) ServerTLS() *tls.Config {

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -19,13 +19,12 @@
 package cert
 
 import (
-	"bytes"
 	"crypto/tls"
-	"encoding/hex"
-	"encoding/pem"
 	"fmt"
+	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -36,171 +35,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test that the certs are automatically created and reloaded.
-func TestReloadCerts(t *testing.T) {
-	dir := t.TempDir()
-	lg := logger.CreateLoggerForTest(t)
-	sqlCfg := &config.TLSConfig{AutoCerts: true}
-	err := security.AutoTLS(lg, sqlCfg, true, dir, "sql", 0)
+func createFile(t *testing.T, src string) {
+	require.NoError(t, os.MkdirAll(filepath.Dir(src), 0755))
+	f, err := os.Create(src)
 	require.NoError(t, err)
-	clusterCfg := &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 0)
-	require.NoError(t, err)
-
-	cfg := &config.Config{
-		Workdir: dir,
-		Security: config.Security{
-			ServerTLS: config.TLSConfig{
-				AutoCerts: true,
-			},
-			PeerTLS: config.TLSConfig{
-				AutoCerts: true,
-			},
-			SQLTLS:     *sqlCfg,
-			ClusterTLS: *clusterCfg,
-		},
-	}
-	certMgr := NewCertManager()
-	certMgr.SetRetryInterval(100 * time.Millisecond)
-	certMgr.SetAutoCertInterval(50 * time.Millisecond)
-	err = certMgr.Init(cfg, lg)
-	require.NoError(t, err)
-	t.Cleanup(certMgr.Close)
-
-	areCertsDifferent := func(before, after [4][][]byte) bool {
-		for i := 0; i < 4; i++ {
-			if len(before[i]) != len(after[i]) {
-				continue
-			}
-			if before[i] == nil || after[i] == nil {
-				continue
-			}
-			different := false
-			for j := 0; j < len(before[i]); j++ {
-				if !bytes.Equal(before[i][j], after[i][j]) {
-					different = true
-					break
-				}
-			}
-			if !different {
-				return false
-			}
-		}
-		return true
-	}
-
-	var before = getAllCertificates(t, certMgr)
-	sqlCfg = &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, sqlCfg, true, dir, "sql", 0)
-	require.NoError(t, err)
-	clusterCfg = &config.TLSConfig{AutoCerts: true}
-	err = security.AutoTLS(lg, clusterCfg, true, dir, "cluster", 0)
-	require.NoError(t, err)
-
-	timer := time.NewTimer(10 * time.Second)
-	for {
-		select {
-		case <-timer.C:
-			t.Fatal("timeout")
-		case <-time.After(100 * time.Millisecond):
-			var after = getAllCertificates(t, certMgr)
-			if areCertsDifferent(before, after) {
-				return
-			}
-		}
-	}
+	require.NoError(t, f.Close())
 }
 
-func getRawCertificate(t *testing.T, tlsConfig *tls.Config) [][]byte {
-	if tlsConfig == nil {
-		return nil
-	}
-	cert, err := tlsConfig.GetCertificate(nil)
+func copyFile(t *testing.T, src, dst string) {
+	f1, err := os.Open(src)
 	require.NoError(t, err)
-	if cert != nil {
-		return cert.Certificate
-	}
-	return nil
+	f2, err := os.Create(dst)
+	require.NoError(t, err)
+	_, err = io.Copy(f2, f1)
+	require.NoError(t, err)
+	require.NoError(t, f1.Close())
+	require.NoError(t, f2.Close())
 }
 
-func getAllCertificates(t *testing.T, certMgr *CertManager) [4][][]byte {
-	return [4][][]byte{
-		getRawCertificate(t, certMgr.ServerTLS()),
-		getRawCertificate(t, certMgr.PeerTLS()),
-		getRawCertificate(t, certMgr.SQLTLS()),
-		getRawCertificate(t, certMgr.ClusterTLS()),
-	}
-}
-
-// Test that configuring no certs still works.
-func TestReloadEmptyCerts(t *testing.T) {
-	lg := logger.CreateLoggerForTest(t)
-	cfg := &config.Config{}
-	certMgr := NewCertManager()
-	certMgr.SetRetryInterval(100 * time.Millisecond)
-	err := certMgr.Init(cfg, lg)
-	require.NoError(t, err)
-	t.Cleanup(certMgr.Close)
-
-	require.Nil(t, certMgr.ServerTLS())
-	require.Nil(t, certMgr.ClusterTLS())
-	require.Nil(t, certMgr.PeerTLS())
-	require.Nil(t, certMgr.SQLTLS())
-}
-
-// Test that rotating CA works.
-func TestRotateCACert(t *testing.T) {
-	dir := t.TempDir()
-	lg := logger.CreateLoggerForTest(t)
-	sqlCfg := &config.TLSConfig{AutoCerts: true, SkipCA: true}
-	err := security.AutoTLS(lg, sqlCfg, true, dir, "sql", 0)
-	require.NoError(t, err)
-	serverCfg := &config.TLSConfig{AutoCerts: true, SkipCA: true}
-	err = security.AutoTLS(lg, serverCfg, true, dir, "server", 0)
-	require.NoError(t, err)
-
-	cfg := &config.Config{
-		Workdir: dir,
-		Security: config.Security{
-			ServerTLS: *serverCfg,
-			SQLTLS:    *sqlCfg,
-		},
-	}
-	certMgr := NewCertManager()
-	certMgr.SetRetryInterval(100 * time.Millisecond)
-	err = certMgr.Init(cfg, lg)
-	require.NoError(t, err)
-	t.Cleanup(certMgr.Close)
-
-	// Connecting with fake CA should not work.
-	stls := certMgr.ServerTLS()
-	ctls := certMgr.SQLTLS()
-	clientErr, serverErr := connectWithTLS(ctls, stls, "")
-	require.ErrorContains(t, clientErr, "certificate signed by unknown authority", fmt.Sprintf("%t, %t, %+v", certMgr.SQLTLS().InsecureSkipVerify, certMgr.serverTLSConfig.InsecureSkipVerify, clientErr))
-	require.Error(t, serverErr)
-
-	// Overwrite the cert files with right CA and it works with the same tls.Config.
-	overrideCerts(t, sqlCfg)
-	overrideCerts(t, serverCfg)
-	timer := time.NewTimer(3 * time.Second)
-	for {
-		select {
-		case <-timer.C:
-			t.Fatal("timeout")
-		case <-time.After(100 * time.Millisecond):
-			clientErr, serverErr := connectWithTLS(ctls, stls, "example.golang")
-			if clientErr == nil && serverErr == nil {
-				return
-			}
-		}
-	}
-}
-
-func connectWithTLS(ctls, stls *tls.Config, serverName string) (clientErr, serverErr error) {
+func connectWithTLS(ctls, stls *tls.Config) (clientErr, serverErr error) {
 	client, server := net.Pipe()
 	var wg waitgroup.WaitGroup
 	wg.Run(func() {
-		ctls.ServerName = serverName
 		tlsConn := tls.Client(client, ctls)
 		clientErr = tlsConn.Handshake()
 		_ = client.Close()
@@ -214,37 +70,273 @@ func connectWithTLS(ctls, stls *tls.Config, serverName string) (clientErr, serve
 	return
 }
 
-func fromHex(s string) []byte {
-	b, _ := hex.DecodeString(s)
-	return b
+// Test various configurations.
+func TestInit(t *testing.T) {
+	lg := logger.CreateLoggerForTest(t)
+	tmpdir := t.TempDir()
+
+	type testcase struct {
+		name  string
+		cfg   config.Config
+		check func(*testing.T, *CertManager)
+		err   string
+	}
+	// should not care much about the internal of *tls.Config,
+	// which should be well-tested in pkg/lib/util/security/.
+	cases := []testcase{
+		{
+			name: "empty",
+			check: func(t *testing.T, cm *CertManager) {
+				require.Nil(t, cm.ServerTLS())
+				require.Nil(t, cm.ClusterTLS())
+				require.Nil(t, cm.PeerTLS())
+				require.Nil(t, cm.SQLTLS())
+			},
+		},
+		{
+			name: "server config",
+			cfg: config.Config{
+				Security: config.Security{
+					ServerTLS: config.TLSConfig{AutoCerts: true},
+				},
+			},
+			check: func(t *testing.T, cm *CertManager) {
+				require.Nil(t, cm.ClusterTLS())
+				require.Nil(t, cm.PeerTLS())
+				require.Nil(t, cm.SQLTLS())
+				require.NotNil(t, cm.ServerTLS())
+			},
+		},
+		{
+			name: "client config",
+			cfg: config.Config{
+				Security: config.Security{
+					SQLTLS: config.TLSConfig{SkipCA: true},
+				},
+			},
+			check: func(t *testing.T, cm *CertManager) {
+				require.Nil(t, cm.ClusterTLS())
+				require.Nil(t, cm.PeerTLS())
+				require.Nil(t, cm.ServerTLS())
+				require.NotNil(t, cm.SQLTLS())
+			},
+		},
+		{
+			name: "invalid config",
+			cfg: config.Config{
+				Security: config.Security{
+					SQLTLS: config.TLSConfig{CA: filepath.Join(tmpdir, "ca")},
+				},
+			},
+			err: "no such file or directory",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Logf("testcase[%d] start: %+v\n", i, tc)
+
+		certMgr := NewCertManager()
+		certMgr.SetRetryInterval(100 * time.Millisecond)
+		err := certMgr.Init(&tc.cfg, lg)
+		if tc.err != "" {
+			require.ErrorContains(t, err, tc.err, fmt.Sprintf("%+v", tc))
+		} else {
+			require.NoError(t, err)
+		}
+		if tc.check != nil {
+			tc.check(t, certMgr)
+		}
+		certMgr.Close()
+	}
 }
 
-func overrideCerts(t *testing.T, cfg *config.TLSConfig) {
-	certPEM, keyPEM, caPEM := getPEMBytes()
-	err := os.WriteFile(cfg.Cert, certPEM, 0600)
-	require.NoError(t, err)
-	err = os.WriteFile(cfg.Key, keyPEM, 0600)
-	require.NoError(t, err)
-	err = os.WriteFile(cfg.CA, caPEM, 0600)
-	require.NoError(t, err)
-}
+// Test rotation works.
+func TestRotate(t *testing.T) {
+	tmpdir := t.TempDir()
+	lg := logger.CreateLoggerForTest(t)
+	caPath := filepath.Join(tmpdir, "ca")
+	keyPath := filepath.Join(tmpdir, "key")
+	certPath := filepath.Join(tmpdir, "cert")
+	caPath1 := filepath.Join(tmpdir, "c1", "ca")
+	keyPath1 := filepath.Join(tmpdir, "c1", "key")
+	certPath1 := filepath.Join(tmpdir, "c1", "cert")
+	caPath2 := filepath.Join(tmpdir, "c2", "ca")
+	keyPath2 := filepath.Join(tmpdir, "c2", "key")
+	certPath2 := filepath.Join(tmpdir, "c2", "cert")
 
-func getPEMBytes() ([]byte, []byte, []byte) {
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: testRSACertificate,
-	})
-	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: testRSAPrivateKey,
-	})
-	caPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: testRSACertificateIssuer,
-	})
-	return certPEM, keyPEM, caPEM
-}
+	createFile(t, caPath)
+	createFile(t, keyPath)
+	createFile(t, certPath)
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration))
 
-var testRSACertificate = fromHex("3082024b308201b4a003020102020900e8f09d3fe25beaa6300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301a310b3009060355040a1302476f310b300906035504031302476f30819f300d06092a864886f70d010101050003818d0030818902818100db467d932e12270648bc062821ab7ec4b6a25dfe1e5245887a3647a5080d92425bc281c0be97799840fb4f6d14fd2b138bc2a52e67d8d4099ed62238b74a0b74732bc234f1d193e596d9747bf3589f6c613cc0b041d4d92b2b2423775b1c3bbd755dce2054cfa163871d1e24c4f31d1a508baab61443ed97a77562f414c852d70203010001a38193308190300e0603551d0f0101ff0404030205a0301d0603551d250416301406082b0601050507030106082b06010505070302300c0603551d130101ff0402300030190603551d0e041204109f91161f43433e49a6de6db680d79f60301b0603551d230414301280104813494d137e1631bba301d5acab6e7b30190603551d1104123010820e6578616d706c652e676f6c616e67300d06092a864886f70d01010b0500038181009d30cc402b5b50a061cbbae55358e1ed8328a9581aa938a495a1ac315a1a84663d43d32dd90bf297dfd320643892243a00bccf9c7db74020015faad3166109a276fd13c3cce10c5ceeb18782f16c04ed73bbb343778d0c1cf10fa1d8408361c94c722b9daedb4606064df4c1b33ec0d1bd42d4dbfe3d1360845c21d33be9fae7")
-var testRSACertificateIssuer = fromHex("3082021930820182a003020102020900ca5e4e811a965964300d06092a864886f70d01010b0500301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f74301e170d3136303130313030303030305a170d3235303130313030303030305a301f310b3009060355040a1302476f3110300e06035504031307476f20526f6f7430819f300d06092a864886f70d010101050003818d0030818902818100d667b378bb22f34143b6cd2008236abefaf2852adf3ab05e01329e2c14834f5105df3f3073f99dab5442d45ee5f8f57b0111c8cb682fbb719a86944eebfffef3406206d898b8c1b1887797c9c5006547bb8f00e694b7a063f10839f269f2c34fff7a1f4b21fbcd6bfdfb13ac792d1d11f277b5c5b48600992203059f2a8f8cc50203010001a35d305b300e0603551d0f0101ff040403020204301d0603551d250416301406082b0601050507030106082b06010505070302300f0603551d130101ff040530030101ff30190603551d0e041204104813494d137e1631bba301d5acab6e7b300d06092a864886f70d01010b050003818100c1154b4bab5266221f293766ae4138899bd4c5e36b13cee670ceeaa4cbdf4f6679017e2fe649765af545749fe4249418a56bd38a04b81e261f5ce86b8d5c65413156a50d12449554748c59a30c515bc36a59d38bddf51173e899820b282e40aa78c806526fd184fb6b4cf186ec728edffa585440d2b3225325f7ab580e87dd76")
-var testRSAPrivateKey = fromHex("3082025b02010002818100db467d932e12270648bc062821ab7ec4b6a25dfe1e5245887a3647a5080d92425bc281c0be97799840fb4f6d14fd2b138bc2a52e67d8d4099ed62238b74a0b74732bc234f1d193e596d9747bf3589f6c613cc0b041d4d92b2b2423775b1c3bbd755dce2054cfa163871d1e24c4f31d1a508baab61443ed97a77562f414c852d702030100010281800b07fbcf48b50f1388db34b016298b8217f2092a7c9a04f77db6775a3d1279b62ee9951f7e371e9de33f015aea80660760b3951dc589a9f925ed7de13e8f520e1ccbc7498ce78e7fab6d59582c2386cc07ed688212a576ff37833bd5943483b5554d15a0b9b4010ed9bf09f207e7e9805f649240ed6c1256ed75ab7cd56d9671024100fded810da442775f5923debae4ac758390a032a16598d62f059bb2e781a9c2f41bfa015c209f966513fe3bf5a58717cbdb385100de914f88d649b7d15309fa49024100dd10978c623463a1802c52f012cfa72ff5d901f25a2292446552c2568b1840e49a312e127217c2186615aae4fb6602a4f6ebf3f3d160f3b3ad04c592f65ae41f02400c69062ca781841a09de41ed7a6d9f54adc5d693a2c6847949d9e1358555c9ac6a8d9e71653ac77beb2d3abaf7bb1183aa14278956575dbebf525d0482fd72d90240560fe1900ba36dae3022115fd952f2399fb28e2975a1c3e3d0b679660bdcb356cc189d611cfdd6d87cd5aea45aa30a2082e8b51e94c2f3dd5d5c6036a8a615ed0240143993d80ece56f877cb80048335701eb0e608cc0c1ca8c2227b52edf8f1ac99c562f2541b5ce81f0515af1c5b4770dba53383964b4b725ff46fdec3d08907df")
+	cfg := &config.Config{
+		Workdir: tmpdir,
+		Security: config.Security{
+			ServerTLS: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+			},
+			SQLTLS: config.TLSConfig{
+				CA: caPath,
+			},
+		},
+	}
+	type testcase struct {
+		name      string
+		pre       func(*testing.T)
+		preErrCli string
+		preErrSrv string
+		reload    func(*testing.T)
+		relErrCli string
+		relErrSrv string
+	}
+
+	cases := []testcase{
+		{
+			name: "normal",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath2, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+		},
+		{
+			name: "rotate ca",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath1, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+			preErrCli: "certificate signed by unknown authority",
+			preErrSrv: "bad certificate",
+			reload: func(t *testing.T) {
+				copyFile(t, caPath2, caPath)
+			},
+		},
+		{
+			name: "rotate certs",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath1, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+			preErrCli: "certificate signed by unknown authority",
+			preErrSrv: "bad certificate",
+			reload: func(t *testing.T) {
+				copyFile(t, keyPath1, keyPath)
+				copyFile(t, certPath1, certPath)
+			},
+		},
+		{
+			name: "rotate key only",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath1, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+			preErrCli: "certificate signed by unknown authority",
+			preErrSrv: "bad certificate",
+			reload: func(t *testing.T) {
+				copyFile(t, keyPath1, keyPath)
+			},
+			relErrCli: "certificate signed by unknown authority",
+			relErrSrv: "bad certificate",
+		},
+		{
+			name: "rotate cert only",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath1, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+			preErrCli: "certificate signed by unknown authority",
+			preErrSrv: "bad certificate",
+			reload: func(t *testing.T) {
+				copyFile(t, certPath1, certPath)
+			},
+			relErrCli: "certificate signed by unknown authority",
+			relErrSrv: "bad certificate",
+		},
+		{
+			name: "rotate all",
+			pre: func(t *testing.T) {
+				copyFile(t, caPath2, caPath)
+				copyFile(t, keyPath2, keyPath)
+				copyFile(t, certPath2, certPath)
+			},
+			reload: func(t *testing.T) {
+				copyFile(t, caPath1, caPath)
+				copyFile(t, keyPath1, keyPath)
+				copyFile(t, certPath1, certPath)
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Logf("testcase[%d] start: %+v\n", i, tc)
+
+		certMgr := NewCertManager()
+		certMgr.SetRetryInterval(100 * time.Millisecond)
+
+		if tc.pre != nil {
+			tc.pre(t)
+		}
+		require.NoError(t, certMgr.Init(cfg, lg))
+
+		stls := certMgr.ServerTLS()
+		ctls := certMgr.SQLTLS()
+
+		// pre reloading test
+		clientErr, serverErr := connectWithTLS(ctls, stls)
+		errmsg := fmt.Sprintf("client: %+v\nserver: %+v\n", clientErr, serverErr)
+		if tc.preErrCli != "" {
+			require.ErrorContains(t, clientErr, tc.preErrCli, errmsg)
+			require.Error(t, serverErr)
+		}
+		if tc.preErrSrv != "" {
+			require.ErrorContains(t, serverErr, tc.preErrSrv, errmsg)
+			require.Error(t, clientErr)
+		}
+		if tc.preErrCli == "" && tc.preErrSrv == "" {
+			require.NoError(t, clientErr)
+			require.NoError(t, serverErr)
+			t.Logf("clientErr: %+v, serverErr: %+v\n", clientErr, serverErr)
+		}
+
+		// reloading test
+		if tc.reload != nil {
+			tc.reload(t)
+		}
+
+		timer := time.NewTimer(time.Second)
+	outer:
+		for {
+			select {
+			case <-timer.C:
+				t.Fatal("timeout on reloading")
+			case <-time.After(150 * time.Millisecond):
+				clientErr, serverErr := connectWithTLS(ctls, stls)
+				errmsg := fmt.Sprintf("client: %+v\nserver: %+v\n", clientErr, serverErr)
+				if tc.relErrCli != "" {
+					require.ErrorContains(t, clientErr, tc.relErrCli, errmsg)
+					require.Error(t, serverErr)
+					break outer
+				}
+				if tc.relErrSrv != "" {
+					require.ErrorContains(t, serverErr, tc.relErrSrv, errmsg)
+					require.Error(t, clientErr)
+					break outer
+				}
+				if tc.relErrCli == "" && tc.relErrSrv == "" {
+					if clientErr == nil && serverErr == nil {
+						break outer
+					}
+					t.Logf("clientErr: %+v, serverErr: %+v\n", clientErr, serverErr)
+				}
+			}
+		}
+
+		certMgr.Close()
+	}
+}


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #136 

Problem Summary: Serverless tier will provide CA now, which results into rejections to all clients without providing certs. This can be solved by not-specifying CA, or the new semantic of `TLSConfig`:

For a server TLS config, if ca is specified and `skip-ca==true`, server will not **require clients to provide certs**, but **recommend/request clients to provide certs if any**.

### What is changed:

1. new semantic for server TLS
2. make `createTempTLS` private, expose `CreateTLSCertificates` to remove `AutoTLS`
3. remove `autoCertInterval`, which is replaced by refactored `certInfo.expire`
4. refactored cert manager tests to be simpler and cover more about rotation(improve coverage by 0.3%). Rotation(CA and certs) are covered by `TestRotate`. And `TestInit` covered some configuration tests. Internal details of certs should be covered by `pkg/lib/util/security/cert_test.go`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
