### PR TITLE
config, router: add health check switch

### DIFF
--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -17,6 +17,7 @@ package config
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -36,6 +37,19 @@ type BackendNamespace struct {
 	Instances    []string  `yaml:"instances" json:"instances" toml:"instances"`
 	SelectorType string    `yaml:"selector-type" json:"selector-type" toml:"selector-type"`
 	Security     TLSConfig `yaml:"security" json:"security" toml:"security"`
+	//HealthCheck  HealthCheck `yaml:"health-check" json:"health-check" toml:"health-check"`
+}
+
+// HealthCheck contains some configurations for health check.
+// Some general configurations of them may be exposed to users in the future.
+// We can use shorter durations to speed up unit tests.
+type HealthCheck struct {
+	Enable             bool          `yaml:"enable" json:"enable" toml:"enable"`
+	Interval           time.Duration `yaml:"interval" json:"interval" toml:"interval"`
+	MaxRetries         int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
+	RetryInterval      time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
+	DialTimeout        time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
+	TombstoneThreshold time.Duration `yaml:"tombstone-threshold" json:"tombstone-threshold" toml:"tombstone-threshold"`
 }
 
 func NewNamespace(data []byte) (*Namespace, error) {

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -48,7 +48,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt, err := router.NewScoreBasedRouter(logger.Named("router"), mgr.httpCli, fetcher)
+	rt, err := router.NewScoreBasedRouter(logger.Named("router"), mgr.httpCli, fetcher, router.NewDefaultHealthCheckConfig())
 	if err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -90,10 +90,10 @@ type PDFetcher struct {
 	backendInfo map[string]*pdBackendInfo
 	client      *clientv3.Client
 	logger      *zap.Logger
-	config      *HealthCheckConfig
+	config      *config.HealthCheck
 }
 
-func NewPDFetcher(client *clientv3.Client, logger *zap.Logger, config *HealthCheckConfig) *PDFetcher {
+func NewPDFetcher(client *clientv3.Client, logger *zap.Logger, config *config.HealthCheck) *PDFetcher {
 	return &PDFetcher{
 		backendInfo: make(map[string]*pdBackendInfo),
 		client:      client,
@@ -121,7 +121,7 @@ func (pf *PDFetcher) fetchBackendList(ctx context.Context) {
 			break
 		}
 		pf.logger.Error("fetch backend list failed, will retry later", zap.Error(err))
-		time.Sleep(pf.config.healthCheckRetryInterval)
+		time.Sleep(pf.config.RetryInterval)
 	}
 
 	if ctx.Err() != nil {
@@ -189,7 +189,7 @@ func (pf *PDFetcher) filterTombstoneBackends() map[string]*BackendInfo {
 		// After running for a long time, there might be many tombstones because failed TiDB instances
 		// don't delete themselves from the Etcd. Checking their health is a waste of time, leading to
 		// longer and longer checking interval. So tombstones won't be added to aliveBackends.
-		if info.lastUpdate.Add(pf.config.tombstoneThreshold).Before(now) {
+		if info.lastUpdate.Add(pf.config.TombstoneThreshold).Before(now) {
 			continue
 		}
 		aliveBackends[addr] = &BackendInfo{

--- a/pkg/manager/router/backend_fetcher_test.go
+++ b/pkg/manager/router/backend_fetcher_test.go
@@ -47,12 +47,12 @@ func TestTombstoneBackends(t *testing.T) {
 		"dead_addr": {
 			TopologyInfo: &infosync.TopologyInfo{},
 			ttl:          oldTTL,
-			lastUpdate:   now.Add(-pf.config.tombstoneThreshold * 2),
+			lastUpdate:   now.Add(-pf.config.TombstoneThreshold * 2),
 		},
 		"restart_addr": {
 			TopologyInfo: &infosync.TopologyInfo{},
 			ttl:          oldTTL,
-			lastUpdate:   now.Add(-pf.config.tombstoneThreshold * 2),
+			lastUpdate:   now.Add(-pf.config.TombstoneThreshold * 2),
 		},
 		"removed_addr": {
 			TopologyInfo: &infosync.TopologyInfo{},

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
@@ -52,13 +53,14 @@ func newMockEventReceiver(backendChan chan map[string]BackendStatus, errChan cha
 	}
 }
 
-func newHealthCheckConfigForTest() *HealthCheckConfig {
-	return &HealthCheckConfig{
-		healthCheckInterval:      500 * time.Millisecond,
-		healthCheckMaxRetries:    healthCheckMaxRetries,
-		healthCheckRetryInterval: 100 * time.Millisecond,
-		healthCheckTimeout:       100 * time.Millisecond,
-		tombstoneThreshold:       tombstoneThreshold,
+func newHealthCheckConfigForTest() *config.HealthCheck {
+	return &config.HealthCheck{
+		Enable:             true,
+		Interval:           500 * time.Millisecond,
+		MaxRetries:         healthCheckMaxRetries,
+		RetryInterval:      100 * time.Millisecond,
+		DialTimeout:        100 * time.Millisecond,
+		TombstoneThreshold: tombstoneThreshold,
 	}
 }
 
@@ -133,7 +135,7 @@ func TestEtcdUnavailable(t *testing.T) {
 		<-etcd.Server.StopNotify()
 		// The observer will retry indefinitely. We verify it won't panic or hang here.
 		// There's no other way than modifying the code or just sleeping.
-		time.Sleep(bo.config.healthCheckInterval + bo.config.healthCheckTimeout + bo.config.healthCheckRetryInterval)
+		time.Sleep(bo.healthCheckConfig.Interval + bo.healthCheckConfig.DialTimeout + bo.healthCheckConfig.RetryInterval)
 		require.Equal(t, 0, len(backendChan))
 	})
 }

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -17,11 +17,11 @@ package router
 import (
 	"container/list"
 	"context"
-	"github.com/pingcap/TiProxy/lib/config"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	"go.uber.org/zap"

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -17,6 +17,7 @@ package router
 import (
 	"container/list"
 	"context"
+	"github.com/pingcap/TiProxy/lib/config"
 	"net/http"
 	"sync"
 	"time"
@@ -42,14 +43,14 @@ type ScoreBasedRouter struct {
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
-func NewScoreBasedRouter(logger *zap.Logger, httpCli *http.Client, fetcher BackendFetcher) (*ScoreBasedRouter, error) {
+func NewScoreBasedRouter(logger *zap.Logger, httpCli *http.Client, fetcher BackendFetcher, cfg *config.HealthCheck) (*ScoreBasedRouter, error) {
 	router := &ScoreBasedRouter{
 		logger:   logger,
 		backends: list.New(),
 	}
 	router.Lock()
 	defer router.Unlock()
-	observer, err := StartBackendObserver(logger.Named("observer"), router, httpCli, NewDefaultHealthCheckConfig(), fetcher)
+	observer, err := StartBackendObserver(logger.Named("observer"), router, httpCli, cfg, fetcher)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -577,8 +577,9 @@ func TestConcurrency(t *testing.T) {
 	// We create other goroutines to change backends easily.
 	etcd := createEtcdServer(t, "127.0.0.1:0")
 	client := createEtcdClient(t, etcd)
-	fetcher := NewPDFetcher(client, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
-	router, err := NewScoreBasedRouter(logger.CreateLoggerForTest(t), nil, fetcher)
+	healthCheckConfig := newHealthCheckConfigForTest()
+	fetcher := NewPDFetcher(client, logger.CreateLoggerForTest(t), healthCheckConfig)
+	router, err := NewScoreBasedRouter(logger.CreateLoggerForTest(t), nil, fetcher, healthCheckConfig)
 	require.NoError(t, err)
 
 	var wg waitgroup.WaitGroup
@@ -694,7 +695,7 @@ func TestRefresh(t *testing.T) {
 		backends: list.New(),
 	}
 	cfg := NewDefaultHealthCheckConfig()
-	cfg.healthCheckInterval = time.Minute
+	cfg.Interval = time.Minute
 	observer, err := StartBackendObserver(lg, rt, nil, cfg, fetcher)
 	require.NoError(t, err)
 	rt.Lock()


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #205

Problem Summary:
The serverless tier doesn't need health check, because the standby tidb might be unhealthy.

What is changed and how it works:
- Add a member `Enable` to `config.HealthCheck`.
- Move `router.HealthCheckConfig` to `config.HealthCheck` and rename some members.
- Add a parameter `*config.HealthCheck` to `NewScoreBasedRouter()`.

TODO:
- Add `config.HealthCheck` to the configuration file. Currently, it's still using the default value.
- The `config.HealthCheck` parameter of `ScoreBasedRouter` and `PDFetcher` is duplicated and should be refined.
- Unit tests

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
