### PR TITLE
lib/config: reasonable default config values

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -32,7 +32,7 @@ func main() {
 		Short: "start the proxy server",
 	}
 
-	configFile := rootCmd.PersistentFlags().String("config", "conf/proxy.toml", "proxy config file path")
+	configFile := rootCmd.PersistentFlags().String("config", "", "proxy config file path")
 	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "", "log level")
 	_ = rootCmd.PersistentFlags().String("cluster_name", "tiproxy", "default cluster name, used to generate node name and differential clusters in dns discovery")
@@ -43,9 +43,14 @@ func main() {
 	_ = rootCmd.PersistentFlags().String("bootstrap_discovery_dns", "", "dns srv discovery")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		proxyConfigData, err := os.ReadFile(*configFile)
-		if err != nil {
-			return err
+		var proxyConfigData []byte
+
+		if *configFile != "" {
+			var err error
+			proxyConfigData, err = os.ReadFile(*configFile)
+			if err != nil {
+				return err
+			}
 		}
 
 		cfg, err := config.NewConfig(proxyConfigData)

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -1,40 +1,66 @@
-workdir = "./work"
+# workdir = "./work"
 
 [proxy]
-addr = "0.0.0.0:6000"
-tcp-keep-alive = true
-max-connections = 1000
-pd-addrs = "127.0.0.1:2379"
+# addr = "0.0.0.0:6000"
+# tcp-keep-alive = true
 # require-backend-tls = true
-# proxy-protocol = "v2"
-# graceful-wait-before-shutdown = 10
 
-[metrics]
+# possible values:
+#   "" => disable proxy protocol.
+#   "v2" => accept proxy protocol if any, require backends to support proxy protocol.
+# proxy-protocol = ""
+
+# possible values:
+# 	0 => disable graceful shutdown.
+# 	30 => graceful shutdown waiting time in 30 seconds.
+# graceful-wait-before-shutdown = 0
+
+# possible values:
+#		"" => enable static routing.
+#		"pd-addr:pd-port" => automatically tidb discovery.
+# pd-addrs = "127.0.0.1:2379"
+
+# possible values:
+#		0 => no limitation.
+#		100 => accept as many as 100 connections.
+# max-connections = 0
 
 [api]
-addr = "0.0.0.0:3080"
-enable-basic-auth = false
-user = ""
-password = ""
+# addr = "0.0.0.0:3080"
+
+# enable HTTP basic auth or not.
+#
+# enable-basic-auth = false
+# user = ""
+# password = ""
 
 [log]
-level = "info"
-encoder = "tidb"
+
+# level = "info"
+
+# possible values:
+# 	"tidb" => formats used by tidb, check https://github.com/tikv/rfcs/blob/master/text/0018-unified-log-format.md.
+# 	"json" => structured json formats.
+# 	"console" => log format for human.
+# encoder = "tidb"
 
 [log.log-file]
-filename = ""
-max-size = 300
-max-days = 1
-max-backups = 1
+# non-empty filename will enable logging to file.
+#
+# filename = ""
+# max-size = 300
+# max-days = 3
+# max-backups = 3
 
 [security]
-rsa-key-size = 4_096
 # tls object is either of type server, client, or peer
 # [xxxx]
 #   ca = "ca.pem"
 #   cert = "c.pem"
 #   key = "k.pem"
-#   auto-certs = true
+#   auto-certs = true # mostly used by tests. It will generate certs if no cert/key is specified.
+# 	rsa-key-size = 4096 # generated RSA keysize if auto-certs is enabled.
+# 	autocert-expire-duration = "72h" # default expire duration for auto certs.
 #   skip-ca = trure
 # client object:
 #   1. requires: ca or skip-ca(skip verify server certs)
@@ -67,7 +93,12 @@ rsa-key-size = 4_096
 	# internal communication between proxies
 	# auto-certs: true
 
+[metrics]
+
+# WARNING: know what you are doing, these two are for debugging.
+# metrics-addr = ""
+# metrics-interval = 0
+
 [advance]
+
 # ignore-wrong-namespace = true
-# peer-port = "3081"
-# watch-interval = "10m"

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -113,12 +113,6 @@ type Security struct {
 func NewConfig(data []byte) (*Config, error) {
 	var cfg Config
 
-	d, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	cfg.Workdir = filepath.Clean(d)
-
 	cfg.Proxy.Addr = "0.0.0.0:6000"
 	cfg.Proxy.TCPKeepAlive = true
 	cfg.Proxy.RequireBackendTLS = true
@@ -147,6 +141,14 @@ func NewConfig(data []byte) (*Config, error) {
 }
 
 func (cfg *Config) Check() error {
+	if cfg.Workdir == "" {
+		d, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		cfg.Workdir = filepath.Clean(d)
+	}
+
 	switch cfg.Proxy.ProxyProtocol {
 	case "v2":
 	case "":

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -25,9 +25,7 @@ import (
 var testProxyConfig = Config{
 	Workdir: "./wd",
 	Advance: Advance{
-		PeerPort:             "343",
 		IgnoreWrongNamespace: true,
-		WatchInterval:        "30m",
 	},
 	Proxy: ProxyServer{
 		Addr:              "0.0.0.0:4000",
@@ -63,7 +61,6 @@ var testProxyConfig = Config{
 		},
 	},
 	Security: Security{
-		RSAKeySize: 64,
 		ServerTLS: TLSConfig{
 			CA:        "a",
 			Cert:      "b",
@@ -83,10 +80,12 @@ var testProxyConfig = Config{
 			Key:    "c",
 		},
 		SQLTLS: TLSConfig{
-			CA:     "a",
-			SkipCA: true,
-			Cert:   "b",
-			Key:    "c",
+			CA:                 "a",
+			RSAKeySize:         0,
+			AutoExpireDuration: "1y",
+			SkipCA:             true,
+			Cert:               "b",
+			Key:                "c",
 		},
 	},
 }

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -34,7 +34,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const DefaultCertExpiration = 72 * time.Hour
+const DefaultCertExpiration = 24 * 90 * time.Hour
 
 func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
 	logger = logger.With(zap.String("cert", certpath), zap.String("key", keypath), zap.String("ca", capath), zap.Int("rsaKeySize", rsaKeySize))

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -34,7 +34,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const DefaultCertExpiration = 10 * 365 * 24 * time.Hour
+const DefaultCertExpiration = 72 * time.Hour
 
 func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
 	logger = logger.With(zap.String("cert", certpath), zap.String("key", keypath), zap.String("ca", capath), zap.Int("rsaKeySize", rsaKeySize))


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #161 

Problem Summary: Update default config values. This will enable to write less code in tidb-operator and dedicated tier.

What is changed:

1. default values for all config options.
2. tiproxy does not need a config file to start anymore.
3. Remove useless `rsa-key-size` in the security section.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
rm conf/proxy.toml
./bin/tiproxy
# this could start directly now
```
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
