### PR TITLE
[WIP] net: simplify IsPeerActive

### DIFF
--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testPipeConn(t *testing.T, a func(*testing.T, *PacketIO), b func(*testing.T, *PacketIO), loop int) {
+func testPipeConn(t *testing.T, a, b func(*testing.T, *PacketIO), loop int) {
 	var wg waitgroup.WaitGroup
 	client, server := net.Pipe()
 	cli, srv := NewPacketIO(client), NewPacketIO(server)
@@ -218,7 +218,6 @@ func TestPeerActive(t *testing.T) {
 			ch <- struct{}{} // let srv write packet
 			// ReadPacket still reads the whole data after checking.
 			ch <- struct{}{}
-			require.True(t, cli.IsPeerActive())
 			data, err := cli.ReadPacket()
 			require.NoError(t, err)
 			require.Equal(t, "123", string(data))
@@ -229,7 +228,6 @@ func TestPeerActive(t *testing.T) {
 			require.True(t, cli.IsPeerActive())
 			// upgrade to TLS and try again
 			require.NoError(t, cli.ClientTLSHandshake(ctls))
-			require.True(t, cli.IsPeerActive())
 			data, err = cli.ReadPacket()
 			require.NoError(t, err)
 			require.Equal(t, "123", string(data))


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

Need some refactors on tests.

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #248 

Problem Summary: As title.

What is changed and how it works: Two lines of tests are removed because there is no `read/write` calls before calling `IsPeerActive`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
