### PR TITLE
backend, net: close the client connection when the backend is down

### DIFF
--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -42,7 +42,10 @@ type ClientConnection struct {
 
 func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *tls.Config, backendTLSConfig *tls.Config,
 	hsHandler backend.HandshakeHandler, connID uint64, proxyProtocol, requireBackendTLS bool) *ClientConnection {
-	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, proxyProtocol, requireBackendTLS)
+	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, &backend.BCConfig{
+		ProxyProtocol:     proxyProtocol,
+		RequireBackendTLS: requireBackendTLS,
+	})
 	opts := make([]pnet.PacketIOption, 0, 2)
 	opts = append(opts, pnet.WithWrapError(ErrClientConn))
 	if proxyProtocol {

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -204,3 +204,65 @@ func TestPacketIOClose(t *testing.T) {
 		1,
 	)
 }
+
+func TestPeerActive(t *testing.T) {
+	stls, ctls, err := security.CreateTLSConfigForTest()
+	require.NoError(t, err)
+	ch := make(chan struct{})
+	testTCPConn(t,
+		func(t *testing.T, cli *PacketIO) {
+			// It's active at the beginning.
+			require.True(t, cli.IsPeerActive())
+			ch <- struct{}{} // let srv write packet
+			// ReadPacket still reads the whole data after checking.
+			ch <- struct{}{}
+			require.True(t, cli.IsPeerActive())
+			data, err := cli.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, "123", string(data))
+			// IsPeerActive works after reading data.
+			require.True(t, cli.IsPeerActive())
+			// IsPeerActive works after writing data.
+			require.NoError(t, cli.WritePacket([]byte("456"), true))
+			require.True(t, cli.IsPeerActive())
+			// upgrade to TLS and try again
+			println("begin cli tls")
+			require.NoError(t, cli.ClientTLSHandshake(ctls))
+			println("end cli tls")
+			require.True(t, cli.IsPeerActive())
+			data, err = cli.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, "123", string(data))
+			require.True(t, cli.IsPeerActive())
+			require.NoError(t, cli.WritePacket([]byte("456"), true))
+			require.True(t, cli.IsPeerActive())
+			// It's not active after the peer closes.
+			ch <- struct{}{}
+			ch <- struct{}{}
+			require.False(t, cli.IsPeerActive())
+		},
+		func(t *testing.T, srv *PacketIO) {
+			<-ch
+			err := srv.WritePacket([]byte("123"), true)
+			require.NoError(t, err)
+			<-ch
+			data, err := srv.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, "456", string(data))
+			// upgrade to TLS and try again
+			println("begin srv tls")
+			_, err = srv.ServerTLSHandshake(stls)
+			println("end srv tls")
+			require.NoError(t, err)
+			err = srv.WritePacket([]byte("123"), true)
+			require.NoError(t, err)
+			data, err = srv.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, "456", string(data))
+			<-ch
+			require.NoError(t, srv.Close())
+			<-ch
+		},
+		10,
+	)
+}

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -226,9 +226,7 @@ func TestPeerActive(t *testing.T) {
 			require.NoError(t, cli.WritePacket([]byte("456"), true))
 			require.True(t, cli.IsPeerActive())
 			// upgrade to TLS and try again
-			println("begin cli tls")
 			require.NoError(t, cli.ClientTLSHandshake(ctls))
-			println("end cli tls")
 			require.True(t, cli.IsPeerActive())
 			data, err = cli.ReadPacket()
 			require.NoError(t, err)
@@ -250,9 +248,7 @@ func TestPeerActive(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "456", string(data))
 			// upgrade to TLS and try again
-			println("begin srv tls")
 			_, err = srv.ServerTLSHandshake(stls)
-			println("end srv tls")
 			require.NoError(t, err)
 			err = srv.WritePacket([]byte("123"), true)
 			require.NoError(t, err)

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -15,6 +15,7 @@
 package net
 
 import (
+	"bufio"
 	"crypto/tls"
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
@@ -28,6 +29,8 @@ func (p *PacketIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionStat
 	}
 	p.conn = tlsConn
 	p.buf.Writer.Reset(p.conn)
+	// Wrap it with another buffer to enable Peek.
+	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(p.conn, defaultReaderSize), p.buf.Writer)
 	return tlsConn.ConnectionState(), nil
 }
 
@@ -39,5 +42,7 @@ func (p *PacketIO) ClientTLSHandshake(tlsConfig *tls.Config) error {
 	}
 	p.conn = tlsConn
 	p.buf.Writer.Reset(p.conn)
+	// Wrap it with another buffer to enable Peek.
+	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(p.conn, defaultReaderSize), p.buf.Writer)
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #195

Problem Summary:
On the serverless tier, when the client is idle for 5 minutes, the backend will quit. But the TiProxy doesn't know the backend quits because it's still reading the client. Then, the serverless tier thinks the connection is still alive and then wakes up a new TiDB instance.

So, TiProxy should always detect the backend and disconnect the client when the backend quits.

What is changed and how it works:
- Add a ticker on `BackendConnMgr` to check the backend periodically in the background goroutine
- Wrap the `PacketIO.conn` with a buffer and add `PacketIO.IsPeerActive()`
- Update the parameters of `NewBackendConnMgr` to make them configurable in the tests
- Fix `checkConnClosed4Proxy`. It never worked before because `ts.mp.err` is not checked

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Start a MySQL client to connect to TiProxy
2. Kill the TiDB
3. The TiProxy shows that the client connection is closed within 1 minute

```
[2023/01/18 19:17:37.985 +08:00] [INFO] [main.nsmgr.router] [router/router_score.go:302] [update backend] [namespace=default] [addr=127.0.0.1:4000] [prev_status=healthy] [cur_status=down]
[2023/01/18 19:18:20.330 +08:00] [INFO] [main.proxy.conn.be] [backend/backend_conn_mgr.go:532] [backend connection is closed, close client connection] [connID=0] [remoteAddr=127.0.0.1:57965] [client=127.0.0.1:57965] [backend=127.0.0.1:4000]
[2023/01/18 19:18:20.331 +08:00] [INFO] [main.proxy] [proxy/proxy.go:166] [connection closed] [connID=0] [remoteAddr=127.0.0.1:57965]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
