### PR TITLE
manager: remove expiration judgement and reload certs periodically

### DIFF
--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -255,12 +255,15 @@ func TestAutoCerts(t *testing.T) {
 	ci, tcfg, err := NewCert(lg, cfg, true)
 	require.NoError(t, err)
 	require.NotNil(t, tcfg)
+	cert1 := ci.cert.Load().(*tls.Certificate)
 	expire1 := getExpireTime(t, ci)
 	require.True(t, ci.autoCertExp.Load() < expire1.Unix())
 
 	// The cert will not be recreated now.
 	ci.cfg.AutoExpireDuration = (DefaultCertExpiration - time.Hour).String()
 	require.NoError(t, ci.Reload(lg))
+	cert2 := ci.cert.Load().(*tls.Certificate)
+	require.Equal(t, cert1, cert2)
 	expire2 := getExpireTime(t, ci)
 	require.Equal(t, expire1, expire2)
 


### PR DESCRIPTION
<!--

Thank you for contributing to Weir!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #243

Problem Summary:
Currently, the certs are reloaded when it's almost expired. However, if the user wants Bring Your Own Key, he should not care when the certs will expire.

What is changed and how it works:
- Remove `Cert.expire` and always reload the certs.
- For auto certs, recreate it in advance.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change (Don't forget to [add the declarative for API](https://github.com/tikv/pd/blob/master/docs/development.md#updating-api-documentation))
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
