### PR TITLE
backend, router: add IO timeout when the backend is unhealthy

### DIFF
--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -75,6 +75,7 @@ type RedirectableConn interface {
 	SetEventReceiver(receiver ConnEventReceiver)
 	Redirect(addr string)
 	GetRedirectingAddr() string
+	SetBackendStatus(status BackendStatus)
 	ConnectionID() uint64
 }
 

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -37,6 +37,7 @@ type mockRedirectableConn struct {
 	t        *testing.T
 	connID   uint64
 	from, to string
+	status   BackendStatus
 	receiver ConnEventReceiver
 }
 
@@ -57,6 +58,12 @@ func (conn *mockRedirectableConn) GetRedirectingAddr() string {
 	conn.Lock()
 	defer conn.Unlock()
 	return conn.to
+}
+
+func (conn *mockRedirectableConn) SetBackendStatus(status BackendStatus) {
+	conn.Lock()
+	conn.status = status
+	conn.Unlock()
 }
 
 func (conn *mockRedirectableConn) ConnectionID() uint64 {
@@ -811,4 +818,18 @@ func TestDisableHealthCheck(t *testing.T) {
 		require.NoError(t, err)
 		return addr == "127.0.0.1:5000"
 	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestSetBackendStatus(t *testing.T) {
+	tester := newRouterTester(t)
+	tester.addBackends(1)
+	tester.addConnections(10)
+	tester.killBackends(1)
+	for _, conn := range tester.conns {
+		require.Equal(t, StatusCannotConnect, conn.status)
+	}
+	tester.updateBackendStatusByAddr(tester.getBackendByIndex(0).addr, StatusHealthy)
+	for _, conn := range tester.conns {
+		require.Equal(t, StatusHealthy, conn.status)
+	}
 }

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -599,7 +599,9 @@ func (mgr *BackendConnManager) setRespondTimeout(redirect bool) {
 			timeout = mgr.config.UnhealthyRedirectTimeout
 		}
 	}
-	mgr.backendIO.SetTimeout(timeout)
+	if err := mgr.backendIO.SetTimeout(timeout); err != nil && !errors.Is(err, net.ErrClosed) {
+		mgr.logger.Warn("set response timeout error", zap.Stringer("backend", mgr.backendIO.RemoteAddr()), zap.Error(err))
+	}
 }
 
 func (mgr *BackendConnManager) ClientAddr() string {

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"crypto/tls"
 	"encoding/binary"
+	"time"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
@@ -28,6 +29,7 @@ type backendConfig struct {
 	authPlugin    string
 	sessionStates string
 	salt          []byte
+	blockTime     time.Duration
 	columns       int
 	loops         int
 	params        int
@@ -72,6 +74,9 @@ func newMockBackend(cfg *backendConfig) *mockBackend {
 func (mb *mockBackend) authenticate(packetIO *pnet.PacketIO) error {
 	if mb.abnormalExit {
 		return packetIO.Close()
+	}
+	if mb.blockTime > 0 {
+		time.Sleep(mb.blockTime)
 	}
 	var err error
 	// write initial handshake
@@ -149,6 +154,9 @@ func (mb *mockBackend) respond(packetIO *pnet.PacketIO) error {
 }
 
 func (mb *mockBackend) respondOnce(packetIO *pnet.PacketIO) error {
+	if mb.blockTime > 0 {
+		time.Sleep(mb.blockTime)
+	}
 	packetIO.ResetSequence()
 	pkt, err := packetIO.ReadPacket()
 	if err != nil {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -30,6 +30,7 @@ type proxyConfig struct {
 	backendTLSConfig     *tls.Config
 	handler              *CustomHandshakeHandler
 	checkBackendInterval time.Duration
+	redirectTimeout      time.Duration
 	sessionToken         string
 	capability           pnet.Capability
 	waitRedirect         bool
@@ -41,6 +42,7 @@ func newProxyConfig() *proxyConfig {
 		capability:           defaultTestBackendCapability,
 		sessionToken:         mockToken,
 		checkBackendInterval: CheckBackendInterval,
+		redirectTimeout:      UnhealthyRedirectTimeout,
 	}
 }
 
@@ -61,7 +63,8 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 		proxyConfig: cfg,
 		logger:      logger.CreateLoggerForTest(t).Named("mockProxy"),
 		BackendConnManager: NewBackendConnManager(logger.CreateLoggerForTest(t), cfg.handler, 0, &BCConfig{
-			CheckBackendInterval: cfg.checkBackendInterval,
+			CheckBackendInterval:     cfg.checkBackendInterval,
+			UnhealthyRedirectTimeout: cfg.redirectTimeout,
 		}),
 	}
 	mp.cmdProcessor.capability = cfg.capability.Uint32()


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #229

Problem Summary:
When the backend is unhealthy, the queries may block. We need to fail fast.

What is changed and how it works:
Add IO timeout when the backend is unhealthy.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
