### PR TITLE
router, config: fix deadlock during closing the router

### DIFF
--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -40,6 +40,14 @@ type BackendNamespace struct {
 	//HealthCheck  HealthCheck `yaml:"health-check" json:"health-check" toml:"health-check"`
 }
 
+const (
+	healthCheckInterval      = 3 * time.Second
+	healthCheckMaxRetries    = 3
+	healthCheckRetryInterval = 1 * time.Second
+	healthCheckTimeout       = 2 * time.Second
+	tombstoneThreshold       = 5 * time.Minute
+)
+
 // HealthCheck contains some configurations for health check.
 // Some general configurations of them may be exposed to users in the future.
 // We can use shorter durations to speed up unit tests.
@@ -50,6 +58,36 @@ type HealthCheck struct {
 	RetryInterval      time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
 	DialTimeout        time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
 	TombstoneThreshold time.Duration `yaml:"tombstone-threshold" json:"tombstone-threshold" toml:"tombstone-threshold"`
+}
+
+// NewDefaultHealthCheckConfig creates a default HealthCheck.
+func NewDefaultHealthCheckConfig() *HealthCheck {
+	return &HealthCheck{
+		Enable:             true,
+		Interval:           healthCheckInterval,
+		MaxRetries:         healthCheckMaxRetries,
+		RetryInterval:      healthCheckRetryInterval,
+		DialTimeout:        healthCheckTimeout,
+		TombstoneThreshold: tombstoneThreshold,
+	}
+}
+
+func (hc *HealthCheck) Check() {
+	if hc.Interval == 0 {
+		hc.Interval = healthCheckInterval
+	}
+	if hc.MaxRetries == 0 {
+		hc.MaxRetries = healthCheckMaxRetries
+	}
+	if hc.RetryInterval == 0 {
+		hc.RetryInterval = healthCheckRetryInterval
+	}
+	if hc.DialTimeout == 0 {
+		hc.DialTimeout = healthCheckTimeout
+	}
+	if hc.TombstoneThreshold == 0 {
+		hc.TombstoneThreshold = tombstoneThreshold
+	}
 }
 
 func NewNamespace(data []byte) (*Namespace, error) {

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -44,11 +44,11 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 
 	var fetcher router.BackendFetcher
 	if mgr.client != nil {
-		fetcher = router.NewPDFetcher(mgr.client, logger.Named("be_fetcher"), router.NewDefaultHealthCheckConfig())
+		fetcher = router.NewPDFetcher(mgr.client, logger.Named("be_fetcher"), config.NewDefaultHealthCheckConfig())
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt, err := router.NewScoreBasedRouter(logger.Named("router"), mgr.httpCli, fetcher, router.NewDefaultHealthCheckConfig())
+	rt, err := router.NewScoreBasedRouter(logger.Named("router"), mgr.httpCli, fetcher, config.NewDefaultHealthCheckConfig())
 	if err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -94,6 +94,7 @@ type PDFetcher struct {
 }
 
 func NewPDFetcher(client *clientv3.Client, logger *zap.Logger, config *config.HealthCheck) *PDFetcher {
+	config.Check()
 	return &PDFetcher{
 		backendInfo: make(map[string]*pdBackendInfo),
 		client:      client,

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -67,27 +67,10 @@ var statusScores = map[BackendStatus]int{
 }
 
 const (
-	healthCheckInterval      = 3 * time.Second
-	healthCheckMaxRetries    = 3
-	healthCheckRetryInterval = 1 * time.Second
-	healthCheckTimeout       = 2 * time.Second
-	tombstoneThreshold       = 5 * time.Minute
-	ttlPathSuffix            = "/ttl"
-	infoPathSuffix           = "/info"
-	statusPathSuffix         = "/status"
+	ttlPathSuffix    = "/ttl"
+	infoPathSuffix   = "/info"
+	statusPathSuffix = "/status"
 )
-
-// NewDefaultHealthCheckConfig creates a default HealthCheck.
-func NewDefaultHealthCheckConfig() *config.HealthCheck {
-	return &config.HealthCheck{
-		Enable:             true,
-		Interval:           healthCheckInterval,
-		MaxRetries:         healthCheckMaxRetries,
-		RetryInterval:      healthCheckRetryInterval,
-		DialTimeout:        healthCheckTimeout,
-		TombstoneThreshold: tombstoneThreshold,
-	}
-}
 
 // BackendEventReceiver receives the event of backend status change.
 type BackendEventReceiver interface {

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -57,10 +57,10 @@ func newHealthCheckConfigForTest() *config.HealthCheck {
 	return &config.HealthCheck{
 		Enable:             true,
 		Interval:           500 * time.Millisecond,
-		MaxRetries:         healthCheckMaxRetries,
+		MaxRetries:         3,
 		RetryInterval:      100 * time.Millisecond,
 		DialTimeout:        100 * time.Millisecond,
-		TombstoneThreshold: tombstoneThreshold,
+		TombstoneThreshold: 5 * time.Minute,
 	}
 }
 

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -48,8 +48,7 @@ func NewScoreBasedRouter(logger *zap.Logger, httpCli *http.Client, fetcher Backe
 		logger:   logger,
 		backends: list.New(),
 	}
-	router.Lock()
-	defer router.Unlock()
+	cfg.Check()
 	observer, err := StartBackendObserver(logger.Named("observer"), router, httpCli, cfg, fetcher)
 	if err != nil {
 		return nil, err
@@ -393,8 +392,6 @@ func (router *ScoreBasedRouter) ConnCount() int {
 
 // Close implements Router.Close interface.
 func (router *ScoreBasedRouter) Close() {
-	router.Lock()
-	defer router.Unlock()
 	if router.cancelFunc != nil {
 		router.cancelFunc()
 		router.cancelFunc = nil


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #207

Problem Summary:
- Close the router may cause deadlock: `router.Close()` holds `router.lock` and waits for `observer` to finish; `observer.observe()` calls `router.OnBackendChanged()`, which waits for `router.lock`.
- If `HealthCheck.Interval==0`, even if `HealthCheck.Enable==false`, there is no interval for calling `backendFetcher`, which exhausts lots of resources.

What is changed and how it works:
- Remove the locks for `StartScoreBasedRouter()` and `Close()`. The lock intends to protect `router.observer` and `router.cancelFunc` but they are not very necessary.
- Add a `HealthCheck.Check()` when creating `ScoreBasedRouter` and `PDFetcher`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
