### PR TITLE
proxy: move proxyprotocol as a seperate package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,7 @@ EXECUTABLE_TARGETS := $(patsubst cmd/%,cmd_%,$(wildcard cmd/*))
 
 default: cmd
 
-dev: cmd lint test
-
-cache: build lint test
+dev: build lint test
 
 cmd: $(EXECUTABLE_TARGETS)
 
@@ -55,8 +53,7 @@ gocovmerge:
 tidy:
 	go mod tidy
 	cd lib && go mod tidy
-
-cache:
+build:
 	go build ./...
 	cd lib && go build ./...
 

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
+	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/hack"
 	"go.uber.org/zap"
@@ -65,14 +66,14 @@ func (auth *Authenticator) writeProxyProtocol(clientIO, backendIO *pnet.PacketIO
 	if auth.proxyProtocol {
 		proxy := clientIO.Proxy()
 		if proxy == nil {
-			proxy = &pnet.Proxy{
+			proxy = &proxyprotocol.Proxy{
 				SrcAddress: clientIO.RemoteAddr(),
 				DstAddress: backendIO.RemoteAddr(),
-				Version:    pnet.ProxyVersion2,
+				Version:    proxyprotocol.ProxyVersion2,
 			}
 		}
 		// either from another proxy or directly from clients, we are acting as a proxy
-		proxy.Command = pnet.ProxyCommandProxy
+		proxy.Command = proxyprotocol.ProxyCommandProxy
 		if err := backendIO.WriteProxyV2(proxy); err != nil {
 			return err
 		}

--- a/pkg/proxy/net/packetio_options.go
+++ b/pkg/proxy/net/packetio_options.go
@@ -16,6 +16,8 @@ package net
 
 import (
 	"net"
+
+	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 )
 
 type PacketIOption = func(*PacketIO)
@@ -31,11 +33,15 @@ func WithWrapError(err error) func(pi *PacketIO) {
 }
 
 // WithRemoteAddr
-var _ net.Addr = &originAddr{}
+var _ proxyprotocol.AddressWrapper = &originAddr{}
 
 type originAddr struct {
 	net.Addr
 	addr string
+}
+
+func (o *originAddr) Unwrap() net.Addr {
+	return o.Addr
 }
 
 func (o *originAddr) String() string {
@@ -46,11 +52,4 @@ func WithRemoteAddr(readdr string, addr net.Addr) func(pi *PacketIO) {
 	return func(pi *PacketIO) {
 		pi.remoteAddr = &originAddr{Addr: addr, addr: readdr}
 	}
-}
-
-func unwrapOriginAddr(addr net.Addr) net.Addr {
-	if oaddr, ok := addr.(*originAddr); ok {
-		return oaddr.Addr
-	}
-	return addr
 }

--- a/pkg/proxy/net/proxy.go
+++ b/pkg/proxy/net/proxy.go
@@ -17,152 +17,17 @@ package net
 import (
 	"bytes"
 	"io"
-	"net"
 
 	"github.com/pingcap/TiProxy/lib/util/errors"
+	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 )
 
-var (
-	ErrAddressFamilyMismatch = errors.New("address family between source and target mismatched")
-)
-
-type ProxyVersion int
-
-const (
-	ProxyVersion2 ProxyVersion = iota + 2
-)
-
-type ProxyCommand int
-
-const (
-	ProxyCommandLocal ProxyCommand = iota
-	ProxyCommandProxy
-)
-
-type ProxyAddressFamily int
-
-const (
-	ProxyAFUnspec ProxyAddressFamily = iota
-	ProxyAFINet
-	ProxyAFINet6
-	ProxyAFUnix
-)
-
-type ProxyNetwork int
-
-const (
-	ProxyNetworkUnspec ProxyNetwork = iota
-	ProxyNetworkStream
-	ProxyNetworkDgram
-)
-
-type ProxyTlvType int
-
-const (
-	ProxyTlvALPN ProxyTlvType = iota + 0x01
-	ProxyTlvAuthority
-	ProxyTlvCRC32C
-	ProxyTlvNoop
-	ProxyTlvUniqueID
-	ProxyTlvSSL ProxyTlvType = iota + 0x20
-	ProxyTlvSSLCN
-	ProxyTlvSSLCipher
-	ProxyTlvSSLSignALG
-	ProxyTlvSSLKeyALG
-	ProxyTlvNetns ProxyTlvType = iota + 0x30
-)
-
-type ProxyTlv struct {
-	content []byte
-	typ     ProxyTlvType
-}
-
-type Proxy struct {
-	SrcAddress net.Addr
-	DstAddress net.Addr
-	TLV        []ProxyTlv
-	Version    ProxyVersion
-	Command    ProxyCommand
-}
-
-func (p *Proxy) ToBytes() ([]byte, error) {
-	magicLen := len(proxyV2Magic)
-	buf := make([]byte, magicLen+4)
-	_ = copy(buf, proxyV2Magic)
-	buf[magicLen] = byte(p.Version<<4) | byte(p.Command&0xF)
-
-	addressFamily := ProxyAFUnspec
-	network := ProxyNetworkUnspec
-
-	srcAddr := unwrapOriginAddr(p.SrcAddress)
-	dstAddr := unwrapOriginAddr(p.DstAddress)
-
-	switch sadd := srcAddr.(type) {
-	case *net.TCPAddr:
-		addressFamily = ProxyAFINet
-		if len(sadd.IP) == net.IPv6len {
-			addressFamily = ProxyAFINet6
-		}
-		network = ProxyNetworkStream
-		dadd, ok := dstAddr.(*net.TCPAddr)
-		if !ok {
-			return nil, ErrAddressFamilyMismatch
-		}
-		buf = append(buf, sadd.IP...)
-		buf = append(buf, dadd.IP...)
-		buf = append(buf, byte(sadd.Port>>8), byte(sadd.Port))
-		buf = append(buf, byte(dadd.Port>>8), byte(dadd.Port))
-	case *net.UDPAddr:
-		addressFamily = ProxyAFINet
-		if len(sadd.IP) == net.IPv6len {
-			addressFamily = ProxyAFINet6
-		}
-		network = ProxyNetworkDgram
-		dadd, ok := dstAddr.(*net.UDPAddr)
-		if !ok {
-			return nil, ErrAddressFamilyMismatch
-		}
-		buf = append(buf, sadd.IP...)
-		buf = append(buf, dadd.IP...)
-		buf = append(buf, byte(sadd.Port>>8), byte(sadd.Port))
-		buf = append(buf, byte(dadd.Port>>8), byte(dadd.Port))
-	case *net.UnixAddr:
-		addressFamily = ProxyAFUnix
-		switch sadd.Net {
-		case "unix":
-			network = ProxyNetworkStream
-		case "unixdgram":
-			network = ProxyNetworkDgram
-		}
-		dadd, ok := dstAddr.(*net.UnixAddr)
-		if !ok {
-			return nil, ErrAddressFamilyMismatch
-		}
-		buf = append(buf, []byte(sadd.Name)...)
-		buf = append(buf, []byte(dadd.Name)...)
-	}
-	buf[magicLen+1] = byte(addressFamily<<4) | byte(network&0xF)
-
-	for _, tlv := range p.TLV {
-		buf = append(buf, byte(tlv.typ))
-		tlen := len(tlv.content)
-		buf = append(buf, byte(tlen>>8), byte(tlen))
-		buf = append(buf, tlv.content...)
-	}
-
-	length := len(buf) - 4 - magicLen
-	buf[magicLen+2] = byte(length >> 8)
-	buf[magicLen+3] = byte(length)
-
-	return buf, nil
-}
-
-func (p *PacketIO) parseProxyV2() (*Proxy, error) {
+func (p *PacketIO) parseProxyV2() (*proxyprotocol.Proxy, error) {
 	rem, err := p.buf.Peek(8)
 	if err != nil {
 		return nil, errors.WithStack(errors.Wrap(ErrReadConn, err))
 	}
-	if !bytes.Equal(rem, proxyV2Magic[4:]) {
+	if !bytes.Equal(rem, proxyprotocol.MagicV2[4:]) {
 		return nil, nil
 	}
 
@@ -173,118 +38,17 @@ func (p *PacketIO) parseProxyV2() (*Proxy, error) {
 	}
 	p.inBytes += 8
 
-	var hdr [4]byte
-
-	if _, err := io.ReadFull(p.buf, hdr[:]); err != nil {
-		return nil, errors.WithStack(err)
+	m, n, err := proxyprotocol.ParseProxyV2(p.buf)
+	p.inBytes += uint64(n)
+	if err == nil {
+		// set RemoteAddr in case of proxy.
+		p.remoteAddr = m.SrcAddress
 	}
-	p.inBytes += 4
-
-	m := &Proxy{}
-	m.Version = ProxyVersion(hdr[0] >> 4)
-	m.Command = ProxyCommand(hdr[0] & 0xF)
-
-	buf := make([]byte, int(hdr[2])<<8|int(hdr[3]))
-	if _, err := io.ReadFull(p.buf, buf); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	p.inBytes += uint64(len(buf))
-
-	addressFamily := ProxyAddressFamily(hdr[1] >> 4)
-	network := ProxyNetwork(hdr[1] & 0xF)
-	switch addressFamily {
-	case ProxyAFINet:
-		fallthrough
-	case ProxyAFINet6:
-		length := 4
-		if addressFamily == ProxyAFINet6 {
-			length = 16
-		}
-		if len(buf) < length*2+4 {
-			// TODO: logging
-			break
-		}
-		saddr := net.IP(buf[:length])
-		daddr := net.IP(buf[length : length*2])
-		sport := int(buf[2*length])<<8 | int(buf[2*length+1])
-		dport := int(buf[2*length+2])<<8 | int(buf[2*length+3])
-		switch network {
-		case ProxyNetworkStream:
-			m.SrcAddress = &net.TCPAddr{
-				IP:   saddr,
-				Port: sport,
-			}
-			m.DstAddress = &net.TCPAddr{
-				IP:   daddr,
-				Port: dport,
-			}
-		case ProxyNetworkDgram:
-			m.SrcAddress = &net.UDPAddr{
-				IP:   saddr,
-				Port: sport,
-			}
-			m.DstAddress = &net.UDPAddr{
-				IP:   daddr,
-				Port: dport,
-			}
-		default:
-			// TODO: logging
-		}
-		buf = buf[length*2+4:]
-	case ProxyAFUnix:
-		if len(buf) < 216 {
-			// TODO: logging
-			break
-		}
-		saddr := string(buf[:108])
-		daddr := string(buf[108:216])
-		switch network {
-		case ProxyNetworkStream:
-			m.SrcAddress = &net.UnixAddr{
-				Name: saddr,
-				Net:  "unix",
-			}
-			m.DstAddress = &net.UnixAddr{
-				Name: daddr,
-				Net:  "unix",
-			}
-		case ProxyNetworkDgram:
-			m.SrcAddress = &net.UnixAddr{
-				Name: saddr,
-				Net:  "unixdgram",
-			}
-			m.DstAddress = &net.UnixAddr{
-				Name: daddr,
-				Net:  "unixdgram",
-			}
-		default:
-			// TODO: logging
-		}
-		buf = buf[216:]
-	default:
-		buf = buf[len(buf):]
-	}
-
-	for len(buf) >= 3 {
-		typ := ProxyTlvType(buf[0])
-		length := int(buf[1])<<8 | int(buf[2])
-		if len(buf) < length+3 {
-			length = len(buf) - 3
-		}
-		m.TLV = append(m.TLV, ProxyTlv{
-			typ:     typ,
-			content: buf[3 : 3+length],
-		})
-		buf = buf[3+length:]
-	}
-
-	// set RemoteAddr in case of proxy.
-	p.remoteAddr = m.SrcAddress
-	return m, nil
+	return m, err
 }
 
 // WriteProxyV2 should only be called at the beginning of connection, before any write operations.
-func (p *PacketIO) WriteProxyV2(m *Proxy) error {
+func (p *PacketIO) WriteProxyV2(m *proxyprotocol.Proxy) error {
 	buf, err := m.ToBytes()
 	if err != nil {
 		return errors.Wrap(ErrWriteConn, err)

--- a/pkg/proxy/proxyprotocol/definition.go
+++ b/pkg/proxy/proxyprotocol/definition.go
@@ -1,0 +1,81 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import "net"
+
+type ProxyVersion int
+
+const (
+	ProxyVersion2 ProxyVersion = iota + 2
+)
+
+type ProxyCommand int
+
+const (
+	ProxyCommandLocal ProxyCommand = iota
+	ProxyCommandProxy
+)
+
+type ProxyAddressFamily int
+
+const (
+	ProxyAFUnspec ProxyAddressFamily = iota
+	ProxyAFINet
+	ProxyAFINet6
+	ProxyAFUnix
+)
+
+type ProxyNetwork int
+
+const (
+	ProxyNetworkUnspec ProxyNetwork = iota
+	ProxyNetworkStream
+	ProxyNetworkDgram
+)
+
+type ProxyTlvType int
+
+const (
+	ProxyTlvALPN ProxyTlvType = iota + 0x01
+	ProxyTlvAuthority
+	ProxyTlvCRC32C
+	ProxyTlvNoop
+	ProxyTlvUniqueID
+	ProxyTlvSSL ProxyTlvType = iota + 0x20
+	ProxyTlvSSLCN
+	ProxyTlvSSLCipher
+	ProxyTlvSSLSignALG
+	ProxyTlvSSLKeyALG
+	ProxyTlvNetns ProxyTlvType = iota + 0x30
+)
+
+type ProxyTlv struct {
+	content []byte
+	typ     ProxyTlvType
+}
+
+type Proxy struct {
+	SrcAddress net.Addr
+	DstAddress net.Addr
+	TLV        []ProxyTlv
+	Version    ProxyVersion
+	Command    ProxyCommand
+}
+
+type AddressWrapper interface {
+	net.Addr
+	Unwrap() net.Addr
+}

--- a/pkg/proxy/proxyprotocol/error.go
+++ b/pkg/proxy/proxyprotocol/error.go
@@ -1,0 +1,21 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import "github.com/pingcap/TiProxy/lib/util/errors"
+
+var (
+	ErrAddressFamilyMismatch = errors.New("address family between source and target mismatched")
+)

--- a/pkg/proxy/proxyprotocol/proxy.go
+++ b/pkg/proxy/proxyprotocol/proxy.go
@@ -1,0 +1,215 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import (
+	"io"
+	"net"
+)
+
+var (
+	MagicV2 = []byte{0xD, 0xA, 0xD, 0xA, 0x0, 0xD, 0xA, 0x51, 0x55, 0x49, 0x54, 0xA}
+)
+
+func unwrapOriginAddr(addr net.Addr) net.Addr {
+	for {
+		v, ok := addr.(AddressWrapper)
+		if !ok {
+			return addr
+		}
+		addr = v.Unwrap()
+	}
+}
+
+func (p *Proxy) ToBytes() ([]byte, error) {
+	magicLen := len(MagicV2)
+	buf := make([]byte, magicLen+4)
+	_ = copy(buf, MagicV2)
+	buf[magicLen] = byte(p.Version<<4) | byte(p.Command&0xF)
+
+	addressFamily := ProxyAFUnspec
+	network := ProxyNetworkUnspec
+
+	srcAddr := unwrapOriginAddr(p.SrcAddress)
+	dstAddr := unwrapOriginAddr(p.DstAddress)
+
+	switch sadd := srcAddr.(type) {
+	case *net.TCPAddr:
+		addressFamily = ProxyAFINet
+		if len(sadd.IP) == net.IPv6len {
+			addressFamily = ProxyAFINet6
+		}
+		network = ProxyNetworkStream
+		dadd, ok := dstAddr.(*net.TCPAddr)
+		if !ok {
+			return nil, ErrAddressFamilyMismatch
+		}
+		buf = append(buf, sadd.IP...)
+		buf = append(buf, dadd.IP...)
+		buf = append(buf, byte(sadd.Port>>8), byte(sadd.Port))
+		buf = append(buf, byte(dadd.Port>>8), byte(dadd.Port))
+	case *net.UDPAddr:
+		addressFamily = ProxyAFINet
+		if len(sadd.IP) == net.IPv6len {
+			addressFamily = ProxyAFINet6
+		}
+		network = ProxyNetworkDgram
+		dadd, ok := dstAddr.(*net.UDPAddr)
+		if !ok {
+			return nil, ErrAddressFamilyMismatch
+		}
+		buf = append(buf, sadd.IP...)
+		buf = append(buf, dadd.IP...)
+		buf = append(buf, byte(sadd.Port>>8), byte(sadd.Port))
+		buf = append(buf, byte(dadd.Port>>8), byte(dadd.Port))
+	case *net.UnixAddr:
+		addressFamily = ProxyAFUnix
+		switch sadd.Net {
+		case "unix":
+			network = ProxyNetworkStream
+		case "unixdgram":
+			network = ProxyNetworkDgram
+		}
+		dadd, ok := dstAddr.(*net.UnixAddr)
+		if !ok {
+			return nil, ErrAddressFamilyMismatch
+		}
+		buf = append(buf, []byte(sadd.Name)...)
+		buf = append(buf, []byte(dadd.Name)...)
+	}
+	buf[magicLen+1] = byte(addressFamily<<4) | byte(network&0xF)
+
+	for _, tlv := range p.TLV {
+		buf = append(buf, byte(tlv.typ))
+		tlen := len(tlv.content)
+		buf = append(buf, byte(tlen>>8), byte(tlen))
+		buf = append(buf, tlv.content...)
+	}
+
+	length := len(buf) - 4 - magicLen
+	buf[magicLen+2] = byte(length >> 8)
+	buf[magicLen+3] = byte(length)
+
+	return buf, nil
+}
+
+func ParseProxyV2(rd io.Reader) (m *Proxy, n int, err error) {
+	var hdr [4]byte
+
+	if _, err = io.ReadFull(rd, hdr[:]); err != nil {
+		return
+	}
+	n += 4
+
+	m = &Proxy{}
+	m.Version = ProxyVersion(hdr[0] >> 4)
+	m.Command = ProxyCommand(hdr[0] & 0xF)
+
+	buf := make([]byte, int(hdr[2])<<8|int(hdr[3]))
+	if _, err = io.ReadFull(rd, buf); err != nil {
+		return
+	}
+	n += len(buf)
+
+	addressFamily := ProxyAddressFamily(hdr[1] >> 4)
+	network := ProxyNetwork(hdr[1] & 0xF)
+	switch addressFamily {
+	case ProxyAFINet:
+		fallthrough
+	case ProxyAFINet6:
+		length := 4
+		if addressFamily == ProxyAFINet6 {
+			length = 16
+		}
+		if len(buf) < length*2+4 {
+			// TODO: logging
+			break
+		}
+		saddr := net.IP(buf[:length])
+		daddr := net.IP(buf[length : length*2])
+		sport := int(buf[2*length])<<8 | int(buf[2*length+1])
+		dport := int(buf[2*length+2])<<8 | int(buf[2*length+3])
+		switch network {
+		case ProxyNetworkStream:
+			m.SrcAddress = &net.TCPAddr{
+				IP:   saddr,
+				Port: sport,
+			}
+			m.DstAddress = &net.TCPAddr{
+				IP:   daddr,
+				Port: dport,
+			}
+		case ProxyNetworkDgram:
+			m.SrcAddress = &net.UDPAddr{
+				IP:   saddr,
+				Port: sport,
+			}
+			m.DstAddress = &net.UDPAddr{
+				IP:   daddr,
+				Port: dport,
+			}
+		default:
+			// TODO: logging
+		}
+		buf = buf[length*2+4:]
+	case ProxyAFUnix:
+		if len(buf) < 216 {
+			// TODO: logging
+			break
+		}
+		saddr := string(buf[:108])
+		daddr := string(buf[108:216])
+		switch network {
+		case ProxyNetworkStream:
+			m.SrcAddress = &net.UnixAddr{
+				Name: saddr,
+				Net:  "unix",
+			}
+			m.DstAddress = &net.UnixAddr{
+				Name: daddr,
+				Net:  "unix",
+			}
+		case ProxyNetworkDgram:
+			m.SrcAddress = &net.UnixAddr{
+				Name: saddr,
+				Net:  "unixdgram",
+			}
+			m.DstAddress = &net.UnixAddr{
+				Name: daddr,
+				Net:  "unixdgram",
+			}
+		default:
+			// TODO: logging
+		}
+		buf = buf[216:]
+	default:
+		buf = buf[len(buf):]
+	}
+
+	for len(buf) >= 3 {
+		typ := ProxyTlvType(buf[0])
+		length := int(buf[1])<<8 | int(buf[2])
+		if len(buf) < length+3 {
+			length = len(buf) - 3
+		}
+		m.TLV = append(m.TLV, ProxyTlv{
+			typ:     typ,
+			content: buf[3 : 3+length],
+		})
+		buf = buf[3+length:]
+	}
+
+	return
+}

--- a/pkg/testkit/main.go
+++ b/pkg/testkit/main.go
@@ -1,0 +1,73 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testkit
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeConn(t *testing.T, a, b func(*testing.T, net.Conn), loop int) {
+	var wg waitgroup.WaitGroup
+	cli, srv := net.Pipe()
+	if ddl, ok := t.Deadline(); ok {
+		require.NoError(t, cli.SetDeadline(ddl))
+		require.NoError(t, srv.SetDeadline(ddl))
+	}
+	for i := 0; i < loop; i++ {
+		wg.Run(func() {
+			a(t, cli)
+			require.NoError(t, cli.Close())
+		})
+		wg.Run(func() {
+			b(t, srv)
+			require.NoError(t, srv.Close())
+		})
+		wg.Wait()
+	}
+}
+
+func TestTCPConn(t *testing.T, a, b func(*testing.T, net.Conn), loop int) {
+	listener, err := net.Listen("tcp", "127.0.0.0:0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, listener.Close())
+	}()
+	var wg waitgroup.WaitGroup
+	for i := 0; i < loop; i++ {
+		wg.Run(func() {
+			cli, err := net.Dial("tcp", listener.Addr().String())
+			require.NoError(t, err)
+			if ddl, ok := t.Deadline(); ok {
+				require.NoError(t, cli.SetDeadline(ddl))
+			}
+			a(t, cli)
+			require.NoError(t, cli.Close())
+		})
+		wg.Run(func() {
+			srv, err := listener.Accept()
+			require.NoError(t, err)
+			if ddl, ok := t.Deadline(); ok {
+				require.NoError(t, srv.SetDeadline(ddl))
+			}
+			b(t, srv)
+			require.NoError(t, srv.Close())
+		})
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #245

Problem Summary: Need to support proxy protocol for HTTP, too. Another point is that, epoll refactor will need a much simpler `PacketIO` and `backend` structure. So we seperate the package.

What is changed and how it works:

1. move `testPipe, testTCP` into `pkg/testkit`
2. seperate proxy protocol
3. add `var _ proxyprotocol.AddressWrapper = &originAddr{}`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
