### PR TITLE
proxy: configurable keepalive

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/TiProxy/lib/util/errors"
@@ -43,17 +44,25 @@ type Metrics struct {
 	MetricsInterval uint   `toml:"metrics-interval" json:"metrics-interval"`
 }
 
+type KeepAlive struct {
+	Enabled bool          `yaml:"enabled,omitempty" toml:"enabled,omitempty" json:"enabled,omitempty"`
+	Cnt     int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
+	Idle    time.Duration `yaml:"idle,omitempty" toml:"idle,omitempty" json:"idle,omitempty"`
+	Intvl   time.Duration `yaml:"intvl,omitempty" toml:"intvl,omitempty" json:"intvl,omitempty"`
+}
+
 type ProxyServerOnline struct {
-	MaxConnections             uint64 `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
-	TCPKeepAlive               bool   `yaml:"tcp-keep-alive,omitempty" toml:"tcp-keep-alive,omitempty" json:"tcp-keep-alive,omitempty"`
-	ProxyProtocol              string `yaml:"proxy-protocol,omitempty" toml:"proxy-protocol,omitempty" json:"proxy-protocol,omitempty"`
-	GracefulWaitBeforeShutdown int    `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty"`
+	MaxConnections             uint64    `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
+	FrontendKeepalive          KeepAlive `yaml:"frontend-keepalive" toml:"frontend-keepalive" json:"frontend-keepalive"`
+	BackendKeepalive           KeepAlive `yaml:"backend-keepalive" toml:"backend-keepalive" json:"backend-keepalive"`
+	ProxyProtocol              string    `yaml:"proxy-protocol,omitempty" toml:"proxy-protocol,omitempty" json:"proxy-protocol,omitempty"`
+	GracefulWaitBeforeShutdown int       `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty"`
+	RequireBackendTLS          bool      `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
 }
 
 type ProxyServer struct {
 	Addr              string `yaml:"addr,omitempty" toml:"addr,omitempty" json:"addr,omitempty"`
 	PDAddrs           string `yaml:"pd-addrs,omitempty" toml:"pd-addrs,omitempty" json:"pd-addrs,omitempty"`
-	RequireBackendTLS bool   `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
 	ProxyServerOnline `yaml:",inline" toml:",inline" json:",inline"`
 }
 
@@ -114,7 +123,7 @@ func NewConfig() *Config {
 	var cfg Config
 
 	cfg.Proxy.Addr = "0.0.0.0:6000"
-	cfg.Proxy.TCPKeepAlive = true
+	cfg.Proxy.FrontendKeepalive.Cnt = 1
 	cfg.Proxy.RequireBackendTLS = true
 	cfg.Proxy.PDAddrs = "127.0.0.1:2379"
 

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -37,10 +37,9 @@ type proxyConfig struct {
 
 func newProxyConfig() *proxyConfig {
 	return &proxyConfig{
-		handler:              &CustomHandshakeHandler{},
-		capability:           defaultTestBackendCapability,
-		sessionToken:         mockToken,
-		checkBackendInterval: CheckBackendInterval,
+		handler:      &CustomHandshakeHandler{},
+		capability:   defaultTestBackendCapability,
+		sessionToken: mockToken,
 	}
 }
 

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -41,19 +41,18 @@ type ClientConnection struct {
 }
 
 func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *tls.Config, backendTLSConfig *tls.Config,
-	hsHandler backend.HandshakeHandler, connID uint64, proxyProtocol, requireBackendTLS bool) *ClientConnection {
-	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, &backend.BCConfig{
-		ProxyProtocol:     proxyProtocol,
-		RequireBackendTLS: requireBackendTLS,
-	})
+	hsHandler backend.HandshakeHandler, connID uint64, cfg *backend.BCConfig) *ClientConnection {
+	cfg.Check()
+	logger.Info("client connection config", zap.Any("cfg", cfg))
+	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, cfg)
 	opts := make([]pnet.PacketIOption, 0, 2)
 	opts = append(opts, pnet.WithWrapError(ErrClientConn))
-	if proxyProtocol {
+	if cfg.ProxyProtocol {
 		opts = append(opts, pnet.WithProxy)
 	}
 	pkt := pnet.NewPacketIO(conn, opts...)
 	return &ClientConnection{
-		logger:            logger.With(zap.Bool("proxy-protocol", proxyProtocol)),
+		logger:            logger,
 		frontendTLSConfig: frontendTLSConfig,
 		backendTLSConfig:  backendTLSConfig,
 		pkt:               pkt,

--- a/pkg/proxy/keepalive/keepalive.go
+++ b/pkg/proxy/keepalive/keepalive.go
@@ -1,0 +1,44 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"net"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/errors"
+)
+
+var (
+	ErrKeepAlive = errors.New("failed to set keepalive")
+)
+
+func SetKeepalive(conn net.Conn, cfg config.KeepAlive) error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	tcpcn, ok := conn.(*net.TCPConn)
+	if !ok {
+		return errors.Wrapf(ErrKeepAlive, "not net.TCPConn")
+	}
+
+	syscn, err := tcpcn.SyscallConn()
+	if err != nil {
+		return errors.Wrap(ErrKeepAlive, err)
+	}
+
+	return setKeepalive(syscn, cfg)
+}

--- a/pkg/proxy/keepalive/keepalive_darwin.go
+++ b/pkg/proxy/keepalive/keepalive_darwin.go
@@ -1,0 +1,52 @@
+//go:build darwin
+// +build darwin
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"syscall"
+
+	"github.com/pingcap/TiProxy/lib/config"
+)
+
+const (
+	// missing in older darwin
+	_TCP_KEEPINTVL = 0x101
+	_TCP_KEEPCNT   = 0x102
+)
+
+func setKeepalive(syscn syscall.RawConn, cfg config.KeepAlive) error {
+	var serr error
+	return errors.Collect(ErrKeepAlive, serr, syscn.Control(func(fd uintptr) {
+		serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(cfg.Idle))
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPCNT, cfg.Cnt)
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPINTVL, int(cfg.Intvl))
+		if serr != nil {
+			return
+		}
+	}
+}

--- a/pkg/proxy/keepalive/keepalive_default.go
+++ b/pkg/proxy/keepalive/keepalive_default.go
@@ -1,0 +1,34 @@
+//go:build !(linux || netbsd || freebsd || dragonfly || aix || windows || darwin)
+// +build !(linux OR netbsd OR freebsd OR dragonfly OR aix OR windows OR darwin)
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"syscall"
+
+	"github.com/pingcap/TiProxy/lib/config"
+)
+
+func setKeepalive(syscn syscall.RawConn, cfg config.KeepAlive) error {
+	var serr error
+	return errors.Collect(ErrKeepAlive, serr, syscn.Control(func(fd uintptr) {
+		serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
+		if serr != nil {
+			return
+		}
+	}
+}

--- a/pkg/proxy/keepalive/keepalive_unix.go
+++ b/pkg/proxy/keepalive/keepalive_unix.go
@@ -1,0 +1,47 @@
+//go:build linux || netbsd || freebsd || dragonfly || aix || windows
+// +build linux netbsd freebsd dragonfly aix windows
+
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"syscall"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/errors"
+)
+
+func setKeepalive(syscn syscall.RawConn, cfg config.KeepAlive) error {
+	var serr error
+	return errors.Collect(ErrKeepAlive, serr, syscn.Control(func(fd uintptr) {
+		serr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_KEEPALIVE, 1)
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(cfg.Idle))
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, cfg.Cnt)
+		if serr != nil {
+			return
+		}
+		serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(cfg.Intvl))
+		if serr != nil {
+			return
+		}
+	}))
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -57,7 +57,7 @@ func TestGracefulShutdown(t *testing.T) {
 		}()
 		conn, err := server.listener.Accept()
 		require.NoError(t, err)
-		clientConn := client.NewClientConnection(lg, conn, nil, nil, hsHandler, 0, false, false)
+		clientConn := client.NewClientConnection(lg, conn, nil, nil, hsHandler, 0, &backend.BCConfig{})
 		server.mu.clients[1] = clientConn
 		server.mu.Unlock()
 		return clientConn


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #229

Problem Summary:  Configurable keepalive parameters using standard `idle + cnt * intvl`.

What is changed and how it works:

1. `RequireBackendTLS` is now online configurable
2. Support passing and online changing of frontend/backend keepalive parameters
3. Cross-platform keepalive support using `SyscallConn` located in `/pkg/proxy/keepalive`
4. Other minor changes

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
