### PR TITLE
keepalive: RT timeout parameters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,4 +63,4 @@ jobs:
       ref: ${{ inputs.ref || github.ref }}
       debug: false
       target: "lint test"
-      all_platform: false
+      all_platform: true

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -46,9 +46,10 @@ type Metrics struct {
 
 type KeepAlive struct {
 	Enabled bool          `yaml:"enabled,omitempty" toml:"enabled,omitempty" json:"enabled,omitempty"`
-	Cnt     int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
 	Idle    time.Duration `yaml:"idle,omitempty" toml:"idle,omitempty" json:"idle,omitempty"`
+	Cnt     int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
 	Intvl   time.Duration `yaml:"intvl,omitempty" toml:"intvl,omitempty" json:"intvl,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty" toml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 type ProxyServerOnline struct {
@@ -123,13 +124,15 @@ type Security struct {
 func DefaultKeepAlive() (frontend, backendHealthy, backendUnhealthy KeepAlive) {
 	frontend.Enabled = true
 	backendHealthy.Enabled = true
-	backendHealthy.Cnt = 5
 	backendHealthy.Idle = 60 * time.Second
+	backendHealthy.Cnt = 5
 	backendHealthy.Intvl = 5 * time.Second
+	backendHealthy.Timeout = 30 * time.Second
 	backendUnhealthy.Enabled = true
-	backendUnhealthy.Cnt = 2
 	backendUnhealthy.Idle = 1 * time.Second
+	backendUnhealthy.Cnt = 2
 	backendUnhealthy.Intvl = 1 * time.Second
+	backendUnhealthy.Timeout = 3 * time.Second
 	return
 }
 

--- a/pkg/proxy/keepalive/keepalive_default.go
+++ b/pkg/proxy/keepalive/keepalive_default.go
@@ -17,11 +17,9 @@
 package keepalive
 
 import (
-	"syscall"
-
 	"github.com/pingcap/TiProxy/lib/config"
 )
 
-func setKeepalive(syscn syscall.RawConn, cfg config.KeepAlive) error {
+func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
 	return nil
 }

--- a/pkg/proxy/keepalive/keepalive_unix.go
+++ b/pkg/proxy/keepalive/keepalive_unix.go
@@ -20,29 +20,23 @@ import (
 	"syscall"
 
 	"github.com/pingcap/TiProxy/lib/config"
-	"github.com/pingcap/TiProxy/lib/util/errors"
 )
 
-func setKeepalive(syscn syscall.RawConn, cfg config.KeepAlive) error {
-	var serr error
-	return errors.Collect(ErrKeepAlive, serr, syscn.Control(func(fd uintptr) {
-		if val := cfg.Idle.Seconds(); val > 0 {
-			serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(val))
-			if serr != nil {
-				return
-			}
+func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
+	if val := cfg.Idle.Seconds(); val > 0 {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPIDLE, int(val)); err != nil {
+			return err
 		}
-		if cfg.Cnt > 0 {
-			serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, cfg.Cnt)
-			if serr != nil {
-				return
-			}
+	}
+	if cfg.Cnt > 0 {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPCNT, cfg.Cnt); err != nil {
+			return err
 		}
-		if val := cfg.Intvl.Seconds(); val > 0 {
-			serr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(val))
-			if serr != nil {
-				return
-			}
+	}
+	if val := cfg.Intvl.Seconds(); val > 0 {
+		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPINTVL, int(val)); err != nil {
+			return err
 		}
-	}))
+	}
+	return nil
 }

--- a/pkg/proxy/keepalive/timeout_darwin.go
+++ b/pkg/proxy/keepalive/timeout_darwin.go
@@ -22,27 +22,6 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 )
 
-const (
-	// missing in older darwin
-	_TCP_KEEPINTVL = 0x101
-	_TCP_KEEPCNT   = 0x102
-)
-
-func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
-	if val := cfg.Idle.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(val)); err != nil {
-			return err
-		}
-	}
-	if cfg.Cnt > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPCNT, cfg.Cnt); err != nil {
-			return err
-		}
-	}
-	if val := cfg.Intvl.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPINTVL, int(val)); err != nil {
-			return err
-		}
-	}
-	return nil
+func setTimeout(fd uintptr, cfg config.KeepAlive) error {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_RXT_CONNDROPTIME, int(cfg.Timeout.Seconds()))
 }

--- a/pkg/proxy/keepalive/timeout_default.go
+++ b/pkg/proxy/keepalive/timeout_default.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build !(windows || linux || darwin)
 
 // Copyright 2023 PingCAP, Inc.
 //
@@ -17,32 +17,9 @@
 package keepalive
 
 import (
-	"syscall"
-
 	"github.com/pingcap/TiProxy/lib/config"
 )
 
-const (
-	// missing in older darwin
-	_TCP_KEEPINTVL = 0x101
-	_TCP_KEEPCNT   = 0x102
-)
-
-func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
-	if val := cfg.Idle.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(val)); err != nil {
-			return err
-		}
-	}
-	if cfg.Cnt > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPCNT, cfg.Cnt); err != nil {
-			return err
-		}
-	}
-	if val := cfg.Intvl.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPINTVL, int(val)); err != nil {
-			return err
-		}
-	}
+func setTimeout(fd uintptr, cfg config.KeepAlive) error {
 	return nil
 }

--- a/pkg/proxy/keepalive/timeout_linux.go
+++ b/pkg/proxy/keepalive/timeout_linux.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build linux
 
 // Copyright 2023 PingCAP, Inc.
 //
@@ -22,27 +22,8 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 )
 
-const (
-	// missing in older darwin
-	_TCP_KEEPINTVL = 0x101
-	_TCP_KEEPCNT   = 0x102
-)
+const _TCP_USER_TIMEOUT = 0x12
 
-func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
-	if val := cfg.Idle.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(val)); err != nil {
-			return err
-		}
-	}
-	if cfg.Cnt > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPCNT, cfg.Cnt); err != nil {
-			return err
-		}
-	}
-	if val := cfg.Intvl.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPINTVL, int(val)); err != nil {
-			return err
-		}
-	}
-	return nil
+func setTimeout(fd uintptr, cfg config.KeepAlive) error {
+	return syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_USER_TIMEOUT, int(cfg.Timeout.Milliseconds()))
 }

--- a/pkg/proxy/keepalive/timeout_windows.go
+++ b/pkg/proxy/keepalive/timeout_windows.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build windows
 
 // Copyright 2023 PingCAP, Inc.
 //
@@ -22,27 +22,8 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 )
 
-const (
-	// missing in older darwin
-	_TCP_KEEPINTVL = 0x101
-	_TCP_KEEPCNT   = 0x102
-)
+const _TCP_MAXRT = 5
 
-func setKeepalive(fd uintptr, cfg config.KeepAlive) error {
-	if val := cfg.Idle.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_KEEPALIVE, int(val)); err != nil {
-			return err
-		}
-	}
-	if cfg.Cnt > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPCNT, cfg.Cnt); err != nil {
-			return err
-		}
-	}
-	if val := cfg.Intvl.Seconds(); val > 0 {
-		if err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, _TCP_KEEPINTVL, int(val)); err != nil {
-			return err
-		}
-	}
-	return nil
+func setTimeout(fd uintptr, cfg config.KeepAlive) error {
+	return syscall.SetsockoptInt(syscall.Handle(fd), syscall.IPPROTO_TCP, _TCP_MAXRT, int(cfg.Timeout.Seconds()))
 }

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/security"
@@ -268,10 +269,18 @@ func TestKeepAlive(t *testing.T) {
 	stls, ctls, err := security.CreateTLSConfigForTest()
 	require.NoError(t, err)
 	frontend, backendHealthy, backendUnhealthy := config.DefaultKeepAlive()
+	backendUnhealthy.Timeout = 2 * time.Second
+	backendUnhealthy.Idle = time.Second
+	backendUnhealthy.Cnt = 1
+	backendUnhealthy.Intvl = time.Second
 	testTCPConn(t,
 		func(t *testing.T, cli *PacketIO) {
 			require.NoError(t, cli.SetKeepalive(frontend))
 			require.NoError(t, cli.ClientTLSHandshake(ctls))
+			// timeout by keepalive + timeout
+			time.Sleep(backendUnhealthy.Timeout)
+			_, err := cli.ReadPacket()
+			require.Error(t, err)
 		},
 		func(t *testing.T, srv *PacketIO) {
 			require.NoError(t, srv.SetKeepalive(backendHealthy))
@@ -279,6 +288,6 @@ func TestKeepAlive(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, srv.SetKeepalive(backendUnhealthy))
 		},
-		10,
+		2,
 	)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #229

Problem Summary: When `ACK` not arrived in time, the connection will abort.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
