### PR TITLE
backend: add quit source to ConnContext

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -388,6 +388,12 @@ func TestConnectFail(t *testing.T) {
 				return ts.mb.authenticate(ts.tc.backendIO)
 			},
 		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcClientErr, ts.mp.QuitSource())
+				return nil
+			},
+		},
 	}
 	ts.runTests(runners)
 }
@@ -499,6 +505,7 @@ func TestSpecialCmds(t *testing.T) {
 				ts.mp.Redirect(ts.tc.backendListener.Addr().String())
 				ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(t, eventSucceed)
 				require.NotEqual(t, backend1, ts.mp.backendIO.Load())
+				require.Equal(t, SrcClientQuit, ts.mp.QuitSource())
 				return nil
 			},
 			backend: func(packetIO *pnet.PacketIO) error {
@@ -599,6 +606,12 @@ func TestCustomHandshake(t *testing.T) {
 			},
 			backend: ts.redirectSucceed4Backend,
 		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcClientQuit, ts.mp.QuitSource())
+				return nil
+			},
+		},
 	}
 	ts.runTests(runners)
 }
@@ -622,6 +635,12 @@ func TestGracefulCloseWhenIdle(t *testing.T) {
 		// really closed
 		{
 			proxy: ts.checkConnClosed4Proxy,
+		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				return nil
+			},
 		},
 	}
 	ts.runTests(runners)
@@ -661,6 +680,12 @@ func TestGracefulCloseWhenActive(t *testing.T) {
 		{
 			proxy: ts.checkConnClosed4Proxy,
 		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				return nil
+			},
+		},
 	}
 	ts.runTests(runners)
 }
@@ -685,14 +710,21 @@ func TestGracefulCloseBeforeHandshake(t *testing.T) {
 		{
 			proxy: ts.checkConnClosed4Proxy,
 		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				return nil
+			},
+		},
 	}
 	ts.runTests(runners)
 }
 
 func TestHandlerReturnError(t *testing.T) {
 	tests := []struct {
-		cfg    cfgOverrider
-		errMsg string
+		cfg        cfgOverrider
+		errMsg     string
+		quitSource ErrorSource
 	}{
 		{
 			cfg: func(config *testConfig) {
@@ -700,7 +732,8 @@ func TestHandlerReturnError(t *testing.T) {
 					return nil, errors.New("mocked error")
 				}
 			},
-			errMsg: "mocked error",
+			errMsg:     "mocked error",
+			quitSource: SrcProxyErr,
 		},
 		{
 			cfg: func(config *testConfig) {
@@ -708,7 +741,8 @@ func TestHandlerReturnError(t *testing.T) {
 					return errors.New("mocked error")
 				}
 			},
-			errMsg: "mocked error",
+			errMsg:     "mocked error",
+			quitSource: SrcProxyErr,
 		},
 		{
 			// TODO: make it fail faster.
@@ -717,7 +751,8 @@ func TestHandlerReturnError(t *testing.T) {
 					return router.NewStaticRouter(nil), nil
 				}
 			},
-			errMsg: connectErrMsg,
+			errMsg:     connectErrMsg,
+			quitSource: SrcProxyErr,
 		},
 	}
 	for _, test := range tests {
@@ -732,6 +767,7 @@ func TestHandlerReturnError(t *testing.T) {
 			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
 				err := ts.mp.Connect(context.Background(), clientIO, ts.mp.frontendTLSConfig, ts.mp.backendTLSConfig)
 				require.Error(t, err)
+				require.Equal(t, test.quitSource, ts.mp.QuitSource())
 				return nil
 			},
 			backend: nil,
@@ -863,6 +899,12 @@ func TestBackendInactive(t *testing.T) {
 			proxy: ts.checkConnClosed4Proxy,
 			backend: func(packetIO *pnet.PacketIO) error {
 				return packetIO.Close()
+			},
+		},
+		{
+			proxy: func(clientIO, backendIO *pnet.PacketIO) error {
+				require.Equal(t, SrcBackendQuit, ts.mp.QuitSource())
+				return nil
 			},
 		},
 	}

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -248,6 +248,7 @@ func TestNormalRedirect(t *testing.T) {
 				ts.mp.Redirect(ts.tc.backendListener.Addr().String())
 				ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(t, eventSucceed)
 				require.NotEqual(t, backend1, ts.mp.backendIO.Load())
+				require.Equal(t, SrcClientQuit, ts.mp.QuitSource())
 				return nil
 			},
 			backend: ts.redirectSucceed4Backend,
@@ -352,6 +353,7 @@ func TestRedirectInTxn(t *testing.T) {
 				require.NoError(t, err)
 				ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(t, eventFail)
 				require.Equal(t, backend1, ts.mp.backendIO.Load())
+				require.Equal(t, SrcClientQuit, ts.mp.QuitSource())
 				return nil
 			},
 			backend: func(packetIO *pnet.PacketIO) error {

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -799,6 +799,9 @@ func TestGetBackendIO(t *testing.T) {
 			if err != nil && len(s) > 0 {
 				badAddrs[s] = struct{}{}
 			}
+			if err != nil {
+				require.Equal(t, SrcProxyErr, connContext.QuitSource())
+			}
 		},
 	}
 	mgr := NewBackendConnManager(logger.CreateLoggerForTest(t), handler, 0, &BCConfig{})

--- a/pkg/proxy/backend/error.go
+++ b/pkg/proxy/backend/error.go
@@ -27,6 +27,11 @@ const (
 	capabilityErrMsg = "Verify TiDB capability failed, please upgrade TiDB"
 )
 
+var (
+	ErrClientConn  = errors.New("this is an error from client")
+	ErrBackendConn = errors.New("this is an error from backend")
+)
+
 // UserError is returned to the client.
 // err is used to log and userMsg is used to report to the user.
 type UserError struct {

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -31,32 +31,32 @@ const (
 type ErrorSource int
 
 const (
-	// SrcClientConn includes: client quit; bad client conn
-	SrcClientConn ErrorSource = iota
+	// SrcClientQuit includes: client quit; bad client conn
+	SrcClientQuit ErrorSource = iota
 	// SrcClientErr includes: wrong password; mal format packet
 	SrcClientErr
 	// SrcProxyQuit includes: proxy graceful shutdown
 	SrcProxyQuit
 	// SrcProxyErr includes: cannot get backend list; capability negotiation
 	SrcProxyErr
-	// SrcBackendConn includes: backend quit
-	SrcBackendConn
+	// SrcBackendQuit includes: backend quit
+	SrcBackendQuit
 	// SrcBackendErr is reserved
 	SrcBackendErr
 )
 
 func (es ErrorSource) String() string {
 	switch es {
-	case SrcClientConn:
-		return "client disconnect"
+	case SrcClientQuit:
+		return "client quit"
 	case SrcClientErr:
 		return "client error"
 	case SrcProxyQuit:
 		return "proxy shutdown"
 	case SrcProxyErr:
 		return "proxy error"
-	case SrcBackendConn:
-		return "backend disconnect"
+	case SrcBackendQuit:
+		return "backend quit"
 	case SrcBackendErr:
 		return "backend error"
 	}

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -28,6 +28,41 @@ const (
 	ConnContextKeyTLSState ConnContextKey = "tls-state"
 )
 
+type ErrorSource int
+
+const (
+	// SrcClientConn includes: client quit; bad client conn
+	SrcClientConn ErrorSource = iota
+	// SrcClientErr includes: wrong password; mal format packet
+	SrcClientErr
+	// SrcProxyQuit includes: proxy graceful shutdown
+	SrcProxyQuit
+	// SrcProxyErr includes: cannot get backend list; capability negotiation
+	SrcProxyErr
+	// SrcBackendConn includes: backend quit
+	SrcBackendConn
+	// SrcBackendErr is reserved
+	SrcBackendErr
+)
+
+func (es ErrorSource) String() string {
+	switch es {
+	case SrcClientConn:
+		return "client disconnect"
+	case SrcClientErr:
+		return "client error"
+	case SrcProxyQuit:
+		return "proxy shutdown"
+	case SrcProxyErr:
+		return "proxy error"
+	case SrcBackendConn:
+		return "backend disconnect"
+	case SrcBackendErr:
+		return "backend error"
+	}
+	return "unknown"
+}
+
 var _ HandshakeHandler = (*DefaultHandshakeHandler)(nil)
 
 type ConnContext interface {
@@ -35,6 +70,7 @@ type ConnContext interface {
 	ServerAddr() string
 	ClientInBytes() uint64
 	ClientOutBytes() uint64
+	QuitSource() ErrorSource
 	SetValue(key, val any)
 	Value(key any) any
 }

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -17,19 +17,13 @@ package client
 import (
 	"context"
 	"crypto/tls"
-	"io"
 	"net"
-	"os"
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/pingcap/tidb/parser/mysql"
 	"go.uber.org/zap"
-)
-
-var (
-	ErrClientConn = errors.New("this is an error from client")
 )
 
 type ClientConnection struct {
@@ -44,7 +38,7 @@ func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *t
 	hsHandler backend.HandshakeHandler, connID uint64, bcConfig *backend.BCConfig) *ClientConnection {
 	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, bcConfig)
 	opts := make([]pnet.PacketIOption, 0, 2)
-	opts = append(opts, pnet.WithWrapError(ErrClientConn))
+	opts = append(opts, pnet.WithWrapError(backend.ErrClientConn))
 	if bcConfig.ProxyProtocol {
 		opts = append(opts, pnet.WithProxy)
 	}
@@ -72,12 +66,12 @@ func (cc *ClientConnection) Run(ctx context.Context) {
 	}
 
 clean:
-	clientErr := errors.Is(err, ErrClientConn)
-	// EOF: client closes; DeadlineExceeded: graceful shutdown; Closed: shut down.
-	if clientErr && (errors.Is(err, io.EOF) || errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, net.ErrClosed)) {
-		return
+	src := cc.connMgr.QuitSource()
+	switch src {
+	case backend.SrcClientConn, backend.SrcClientErr, backend.SrcProxyQuit:
+	default:
+		cc.logger.Info(msg, zap.Error(err), zap.Stringer("quit source", src))
 	}
-	cc.logger.Info(msg, zap.Error(err), zap.Bool("clientErr", clientErr), zap.Bool("serverErr", !clientErr))
 }
 
 func (cc *ClientConnection) processMsg(ctx context.Context) error {

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -68,7 +68,7 @@ func (cc *ClientConnection) Run(ctx context.Context) {
 clean:
 	src := cc.connMgr.QuitSource()
 	switch src {
-	case backend.SrcClientConn, backend.SrcClientErr, backend.SrcProxyQuit:
+	case backend.SrcClientQuit, backend.SrcClientErr, backend.SrcProxyQuit:
 	default:
 		cc.logger.Info(msg, zap.Error(err), zap.Stringer("quit source", src))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #235

Problem Summary:
Gateway needs to know whether the client is disconnected normally or not.

What is changed and how it works:
Add QuitSource() to ConnContext. There are multiple sources.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
