### PR TITLE
router: refresh backends when the backends are empty

### DIFF
--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -90,6 +90,11 @@ func (router *ScoreBasedRouter) routeOnce(excluded []string) string {
 			return backend.addr
 		}
 	}
+	// No available backends, maybe the health check result is outdated during rolling restart.
+	// Refresh the backends asynchronously in this case.
+	if router.observer != nil {
+		router.observer.Refresh()
+	}
 	return ""
 }
 

--- a/pkg/proxy/backend/backend_conn.go
+++ b/pkg/proxy/backend/backend_conn.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	DialTimeout = 5 * time.Second
+	DialTimeout = 2 * time.Second
 )
 
 type BackendConnection struct {


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #168

Problem Summary:
When 2 TiDB instances are rolling restart, the TiProxy may think both of them are down at one moment. In this case, the TiProxy should refresh the backends immediately.

What is changed and how it works:
- Do the health check again when there is no backends to return
- Change the DialTimeout to 2 seconds

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
