### PR TITLE
backend, metrics: add logs and metrics for getting a backend

### DIFF
--- a/pkg/metrics/balance.go
+++ b/pkg/metrics/balance.go
@@ -58,7 +58,7 @@ var (
 			Namespace: ModuleProxy,
 			Subsystem: LabelBalance,
 			Name:      "migrate_duration_millis",
-			Help:      "Bucketed histogram of migrating time (s) of sessions.",
+			Help:      "Bucketed histogram of migrating time (ms) of sessions.",
 			Buckets:   prometheus.ExponentialBuckets(0.1, 2, 26), // 0.1ms ~ 1h
 		}, []string{LblFrom, LblTo, LblMigrateResult})
 )

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -1067,6 +1067,126 @@
          "title": "Balance",
          "titleSize": "h6",
          "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 16,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_TEST-CLUSTER}",
+               "description": "Duration of getting an available backend.",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 17,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "99",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.95, sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (le))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "95",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[30s])) / sum(rate(tiproxy_session_get_backend_duration_millis_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[30s]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "avg",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Get Backend Duration",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Backend",
+         "titleSize": "h6",
+         "type": "row"
       }
    ],
    "refresh": "30s",

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -282,6 +282,34 @@ local bMigDurP = graphPanel.new(
   )
 );
 
+// Backend Summary
+local backendRow = row.new(collapse=true, title='Backend');
+local bGetDurP = graphPanel.new(
+  title='Get Backend Duration',
+  datasource=myDS,
+  legend_rightSide=true,
+  description='Duration of getting an available backend.',
+  format='s',
+)
+.addTarget(
+  prometheus.target(
+    'histogram_quantile(0.99, sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}[1m])) by (le))',
+    legendFormat='99',
+  )
+)
+.addTarget(
+  prometheus.target(
+    'histogram_quantile(0.95, sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}[1m])) by (le))',
+    legendFormat='95',
+  )
+)
+.addTarget(
+  prometheus.target(
+    'sum(rate(tiproxy_session_get_backend_duration_millis_bucket{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}[30s])) / sum(rate(tiproxy_session_get_backend_duration_millis_count{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}[30s]))',
+    legendFormat='avg',
+  )
+);
+
 // Merge together.
 local panelW = 12;
 local panelH = 6;
@@ -316,6 +344,12 @@ newDash
   .addPanel(bConnP, gridPos=leftPanelPos)
   .addPanel(bMigCounterP, gridPos=rightPanelPos)
   .addPanel(bMigDurP, gridPos=leftPanelPos)
+  ,
+  gridPos=rowPos
+)
+.addPanel(
+  backendRow
+  .addPanel(bGetDurP, gridPos=leftPanelPos)
   ,
   gridPos=rowPos
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -120,6 +120,7 @@ func registerProxyMetrics() {
 	prometheus.MustRegister(BackendConnGauge)
 	prometheus.MustRegister(QueryTotalCounter)
 	prometheus.MustRegister(QueryDurationHistogram)
+	prometheus.MustRegister(GetBackendHistogram)
 	prometheus.MustRegister(MigrateCounter)
 	prometheus.MustRegister(MigrateDurationHistogram)
 }

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -39,4 +39,13 @@ var (
 			Help:      "Bucketed histogram of processing time (s) of handled queries.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblBackend, LblCmdType})
+
+	GetBackendHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelSession,
+			Name:      "get_backend_duration_millis",
+			Help:      "Bucketed histogram of time (ms) for getting an available backend.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 26), // 1us ~ 30s
+		})
 )

--- a/pkg/proxy/backend/metrics.go
+++ b/pkg/proxy/backend/metrics.go
@@ -61,3 +61,7 @@ func readCmdCounter(cmd byte, addr string) (int, error) {
 	}
 	return metrics.ReadCounter(metrics.QueryTotalCounter.WithLabelValues(addr, label))
 }
+
+func addGetBackendMetrics(duration time.Duration) {
+	metrics.GetBackendHistogram.Observe(float64(duration.Milliseconds()))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #210

Problem Summary:
Getting backend is problematic on the serverless tier. We need more logs to help investigating.

What is changed and how it works:
- Add error logs when getting backend fails; add warn logs when getting backend too slow
- Add duration metrics for getting backends

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
[2023/02/06 15:20:54.085 +08:00] [ERROR] [main.proxy.conn.be] [backend/backend_conn_mgr.go:245] [get backend failed] [connID=0] [remoteAddr=127.0.0.1:62995] [duration=15.000037552s] [last_err="no instances to route"]
```

```
tiproxy_session_get_backend_duration_millis_bucket{le="0.001"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.002"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.004"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.008"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.016"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.032"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.064"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.128"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.256"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="0.512"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="1.024"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="2.048"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="4.096"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="8.192"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="16.384"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="32.768"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="65.536"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="131.072"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="262.144"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="524.288"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="1048.576"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="2097.152"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="4194.304"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="8388.608"} 0
tiproxy_session_get_backend_duration_millis_bucket{le="16777.216"} 1
tiproxy_session_get_backend_duration_millis_bucket{le="33554.432"} 1
tiproxy_session_get_backend_duration_millis_bucket{le="+Inf"} 1
tiproxy_session_get_backend_duration_millis_sum 15000
tiproxy_session_get_backend_duration_millis_count 1
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
