### PR TITLE
router: remove connMap

### DIFF
--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -48,8 +48,8 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt, err := router.NewScoreBasedRouter(logger.Named("router"), mgr.httpCli, fetcher, config.NewDefaultHealthCheckConfig())
-	if err != nil {
+	rt := router.NewScoreBasedRouter(logger.Named("router"))
+	if err := rt.Init(mgr.httpCli, fetcher, config.NewDefaultHealthCheckConfig()); err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}
 	return &Namespace{

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -73,10 +73,11 @@ const (
 // RedirectableConn indicates a redirect-able connection.
 type RedirectableConn interface {
 	SetEventReceiver(receiver ConnEventReceiver)
+	SetValue(key, val any)
+	Value(key any) any
 	Redirect(addr string)
 	GetRedirectingAddr() string
 	NotifyBackendStatus(status BackendStatus)
-	ConnectionID() uint64
 }
 
 // backendWrapper contains the connections on the backend.
@@ -86,7 +87,6 @@ type backendWrapper struct {
 	// A list of *connWrapper and is ordered by the connecting or redirecting time.
 	// connList and connMap include moving out connections but not moving in connections.
 	connList *glist.List[*connWrapper]
-	connMap  map[uint64]*glist.Element[*connWrapper]
 }
 
 // score calculates the score of the backend. Larger score indicates higher load.

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -41,6 +41,14 @@ type mockRedirectableConn struct {
 	receiver ConnEventReceiver
 }
 
+func newMockRedirectableConn(t *testing.T, id uint64) *mockRedirectableConn {
+	return &mockRedirectableConn{
+		t:      t,
+		connID: id,
+		kv:     make(map[any]any),
+	}
+}
+
 func (conn *mockRedirectableConn) SetEventReceiver(receiver ConnEventReceiver) {
 	conn.Lock()
 	conn.receiver = receiver
@@ -124,10 +132,7 @@ func newRouterTester(t *testing.T) *routerTester {
 
 func (tester *routerTester) createConn() *mockRedirectableConn {
 	tester.connID++
-	return &mockRedirectableConn{
-		t:      tester.t,
-		connID: tester.connID,
-	}
+	return newMockRedirectableConn(tester.t, tester.connID)
 }
 
 func (tester *routerTester) addBackends(num int) {
@@ -648,10 +653,7 @@ func TestConcurrency(t *testing.T) {
 
 					if conn == nil {
 						// not connected, connect
-						conn = &mockRedirectableConn{
-							t:      t,
-							connID: connID,
-						}
+						conn = newMockRedirectableConn(t, connID)
 						selector := router.GetBackendSelector()
 						addr, err := selector.Next()
 						require.NoError(t, err)

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -131,7 +131,6 @@ type BackendConnManager struct {
 	backendTLS       *tls.Config
 	handshakeHandler HandshakeHandler
 	ctxmap           sync.Map
-	rtdata           atomic.Value
 	connectionID     uint64
 }
 
@@ -160,14 +159,6 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 // It returns the ID of the frontend connection. The ID stays still after session migration.
 func (mgr *BackendConnManager) ConnectionID() uint64 {
 	return mgr.connectionID
-}
-
-func (mgr *BackendConnManager) SetRouterData(t any) {
-	mgr.rtdata.Store(t)
-}
-
-func (mgr *BackendConnManager) GetRouterData() any {
-	return mgr.rtdata.Load()
 }
 
 // Connect connects to the first backend and then start watching redirection signals.

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -131,6 +131,7 @@ type BackendConnManager struct {
 	backendTLS       *tls.Config
 	handshakeHandler HandshakeHandler
 	ctxmap           sync.Map
+	rtdata           atomic.Value
 	connectionID     uint64
 }
 
@@ -159,6 +160,14 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 // It returns the ID of the frontend connection. The ID stays still after session migration.
 func (mgr *BackendConnManager) ConnectionID() uint64 {
 	return mgr.connectionID
+}
+
+func (mgr *BackendConnManager) SetRouterData(t any) {
+	mgr.rtdata.Store(t)
+}
+
+func (mgr *BackendConnManager) GetRouterData() any {
+	return mgr.rtdata.Load()
 }
 
 // Connect connects to the first backend and then start watching redirection signals.


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Instead of keep a map of `id <-> conn`, we could store additional router data, e.g. pointer to the list element, into `conn` directly.

What is changed and how it works:

1. Split `NewScoreBasedRouter` into two functions, another one is `Init`. It is to cleanup initialization in `router_test.go`. Gateway may need to adapt it.
2. Add `SetValue` and `Value`. It is used to store `Elemet[*connWrapper]`. We can locate the list element instantly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
