### PR TITLE
backend: set tls state in conncontext

### DIFF
--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -22,6 +22,12 @@ import (
 )
 
 // Context keys.
+type ConnContextKey string
+
+const (
+	ConnContextKeyTLSState ConnContextKey = "tls-state"
+)
+
 var _ HandshakeHandler = (*DefaultHandshakeHandler)(nil)
 
 type ConnContext interface {

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -38,6 +38,7 @@ package net
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"io"
 	"net"
 	"time"
@@ -252,6 +253,13 @@ func (p *PacketIO) InBytes() uint64 {
 
 func (p *PacketIO) OutBytes() uint64 {
 	return p.outBytes
+}
+
+func (p *PacketIO) TLSConnectionState() tls.ConnectionState {
+	if tlsConn, ok := p.conn.(*tls.Conn); ok {
+		return tlsConn.ConnectionState()
+	}
+	return tls.ConnectionState{}
 }
 
 func (p *PacketIO) Flush() error {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
set tls state in conn context, so later we can use `show session status` to check tls state.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
