### PR TITLE
router, backend: stop retrying connecting to backends if the fetcher fails

### DIFF
--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -32,9 +32,12 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
+var _ BackendFetcher = (*PDFetcher)(nil)
+var _ BackendFetcher = (*StaticFetcher)(nil)
+
 // BackendFetcher is an interface to fetch the backend list.
 type BackendFetcher interface {
-	GetBackendList(context.Context) map[string]*BackendInfo
+	GetBackendList(context.Context) (map[string]*BackendInfo, error)
 }
 
 // InitEtcdClient initializes an etcd client that fetches TiDB instance topology from PD.
@@ -99,10 +102,10 @@ func NewPDFetcher(client *clientv3.Client, logger *zap.Logger, config *HealthChe
 	}
 }
 
-func (pf *PDFetcher) GetBackendList(ctx context.Context) map[string]*BackendInfo {
+func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInfo, error) {
 	pf.fetchBackendList(ctx)
 	backendInfo := pf.filterTombstoneBackends()
-	return backendInfo
+	return backendInfo, nil
 }
 
 func (pf *PDFetcher) fetchBackendList(ctx context.Context) {
@@ -208,8 +211,8 @@ func NewStaticFetcher(staticAddrs []string) *StaticFetcher {
 	}
 }
 
-func (sf *StaticFetcher) GetBackendList(context.Context) map[string]*BackendInfo {
-	return sf.backends
+func (sf *StaticFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+	return sf.backends, nil
 }
 
 func backendListToMap(addrs []string) map[string]*BackendInfo {

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -185,6 +185,7 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 		backendInfo, err := bo.fetcher.GetBackendList(ctx)
 		if err == nil {
 			if lastErr != nil {
+				bo.logger.Info("fetching backends succeeds now")
 				bo.eventReceiver.OnObserveError(err)
 			}
 			backendStatus := bo.checkHealth(ctx, backendInfo)
@@ -192,8 +193,10 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 				return
 			}
 			bo.notifyIfChanged(backendStatus)
-		} else if lastErr == nil {
-			bo.logger.Warn("fetching backends encounters error", zap.Error(err))
+		} else {
+			if lastErr == nil {
+				bo.logger.Warn("fetching backends encounters error", zap.Error(err))
+			}
 			bo.eventReceiver.OnObserveError(err)
 		}
 		lastErr = err

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -101,9 +101,7 @@ func NewDefaultHealthCheckConfig() *HealthCheckConfig {
 // BackendEventReceiver receives the event of backend status change.
 type BackendEventReceiver interface {
 	// OnBackendChanged is called when the backend list changes.
-	OnBackendChanged(backends map[string]BackendStatus)
-	// OnObserveError is called when observing backends fails after success or succeeds after failure.
-	OnObserveError(err error)
+	OnBackendChanged(backends map[string]BackendStatus, err error)
 }
 
 // BackendInfo stores the status info of each backend.
@@ -180,26 +178,18 @@ func (bo *BackendObserver) Refresh() {
 }
 
 func (bo *BackendObserver) observe(ctx context.Context) {
-	var lastErr error
 	for ctx.Err() == nil {
 		backendInfo, err := bo.fetcher.GetBackendList(ctx)
-		if err == nil {
-			if lastErr != nil {
-				bo.logger.Info("fetching backends succeeds now")
-				bo.eventReceiver.OnObserveError(err)
-			}
+		if err != nil {
+			bo.logger.Warn("fetching backends encounters error", zap.Error(err))
+			bo.eventReceiver.OnBackendChanged(nil, err)
+		} else {
 			backendStatus := bo.checkHealth(ctx, backendInfo)
 			if ctx.Err() != nil {
 				return
 			}
 			bo.notifyIfChanged(backendStatus)
-		} else {
-			if lastErr == nil {
-				bo.logger.Warn("fetching backends encounters error", zap.Error(err))
-			}
-			bo.eventReceiver.OnObserveError(err)
 		}
-		lastErr = err
 		select {
 		case <-time.After(bo.config.healthCheckInterval):
 		case <-bo.refreshChan:
@@ -301,9 +291,8 @@ func (bo *BackendObserver) notifyIfChanged(backendStatus map[string]BackendStatu
 			}
 		}
 	}
-	if len(updatedBackends) > 0 {
-		bo.eventReceiver.OnBackendChanged(updatedBackends)
-	}
+	// Notify it even when the updatedBackends is empty, in order to clear the last error.
+	bo.eventReceiver.OnBackendChanged(updatedBackends, nil)
 	bo.curBackendInfo = backendStatus
 }
 

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	"github.com/stretchr/testify/require"
@@ -33,15 +34,21 @@ import (
 
 type mockEventReceiver struct {
 	backendChan chan map[string]BackendStatus
+	errChan     chan error
 }
 
 func (mer *mockEventReceiver) OnBackendChanged(backends map[string]BackendStatus) {
 	mer.backendChan <- backends
 }
 
-func newMockEventReceiver(backendChan chan map[string]BackendStatus) *mockEventReceiver {
+func (mer *mockEventReceiver) OnObserveError(err error) {
+	mer.errChan <- err
+}
+
+func newMockEventReceiver(backendChan chan map[string]BackendStatus, errChan chan error) *mockEventReceiver {
 	return &mockEventReceiver{
 		backendChan: backendChan,
+		errChan:     errChan,
 	}
 }
 
@@ -94,7 +101,8 @@ func TestCancelObserver(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			backends = append(backends, addBackend(t, kv))
 		}
-		backendInfo := bo.fetcher.GetBackendList(context.Background())
+		backendInfo, err := bo.fetcher.GetBackendList(context.Background())
+		require.NoError(t, err)
 		require.Equal(t, 3, len(backendInfo))
 
 		// Try 10 times.
@@ -133,11 +141,12 @@ func TestEtcdUnavailable(t *testing.T) {
 // Test that the notified backend status is correct for external fetcher.
 func TestExternalFetcher(t *testing.T) {
 	backendAddrs := make([]string, 0)
+	var observeError error
 	var mutex sync.Mutex
-	backendGetter := func() []string {
+	backendGetter := func() ([]string, error) {
 		mutex.Lock()
 		defer mutex.Unlock()
-		return backendAddrs
+		return backendAddrs, observeError
 	}
 	addBackend := func() *backendServer {
 		backend := newBackendServer(t)
@@ -152,9 +161,15 @@ func TestExternalFetcher(t *testing.T) {
 		backendAddrs = append(backendAddrs[:idx], backendAddrs[idx+1:]...)
 		mutex.Unlock()
 	}
+	mockError := func() {
+		mutex.Lock()
+		observeError = errors.New("mock observe error")
+		mutex.Unlock()
+	}
 
 	backendChan := make(chan map[string]BackendStatus, 1)
-	mer := newMockEventReceiver(backendChan)
+	errChan := make(chan error, 1)
+	mer := newMockEventReceiver(backendChan, errChan)
 	fetcher := NewExternalFetcher(backendGetter)
 	bo, err := NewBackendObserver(logger.CreateLoggerForTest(t), mer, nil, newHealthCheckConfigForTest(), fetcher)
 	require.NoError(t, err)
@@ -175,6 +190,12 @@ func TestExternalFetcher(t *testing.T) {
 	backend2.close()
 	checkStatus(t, backendChan, backend2, StatusCannotConnect)
 	removeBackend(backend2)
+
+	// returns observe error
+	require.Len(t, errChan, 0)
+	mockError()
+	err = <-errChan
+	require.Error(t, err)
 }
 
 func runETCDTest(t *testing.T, f func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]BackendStatus)) {
@@ -182,7 +203,7 @@ func runETCDTest(t *testing.T, f func(etcd *embed.Etcd, kv clientv3.KV, bo *Back
 	client := createEtcdClient(t, etcd)
 	kv := clientv3.NewKV(client)
 	backendChan := make(chan map[string]BackendStatus, 1)
-	mer := newMockEventReceiver(backendChan)
+	mer := newMockEventReceiver(backendChan, make(chan error, 1))
 	fetcher := NewPDFetcher(client, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
 	bo, err := NewBackendObserver(logger.CreateLoggerForTest(t), mer, nil, newHealthCheckConfigForTest(), fetcher)
 	require.NoError(t, err)
@@ -293,16 +314,16 @@ func startListener(t *testing.T, addr string) (net.Listener, string) {
 
 // ExternalFetcher fetches backend list from a given callback.
 type ExternalFetcher struct {
-	backendGetter func() []string
+	backendGetter func() ([]string, error)
 }
 
-func NewExternalFetcher(backendGetter func() []string) *ExternalFetcher {
+func NewExternalFetcher(backendGetter func() ([]string, error)) *ExternalFetcher {
 	return &ExternalFetcher{
 		backendGetter: backendGetter,
 	}
 }
 
-func (ef *ExternalFetcher) GetBackendList(context.Context) map[string]*BackendInfo {
-	addrs := ef.backendGetter()
-	return backendListToMap(addrs)
+func (ef *ExternalFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+	addrs, err := ef.backendGetter()
+	return backendListToMap(addrs), err
 }

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -37,12 +37,12 @@ type mockEventReceiver struct {
 	errChan     chan error
 }
 
-func (mer *mockEventReceiver) OnBackendChanged(backends map[string]BackendStatus) {
-	mer.backendChan <- backends
-}
-
-func (mer *mockEventReceiver) OnObserveError(err error) {
-	mer.errChan <- err
+func (mer *mockEventReceiver) OnBackendChanged(backends map[string]BackendStatus, err error) {
+	if err != nil {
+		mer.errChan <- err
+	} else if len(backends) > 0 {
+		mer.backendChan <- backends
+	}
 }
 
 func newMockEventReceiver(backendChan chan map[string]BackendStatus, errChan chan error) *mockEventReceiver {

--- a/pkg/manager/router/backend_selector.go
+++ b/pkg/manager/router/backend_selector.go
@@ -17,7 +17,7 @@ package router
 type BackendSelector struct {
 	excluded  []string
 	cur       string
-	routeOnce func(excluded []string) string
+	routeOnce func(excluded []string) (string, error)
 	addConn   func(addr string, conn RedirectableConn) error
 }
 
@@ -25,12 +25,16 @@ func (bs *BackendSelector) Reset() {
 	bs.excluded = bs.excluded[:0]
 }
 
-func (bs *BackendSelector) Next() string {
-	bs.cur = bs.routeOnce(bs.excluded)
+func (bs *BackendSelector) Next() (string, error) {
+	addr, err := bs.routeOnce(bs.excluded)
+	if err != nil {
+		return addr, err
+	}
+	bs.cur = addr
 	if bs.cur != "" {
 		bs.excluded = append(bs.excluded, bs.cur)
 	}
-	return bs.cur
+	return bs.cur, nil
 }
 
 func (bs *BackendSelector) Succeed(conn RedirectableConn) error {

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -282,10 +282,10 @@ func (router *ScoreBasedRouter) OnConnClosed(addr string, conn RedirectableConn)
 }
 
 // OnBackendChanged implements BackendEventReceiver.OnBackendChanged interface.
-func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStatus) {
+func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStatus, err error) {
 	router.Lock()
 	defer router.Unlock()
-	router.observeError = nil
+	router.observeError = err
 	for addr, status := range backends {
 		be := router.lookupBackend(addr, true)
 		if be == nil && status != StatusCannotConnect {
@@ -307,13 +307,6 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStat
 			router.adjustBackendList(be)
 		}
 	}
-}
-
-// OnObserveError implements BackendEventReceiver.OnObserveError interface.
-func (router *ScoreBasedRouter) OnObserveError(err error) {
-	router.Lock()
-	router.observeError = err
-	router.Unlock()
 }
 
 func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -37,7 +37,8 @@ type ScoreBasedRouter struct {
 	cancelFunc context.CancelFunc
 	wg         waitgroup.WaitGroup
 	// A list of *backendWrapper. The backends are in descending order of scores.
-	backends *list.List
+	backends     *list.List
+	observeError error
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
@@ -69,9 +70,12 @@ func (router *ScoreBasedRouter) GetBackendSelector() BackendSelector {
 	}
 }
 
-func (router *ScoreBasedRouter) routeOnce(excluded []string) string {
+func (router *ScoreBasedRouter) routeOnce(excluded []string) (string, error) {
 	router.Lock()
 	defer router.Unlock()
+	if router.observeError != nil {
+		return "", router.observeError
+	}
 	for be := router.backends.Back(); be != nil; be = be.Prev() {
 		backend := be.Value.(*backendWrapper)
 		// These backends may be recycled, so we should not connect to them again.
@@ -87,7 +91,7 @@ func (router *ScoreBasedRouter) routeOnce(excluded []string) string {
 			}
 		}
 		if !found {
-			return backend.addr
+			return backend.addr, nil
 		}
 	}
 	// No available backends, maybe the health check result is outdated during rolling restart.
@@ -95,7 +99,7 @@ func (router *ScoreBasedRouter) routeOnce(excluded []string) string {
 	if router.observer != nil {
 		router.observer.Refresh()
 	}
-	return ""
+	return "", nil
 }
 
 func (router *ScoreBasedRouter) addNewConn(addr string, conn RedirectableConn) error {
@@ -281,6 +285,7 @@ func (router *ScoreBasedRouter) OnConnClosed(addr string, conn RedirectableConn)
 func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStatus) {
 	router.Lock()
 	defer router.Unlock()
+	router.observeError = nil
 	for addr, status := range backends {
 		be := router.lookupBackend(addr, true)
 		if be == nil && status != StatusCannotConnect {
@@ -302,6 +307,13 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]BackendStat
 			router.adjustBackendList(be)
 		}
 	}
+}
+
+// OnObserveError implements BackendEventReceiver.OnObserveError interface.
+func (router *ScoreBasedRouter) OnObserveError(err error) {
+	router.Lock()
+	router.observeError = err
+	router.Unlock()
 }
 
 func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -27,7 +27,7 @@ func NewStaticRouter(addr []string) *StaticRouter {
 
 func (r *StaticRouter) GetBackendSelector() BackendSelector {
 	return BackendSelector{
-		routeOnce: func(excluded []string) string {
+		routeOnce: func(excluded []string) (string, error) {
 			for _, addr := range r.addrs {
 				found := false
 				for _, e := range excluded {
@@ -37,10 +37,10 @@ func (r *StaticRouter) GetBackendSelector() BackendSelector {
 					}
 				}
 				if !found {
-					return addr
+					return addr, nil
 				}
 			}
-			return ""
+			return "", nil
 		},
 		addConn: func(addr string, conn RedirectableConn) error {
 			r.cnt++

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	"github.com/pingcap/TiProxy/pkg/metrics"
@@ -173,7 +174,8 @@ func (tester *routerTester) checkBackendOrder() {
 
 func (tester *routerTester) simpleRoute(conn RedirectableConn) string {
 	selector := tester.router.GetBackendSelector()
-	addr := selector.Next()
+	addr, err := selector.Next()
+	require.NoError(tester.t, err)
 	if len(addr) > 0 {
 		err := selector.Succeed(conn)
 		require.NoError(tester.t, err)
@@ -382,31 +384,37 @@ func TestSelectorReturnOrder(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		addrs := make(map[string]struct{}, 3)
 		for j := 0; j < 3; j++ {
-			addr := selector.Next()
+			addr, err := selector.Next()
+			require.NoError(t, err)
 			addrs[addr] = struct{}{}
 		}
 		// All 3 addresses are different.
 		require.Equal(t, 3, len(addrs))
-		addr := selector.Next()
+		addr, err := selector.Next()
+		require.NoError(t, err)
 		require.True(t, len(addr) == 0)
 		selector.Reset()
 	}
 
 	tester.killBackends(1)
 	for i := 0; i < 2; i++ {
-		addr := selector.Next()
+		addr, err := selector.Next()
+		require.NoError(t, err)
 		require.True(t, len(addr) > 0)
 	}
-	addr := selector.Next()
+	addr, err := selector.Next()
+	require.NoError(t, err)
 	require.True(t, len(addr) == 0)
 	selector.Reset()
 
 	tester.addBackends(1)
 	for i := 0; i < 3; i++ {
-		addr := selector.Next()
+		addr, err := selector.Next()
+		require.NoError(t, err)
 		require.True(t, len(addr) > 0)
 	}
-	addr = selector.Next()
+	addr, err = selector.Next()
+	require.NoError(t, err)
 	require.True(t, len(addr) == 0)
 }
 
@@ -625,7 +633,8 @@ func TestConcurrency(t *testing.T) {
 							connID: connID,
 						}
 						selector := router.GetBackendSelector()
-						addr := selector.Next()
+						addr, err := selector.Next()
+						require.NoError(t, err)
 						if len(addr) == 0 {
 							conn = nil
 							continue
@@ -673,10 +682,10 @@ func TestConcurrency(t *testing.T) {
 func TestRefresh(t *testing.T) {
 	backends := make([]string, 0)
 	var m sync.Mutex
-	fetcher := NewExternalFetcher(func() []string {
+	fetcher := NewExternalFetcher(func() ([]string, error) {
 		m.Lock()
 		defer m.Unlock()
-		return backends
+		return backends, nil
 	})
 	// Create a router with a very long health check interval.
 	lg := logger.CreateLoggerForTest(t)
@@ -694,7 +703,8 @@ func TestRefresh(t *testing.T) {
 	defer rt.Close()
 	// The initial backends are empty.
 	selector := rt.GetBackendSelector()
-	addr := selector.Next()
+	addr, err := selector.Next()
+	require.NoError(t, err)
 	require.True(t, len(addr) == 0)
 	// Create a new backend and add to the list.
 	server := newBackendServer(t)
@@ -703,15 +713,81 @@ func TestRefresh(t *testing.T) {
 	m.Unlock()
 	defer server.close()
 	// The backends are refreshed very soon.
-	timer := time.NewTimer(3 * time.Second)
+	finally(t, func() bool {
+		addr, err = selector.Next()
+		require.NoError(t, err)
+		return len(addr) > 0
+	}, 100*time.Millisecond, 3*time.Second)
+}
+
+func TestObserveError(t *testing.T) {
+	backends := make([]string, 0)
+	var observeError error
+	var m sync.Mutex
+	fetcher := NewExternalFetcher(func() ([]string, error) {
+		m.Lock()
+		defer m.Unlock()
+		return backends, observeError
+	})
+	// Create a router with a very short health check interval.
+	lg := logger.CreateLoggerForTest(t)
+	rt := &ScoreBasedRouter{
+		logger:   lg,
+		backends: list.New(),
+	}
+	observer, err := StartBackendObserver(lg, rt, nil, newHealthCheckConfigForTest(), fetcher)
+	require.NoError(t, err)
+	rt.Lock()
+	rt.observer = observer
+	rt.Unlock()
+	defer rt.Close()
+	// No backends and no error.
+	selector := rt.GetBackendSelector()
+	addr, err := selector.Next()
+	require.NoError(t, err)
+	require.True(t, len(addr) == 0)
+	// Create a new backend and add to the list.
+	server := newBackendServer(t)
+	m.Lock()
+	backends = append(backends, server.sqlAddr)
+	m.Unlock()
+	defer server.close()
+	// The backends are refreshed very soon.
+	finally(t, func() bool {
+		selector.Reset()
+		addr, err = selector.Next()
+		require.NoError(t, err)
+		return len(addr) > 0
+	}, 100*time.Millisecond, 3*time.Second)
+	// Mock an observe error.
+	m.Lock()
+	observeError = errors.New("mock observe error")
+	m.Unlock()
+	finally(t, func() bool {
+		selector.Reset()
+		addr, err = selector.Next()
+		return len(addr) == 0 && err != nil
+	}, 100*time.Millisecond, 3*time.Second)
+	// Clear the observe error.
+	m.Lock()
+	observeError = nil
+	m.Unlock()
+	finally(t, func() bool {
+		selector.Reset()
+		addr, err = selector.Next()
+		return len(addr) > 0 && err == nil
+	}, 100*time.Millisecond, 3*time.Second)
+}
+
+func finally(t *testing.T, checker func() bool, checkInterval, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	for {
 		select {
 		case <-timer.C:
 			t.Fatal("timeout")
-		case <-time.After(100 * time.Millisecond):
-			addr = selector.Next()
-			if len(addr) > 0 {
+		case <-time.After(checkInterval):
+			if checker() {
 				return
 			}
 		}

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -120,7 +120,7 @@ func (tester *routerTester) addBackends(num int) {
 		backends[addr] = StatusHealthy
 		metrics.BackendConnGauge.WithLabelValues(addr).Set(0)
 	}
-	tester.router.OnBackendChanged(backends)
+	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
 }
 
@@ -138,7 +138,7 @@ func (tester *routerTester) killBackends(num int) {
 		}
 		backends[backend.addr] = StatusCannotConnect
 	}
-	tester.router.OnBackendChanged(backends)
+	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
 }
 
@@ -146,7 +146,7 @@ func (tester *routerTester) updateBackendStatusByAddr(addr string, status Backen
 	backends := map[string]BackendStatus{
 		addr: status,
 	}
-	tester.router.OnBackendChanged(backends)
+	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
 }
 
@@ -589,7 +589,7 @@ func TestConcurrency(t *testing.T) {
 		"1": StatusHealthy,
 		"2": StatusHealthy,
 	}
-	router.OnBackendChanged(backends)
+	router.OnBackendChanged(backends, nil)
 	for addr, status := range backends {
 		func(addr string, status BackendStatus) {
 			wg.Run(func() {
@@ -607,7 +607,7 @@ func TestConcurrency(t *testing.T) {
 					}
 					router.OnBackendChanged(map[string]BackendStatus{
 						addr: status,
-					})
+					}, nil)
 				}
 			})
 		}(addr, status)


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #179

Problem Summary:
Currently, when the backend fetcher returns an empty backend list, the proxy keeps retrying for 5 seconds.
However, the serverless tier may encounter some problems that can't be recovered immediately. In this case, the fetcher can return an error, indicating that the proxy doesn't need to retry.

What is changed and how it works:
- Add a return value of `error` type for `BackendFetcher.GetBackendList()`
- Add the return value for `Observer`, `BackendEventReceiver`, `BackendSelector`, and so on
- Stop retrying connecting if the error is not nil

Note that https://github.com/pingcap/TiProxy/issues/180 will be fixed in another PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
