### PR TITLE
backend: revert PR 201 because to make the test accurate

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -646,9 +646,8 @@ func TestGracefulCloseWhenActive(t *testing.T) {
 		{
 			proxy: func(_, _ *pnet.PacketIO) error {
 				ts.mp.GracefulClose()
-				require.Eventually(t, func() bool {
-					return statusNotifyClose == ts.mp.closeStatus.Load()
-				}, 300*time.Millisecond, 100*time.Millisecond)
+				time.Sleep(300 * time.Millisecond)
+				require.Equal(t, statusNotifyClose, ts.mp.closeStatus.Load())
 				return nil
 			},
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:
https://github.com/pingcap/TiProxy/pull/201 tried to make the test faster but there's a misunderstanding here:
I want to prove that the status of `closeStatus` is always `statusNotifyClose` and will never change to `statusClosing` or `statusClosed`, so I waited for 300ms.
If it's changed to `require.Eventually`, it will definitely return on the first try.

What is changed and how it works:
Revert the code.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
