### PR TITLE
backend, net: make connection concurrency safe

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -120,9 +120,11 @@ type BackendConnManager struct {
 	closeStatus        atomic.Int32
 	checkBackendTicker *time.Ticker
 	// cancelFunc is used to cancel the signal processing goroutine.
-	cancelFunc       context.CancelFunc
-	clientIO         *pnet.PacketIO
-	backendIO        *pnet.PacketIO
+	cancelFunc context.CancelFunc
+	clientIO   *pnet.PacketIO
+	// type *pnet.PacketIO. The backendIO may be written during redirection
+	// and be read in ExecuteCmd/Redirect/setTimeout/setKeepalive.
+	backendIO        unsafe.Pointer
 	backendTLS       *tls.Config
 	handshakeHandler HandshakeHandler
 	ctxmap           sync.Map
@@ -228,8 +230,9 @@ func (mgr *BackendConnManager) getBackendIO(cctx ConnContext, auth *Authenticato
 			// NOTE: should use DNS name as much as possible
 			// Usually certs are signed with domain instead of IP addrs
 			// And `RemoteAddr()` will return IP addr
-			mgr.backendIO = pnet.NewPacketIO(cn, pnet.WithRemoteAddr(addr, cn.RemoteAddr()))
-			return mgr.backendIO, nil
+			backendIO := pnet.NewPacketIO(cn, pnet.WithRemoteAddr(addr, cn.RemoteAddr()))
+			atomic.StorePointer(&mgr.backendIO, unsafe.Pointer(backendIO))
+			return backendIO, nil
 		},
 		backoff.WithContext(backoff.NewConstantBackOff(200*time.Millisecond), bctx),
 		func(err error, d time.Duration) {
@@ -245,7 +248,7 @@ func (mgr *BackendConnManager) getBackendIO(cctx ConnContext, auth *Authenticato
 		mgr.logger.Error("get backend failed", zap.Duration("duration", duration), zap.NamedError("last_err", origErr))
 	} else if duration >= 3*time.Second {
 		mgr.logger.Warn("get backend slow", zap.Duration("duration", duration), zap.NamedError("last_err", origErr),
-			zap.Stringer("backend_addr", mgr.backendIO.RemoteAddr()))
+			zap.String("backend_addr", mgr.ServerAddr()))
 	}
 	if err != nil && errors.Is(err, context.DeadlineExceeded) {
 		if origErr != nil {
@@ -272,7 +275,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) e
 	}
 	defer mgr.resetCheckBackendTicker()
 	waitingRedirect := atomic.LoadPointer(&mgr.signal) != nil
-	holdRequest, err := mgr.cmdProcessor.executeCmd(request, mgr.clientIO, mgr.backendIO, waitingRedirect)
+	holdRequest, err := mgr.cmdProcessor.executeCmd(request, mgr.clientIO, (*pnet.PacketIO)(atomic.LoadPointer(&mgr.backendIO)), waitingRedirect)
 	if !holdRequest {
 		addCmdMetrics(cmd, mgr.ServerAddr(), startTime)
 	}
@@ -310,7 +313,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) e
 		if waitingRedirect && holdRequest {
 			mgr.tryRedirect(ctx)
 			// Execute the held request no matter redirection succeeds or not.
-			_, err = mgr.cmdProcessor.executeCmd(request, mgr.clientIO, mgr.backendIO, false)
+			_, err = mgr.cmdProcessor.executeCmd(request, mgr.clientIO, (*pnet.PacketIO)(atomic.LoadPointer(&mgr.backendIO)), false)
 			addCmdMetrics(cmd, mgr.ServerAddr(), startTime)
 			if err != nil && !IsMySQLError(err) {
 				return err
@@ -348,10 +351,10 @@ func (mgr *BackendConnManager) initSessionStates(backendIO *pnet.PacketIO, sessi
 	return err
 }
 
-func (mgr *BackendConnManager) querySessionStates() (sessionStates, sessionToken string, err error) {
+func (mgr *BackendConnManager) querySessionStates(backendIO *pnet.PacketIO) (sessionStates, sessionToken string, err error) {
 	// Do not lock here because the caller already locks.
 	var result *gomysql.Result
-	if result, _, err = mgr.cmdProcessor.query(mgr.backendIO, sqlQueryState); err != nil {
+	if result, _, err = mgr.cmdProcessor.query(backendIO, sqlQueryState); err != nil {
 		return
 	}
 	if sessionStates, err = result.GetStringByName(0, sessionStatesCol); err != nil {
@@ -415,8 +418,9 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 		// - Avoid the risk of deadlock
 		mgr.redirectResCh <- rs
 	}()
+	backendIO := (*pnet.PacketIO)(atomic.LoadPointer(&mgr.backendIO))
 	var sessionStates, sessionToken string
-	if sessionStates, sessionToken, rs.err = mgr.querySessionStates(); rs.err != nil {
+	if sessionStates, sessionToken, rs.err = mgr.querySessionStates(backendIO); rs.err != nil {
 		return
 	}
 	if rs.err = mgr.updateAuthInfoFromSessionStates(hack.Slice(sessionStates)); rs.err != nil {
@@ -442,11 +446,11 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 		}
 		return
 	}
-	if ignoredErr := mgr.backendIO.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
+	if ignoredErr := backendIO.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
 		mgr.logger.Error("close previous backend connection failed", zap.Error(ignoredErr))
 	}
 
-	mgr.backendIO = newBackendIO
+	atomic.StorePointer(&mgr.backendIO, unsafe.Pointer(newBackendIO))
 	mgr.handshakeHandler.OnHandshake(mgr, mgr.ServerAddr(), nil)
 }
 
@@ -538,9 +542,10 @@ func (mgr *BackendConnManager) checkBackendActive() {
 
 	mgr.processLock.Lock()
 	defer mgr.processLock.Unlock()
-	if !mgr.backendIO.IsPeerActive() {
+	backendIO := (*pnet.PacketIO)(atomic.LoadPointer(&mgr.backendIO))
+	if !backendIO.IsPeerActive() {
 		mgr.logger.Info("backend connection is closed, close client connection", zap.Stringer("client", mgr.clientIO.RemoteAddr()),
-			zap.Stringer("backend", mgr.backendIO.RemoteAddr()))
+			zap.Stringer("backend", backendIO.RemoteAddr()))
 		if err := mgr.clientIO.GracefulClose(); err != nil {
 			mgr.logger.Warn("graceful close client IO error", zap.Stringer("addr", mgr.clientIO.RemoteAddr()), zap.Error(err))
 		}
@@ -566,10 +571,10 @@ func (mgr *BackendConnManager) ClientAddr() string {
 }
 
 func (mgr *BackendConnManager) ServerAddr() string {
-	if mgr.backendIO == nil {
-		return ""
+	if backendIO := (*pnet.PacketIO)(atomic.LoadPointer(&mgr.backendIO)); backendIO != nil {
+		return backendIO.RemoteAddr().String()
 	}
-	return mgr.backendIO.RemoteAddr().String()
+	return ""
 }
 
 func (mgr *BackendConnManager) ClientInBytes() uint64 {
@@ -613,10 +618,9 @@ func (mgr *BackendConnManager) Close() error {
 	var connErr error
 	var addr string
 	mgr.processLock.Lock()
-	if mgr.backendIO != nil {
-		addr = mgr.ServerAddr()
-		connErr = mgr.backendIO.Close()
-		mgr.backendIO = nil
+	if backendIO := (*pnet.PacketIO)(atomic.SwapPointer(&mgr.backendIO, nil)); backendIO != nil {
+		addr = backendIO.RemoteAddr().String()
+		connErr = backendIO.Close()
 	}
 	mgr.processLock.Unlock()
 

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -48,7 +48,6 @@ import (
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/dbterror"
-	goatomic "go.uber.org/atomic"
 )
 
 var (
@@ -81,7 +80,7 @@ type PacketIO struct {
 	// conn is written during TLS handshake and read during setting keep alive concurrently.
 	conn        atomic.Pointer[net.Conn]
 	buf         *bufio.ReadWriter
-	proxyInited *goatomic.Bool
+	proxyInited atomic.Bool
 	proxy       *Proxy
 	remoteAddr  net.Addr
 	wrap        error
@@ -95,10 +94,10 @@ func NewPacketIO(conn net.Conn, opts ...PacketIOption) *PacketIO {
 	)
 	p := &PacketIO{
 		sequence: 0,
-		// TODO: disable it by default now
-		proxyInited: goatomic.NewBool(true),
-		buf:         buf,
+		buf:      buf,
 	}
+	// TODO: disable it by default now
+	p.proxyInited.Store(true)
 	cn := (net.Conn)(&rdbufConn{
 		conn,
 		buf.Reader,

--- a/pkg/proxy/net/packetio_options.go
+++ b/pkg/proxy/net/packetio_options.go
@@ -16,14 +16,12 @@ package net
 
 import (
 	"net"
-
-	"go.uber.org/atomic"
 )
 
 type PacketIOption = func(*PacketIO)
 
 func WithProxy(pi *PacketIO) {
-	pi.proxyInited = atomic.NewBool(true)
+	pi.proxyInited.Store(true)
 }
 
 func WithWrapError(err error) func(pi *PacketIO) {

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -148,7 +148,7 @@ func TestPacketIO(t *testing.T) {
 func TestTLS(t *testing.T) {
 	stls, ctls, err := security.CreateTLSConfigForTest()
 	require.NoError(t, err)
-	message := []byte("hello wolrd")
+	message := []byte("hello world")
 	testTCPConn(t,
 		func(t *testing.T, cli *PacketIO) {
 			data, err := cli.ReadPacket()

--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -48,7 +48,7 @@ func TestProxyParse(t *testing.T) {
 		func(t *testing.T, srv *PacketIO) {
 			// skip 4 bytes of magic
 			var hdr [4]byte
-			_, err := io.ReadFull(srv.conn, hdr[:])
+			_, err := io.ReadFull(*srv.conn.Load(), hdr[:])
 			require.NoError(t, err)
 
 			// try to parse V2

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -22,6 +22,8 @@ import (
 )
 
 func (p *PacketIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionState, error) {
+	p.Lock()
+	defer p.Unlock()
 	tlsConfig = tlsConfig.Clone()
 	tlsConn := tls.Server(p.conn, tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
@@ -35,6 +37,8 @@ func (p *PacketIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionStat
 }
 
 func (p *PacketIO) ClientTLSHandshake(tlsConfig *tls.Config) error {
+	p.Lock()
+	defer p.Unlock()
 	tlsConfig = tlsConfig.Clone()
 	tlsConn := tls.Client(p.conn, tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -17,36 +17,34 @@ package net
 import (
 	"bufio"
 	"crypto/tls"
-
 	"github.com/pingcap/TiProxy/lib/util/errors"
+	"net"
 )
 
 func (p *PacketIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionState, error) {
-	p.Lock()
-	defer p.Unlock()
 	tlsConfig = tlsConfig.Clone()
-	tlsConn := tls.Server(p.conn, tlsConfig)
+	tlsConn := tls.Server(*p.conn.Load(), tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
 		return tls.ConnectionState{}, p.wrapErr(errors.Wrap(ErrHandshakeTLS, err))
 	}
-	p.conn = tlsConn
-	p.buf.Writer.Reset(p.conn)
+	conn := (net.Conn)(tlsConn)
+	p.conn.Store(&conn)
+	p.buf.Writer.Reset(conn)
 	// Wrap it with another buffer to enable Peek.
-	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(p.conn, defaultReaderSize), p.buf.Writer)
+	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(conn, defaultReaderSize), p.buf.Writer)
 	return tlsConn.ConnectionState(), nil
 }
 
 func (p *PacketIO) ClientTLSHandshake(tlsConfig *tls.Config) error {
-	p.Lock()
-	defer p.Unlock()
 	tlsConfig = tlsConfig.Clone()
-	tlsConn := tls.Client(p.conn, tlsConfig)
+	tlsConn := tls.Client(*p.conn.Load(), tlsConfig)
 	if err := tlsConn.Handshake(); err != nil {
 		return errors.WithStack(errors.Wrap(ErrHandshakeTLS, err))
 	}
-	p.conn = tlsConn
-	p.buf.Writer.Reset(p.conn)
+	conn := (net.Conn)(tlsConn)
+	p.conn.Store(&conn)
+	p.buf.Writer.Reset(conn)
 	// Wrap it with another buffer to enable Peek.
-	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(p.conn, defaultReaderSize), p.buf.Writer)
+	p.buf = bufio.NewReadWriter(bufio.NewReaderSize(conn, defaultReaderSize), p.buf.Writer)
 	return nil
 }

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -17,8 +17,9 @@ package net
 import (
 	"bufio"
 	"crypto/tls"
-	"github.com/pingcap/TiProxy/lib/util/errors"
 	"net"
+
+	"github.com/pingcap/TiProxy/lib/util/errors"
 )
 
 func (p *PacketIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionState, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/TiProxy/issues/229

Problem Summary:
To make set timeout / keep alive concurrently with forwarding messages / TLS handshake, the `mgr.backendIO` and `PacketIO.conn` must be concurrency safe.

What is changed and how it works:
- Make `mgr.backendIO` atomic
- Add RWMutex to `PacketIO.conn`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
