### PR TITLE
config, api: add API for getting the config checksum 

### DIFF
--- a/lib/config/health.go
+++ b/lib/config/health.go
@@ -15,5 +15,5 @@
 package config
 
 type HealthInfo struct {
-	ConfigVersion uint32 `json:"config_version"`
+	ConfigChecksum uint32 `json:"config_checksum"`
 }

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -163,3 +163,18 @@ func TestConfigRemove(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpcfg, []byte(`proxy.addr = "vv"`), 0644))
 	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "vv" }, time.Second, 100*time.Millisecond)
 }
+
+func TestChecksum(t *testing.T) {
+	cfgmgr, _ := testConfigManager(t, "")
+	c1 := cfgmgr.GetConfigChecksum()
+	require.NoError(t, cfgmgr.SetTOMLConfig([]byte(`proxy.addr = "gg"`)))
+	c2 := cfgmgr.GetConfigChecksum()
+	require.NoError(t, cfgmgr.SetTOMLConfig([]byte(`proxy.addr = "vv"`)))
+	c3 := cfgmgr.GetConfigChecksum()
+	require.NoError(t, cfgmgr.SetTOMLConfig([]byte(`proxy.addr="gg"`)))
+	c4 := cfgmgr.GetConfigChecksum()
+	require.Equal(t, c2, c4)
+	require.NotEqual(t, c1, c2)
+	require.NotEqual(t, c1, c3)
+	require.NotEqual(t, c2, c3)
+}

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -57,6 +57,7 @@ type ConfigManager struct {
 		listeners []chan<- *config.Config
 		current   *config.Config
 		version   uint32
+		checksum  uint32
 	}
 }
 

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -56,7 +56,6 @@ type ConfigManager struct {
 		sync.Mutex
 		listeners []chan<- *config.Config
 		current   *config.Config
-		version   uint32
 		checksum  uint32
 	}
 }

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -24,7 +24,7 @@ import (
 
 func (h *HTTPServer) DebugHealth(c *gin.Context) {
 	c.JSON(http.StatusOK, config.HealthInfo{
-		ConfigVersion: h.mgr.cfg.GetConfigVersion(),
+		ConfigChecksum: h.mgr.cfg.GetConfigChecksum(),
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #202

Problem Summary:
The operator or some other tools can fetch the checksum to know the version of the config.

What is changed and how it works:
Add the get checksum API for ConfigManager and HTTP.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
