### PR TITLE
config: adjust keep alive parameters and add comments

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -47,12 +47,12 @@ type Metrics struct {
 type KeepAlive struct {
 	Enabled bool `yaml:"enabled,omitempty" toml:"enabled,omitempty" json:"enabled,omitempty"`
 	// Idle, Cnt, and Intvl works only when the connection is idle. User packets will interrupt keep-alive.
-	// If the peer crashes and doesn't send FIN, the connection will be closed within Idle+Cnt*Intvl.
+	// If the peer crashes and doesn't send any packets, the connection will be closed within Idle+Cnt*Intvl.
 	Idle  time.Duration `yaml:"idle,omitempty" toml:"idle,omitempty" json:"idle,omitempty"`
 	Cnt   int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
 	Intvl time.Duration `yaml:"intvl,omitempty" toml:"intvl,omitempty" json:"intvl,omitempty"`
 	// Timeout is the timeout of waiting ACK. It works for both user packets and keep-alive.
-	// For keep-alive, the timeout of waiting ACK is min(Timeout, Cnt*Intvl).
+	// It is suggested to be equal or close to Cnt*Intvl.
 	Timeout time.Duration `yaml:"timeout,omitempty" toml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -45,17 +45,25 @@ type Metrics struct {
 }
 
 type KeepAlive struct {
-	Enabled bool          `yaml:"enabled,omitempty" toml:"enabled,omitempty" json:"enabled,omitempty"`
-	Idle    time.Duration `yaml:"idle,omitempty" toml:"idle,omitempty" json:"idle,omitempty"`
-	Cnt     int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
-	Intvl   time.Duration `yaml:"intvl,omitempty" toml:"intvl,omitempty" json:"intvl,omitempty"`
+	Enabled bool `yaml:"enabled,omitempty" toml:"enabled,omitempty" json:"enabled,omitempty"`
+	// Idle, Cnt, and Intvl works only when the connection is idle. User packets will interrupt keep-alive.
+	// If the peer crashes and doesn't send FIN, the connection will be closed within Idle+Cnt*Intvl.
+	Idle  time.Duration `yaml:"idle,omitempty" toml:"idle,omitempty" json:"idle,omitempty"`
+	Cnt   int           `yaml:"cnt,omitempty" toml:"cnt,omitempty" json:"cnt,omitempty"`
+	Intvl time.Duration `yaml:"intvl,omitempty" toml:"intvl,omitempty" json:"intvl,omitempty"`
+	// Timeout is the timeout of waiting ACK. It works for both user packets and keep-alive.
+	// For keep-alive, the timeout of waiting ACK is min(Timeout, Cnt*Intvl).
 	Timeout time.Duration `yaml:"timeout,omitempty" toml:"timeout,omitempty" json:"timeout,omitempty"`
 }
 
 type ProxyServerOnline struct {
-	MaxConnections             uint64    `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
-	FrontendKeepalive          KeepAlive `yaml:"frontend-keepalive" toml:"frontend-keepalive" json:"frontend-keepalive"`
-	BackendHealthyKeepalive    KeepAlive `yaml:"backend-healthy-keepalive" toml:"backend-healthy-keepalive" json:"backend-healthy-keepalive"`
+	MaxConnections    uint64    `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
+	FrontendKeepalive KeepAlive `yaml:"frontend-keepalive" toml:"frontend-keepalive" json:"frontend-keepalive"`
+	// BackendHealthyKeepalive applies when the observer treats the backend as healthy.
+	// The config values should be conservative to save CPU and tolerate network fluctuation.
+	BackendHealthyKeepalive KeepAlive `yaml:"backend-healthy-keepalive" toml:"backend-healthy-keepalive" json:"backend-healthy-keepalive"`
+	// BackendUnhealthyKeepalive applies when the observer treats the backend as unhealthy.
+	// The config values can be aggressive because the backend may stop anytime.
 	BackendUnhealthyKeepalive  KeepAlive `yaml:"backend-unhealthy-keepalive" toml:"backend-unhealthy-keepalive" json:"backend-unhealthy-keepalive"`
 	ProxyProtocol              string    `yaml:"proxy-protocol,omitempty" toml:"proxy-protocol,omitempty" json:"proxy-protocol,omitempty"`
 	GracefulWaitBeforeShutdown int       `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty"`
@@ -126,13 +134,13 @@ func DefaultKeepAlive() (frontend, backendHealthy, backendUnhealthy KeepAlive) {
 	backendHealthy.Enabled = true
 	backendHealthy.Idle = 60 * time.Second
 	backendHealthy.Cnt = 5
-	backendHealthy.Intvl = 5 * time.Second
-	backendHealthy.Timeout = 30 * time.Second
+	backendHealthy.Intvl = 3 * time.Second
+	backendHealthy.Timeout = 15 * time.Second
 	backendUnhealthy.Enabled = true
-	backendUnhealthy.Idle = 1 * time.Second
-	backendUnhealthy.Cnt = 2
+	backendUnhealthy.Idle = 10 * time.Second
+	backendUnhealthy.Cnt = 5
 	backendUnhealthy.Intvl = 1 * time.Second
-	backendUnhealthy.Timeout = 3 * time.Second
+	backendUnhealthy.Timeout = 5 * time.Second
 	return
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close none

Problem Summary:
Now that we have TCP timeout, we can make keep alive parameters less aggressive, because it only works when the client is idle.
Besides, 30s is too long for a backend to respond. The client cannot wait for 30s.

What is changed and how it works:
- Adjust healthy keep alive to 75s and timeout to 15s
- Adjust unhealthy keep alive to 15s and timeout to 5s

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
