### PR TITLE
net: complete some definitions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,5 +62,5 @@ jobs:
     with:
       ref: ${{ inputs.ref || github.ref }}
       debug: false
-      target: "cache"
+      target: "build"
       all_platform: true

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ gocovmerge:
 tidy:
 	go mod tidy
 	cd lib && go mod tidy
+
 build:
 	go build ./...
 	cd lib && go build ./...

--- a/pkg/proxy/backend/metrics.go
+++ b/pkg/proxy/backend/metrics.go
@@ -15,37 +15,14 @@
 package backend
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/pingcap/TiProxy/pkg/metrics"
-	"github.com/pingcap/tidb/parser/mysql"
-)
-
-// The labels are consistent with TiDB.
-var (
-	cmdToLabel = map[byte]string{
-		mysql.ComSleep:            "Sleep",
-		mysql.ComQuit:             "Quit",
-		mysql.ComInitDB:           "InitDB",
-		mysql.ComQuery:            "Query",
-		mysql.ComPing:             "Ping",
-		mysql.ComFieldList:        "FieldList",
-		mysql.ComStmtPrepare:      "StmtPrepare",
-		mysql.ComStmtExecute:      "StmtExecute",
-		mysql.ComStmtFetch:        "StmtFetch",
-		mysql.ComStmtClose:        "StmtClose",
-		mysql.ComStmtSendLongData: "StmtSendLongData",
-		mysql.ComStmtReset:        "StmtReset",
-		mysql.ComSetOption:        "SetOption",
-	}
+	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 )
 
 func addCmdMetrics(cmd byte, addr string, startTime time.Time) {
-	label, ok := cmdToLabel[cmd]
-	if !ok {
-		label = strconv.Itoa(int(cmd))
-	}
+	label := pnet.Command(cmd).String() 
 	metrics.QueryTotalCounter.WithLabelValues(addr, label).Inc()
 
 	// The duration labels are different with TiDB: Labels in TiDB are statement types.
@@ -55,10 +32,7 @@ func addCmdMetrics(cmd byte, addr string, startTime time.Time) {
 }
 
 func readCmdCounter(cmd byte, addr string) (int, error) {
-	label, ok := cmdToLabel[cmd]
-	if !ok {
-		label = strconv.Itoa(int(cmd))
-	}
+	label := pnet.Command(cmd).String() 
 	return metrics.ReadCounter(metrics.QueryTotalCounter.WithLabelValues(addr, label))
 }
 

--- a/pkg/proxy/backend/metrics.go
+++ b/pkg/proxy/backend/metrics.go
@@ -22,7 +22,7 @@ import (
 )
 
 func addCmdMetrics(cmd byte, addr string, startTime time.Time) {
-	label := pnet.Command(cmd).String() 
+	label := pnet.Command(cmd).String()
 	metrics.QueryTotalCounter.WithLabelValues(addr, label).Inc()
 
 	// The duration labels are different with TiDB: Labels in TiDB are statement types.
@@ -32,7 +32,7 @@ func addCmdMetrics(cmd byte, addr string, startTime time.Time) {
 }
 
 func readCmdCounter(cmd byte, addr string) (int, error) {
-	label := pnet.Command(cmd).String() 
+	label := pnet.Command(cmd).String()
 	return metrics.ReadCounter(metrics.QueryTotalCounter.WithLabelValues(addr, label))
 }
 

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
-	"github.com/pingcap/tidb/parser/mysql"
 	"go.uber.org/zap"
 )
 
@@ -85,9 +84,7 @@ func (cc *ClientConnection) processMsg(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		cmd := clientPkt[0]
-		switch cmd {
-		case mysql.ComQuit:
+		if pnet.Command(clientPkt[0]) == pnet.ComQuit {
 			return nil
 		}
 	}

--- a/pkg/proxy/net/command.go
+++ b/pkg/proxy/net/command.go
@@ -1,0 +1,118 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import "fmt"
+
+type Command byte
+
+// Command information. Ref https://dev.mysql.com/doc/dev/mysql-server/latest/my__command_8h.html#ae2ff1badf13d2b8099af8b47831281e1.
+const (
+	ComSleep Command = iota
+	ComQuit
+	ComInitDB
+	ComQuery
+	ComFieldList
+	ComCreateDB
+	ComDropDB
+	ComRefresh
+	ComDeprecated1
+	ComStatistics
+	ComProcessInfo
+	ComConnect
+	ComProcessKill
+	ComDebug
+	ComPing
+	ComTime
+	ComDelayedInsert
+	ComChangeUser
+	ComBinlogDump
+	ComTableDump
+	ComConnectOut
+	ComRegisterSlave
+	ComStmtPrepare
+	ComStmtExecute
+	ComStmtSendLongData
+	ComStmtClose
+	ComStmtReset
+	ComSetOption
+	ComStmtFetch
+	ComDaemon
+	ComBinlogDumpGtid
+	ComResetConnection
+	ComEnd // Not a real command
+)
+
+// Ref https://github.com/pingcap/tidb/blob/master/server/metrics/metrics.go#L51. Should be same.
+var commandStrs = [ComEnd]string{
+	"Sleep",
+	"Quit",
+	"InitDB",
+	"Query",
+	"FieldList",
+	"CreateDB",
+	"DropDB",
+	"Refresh",
+	"(DEPRECATED)Shutdown",
+	"Statistics",
+	"ProcessInfo",
+	"Connect",
+	"ProcessKill",
+	"Debug",
+	"Ping",
+	"Time",
+	"DelayedInsert",
+	"ChangeUser",
+	"BinlogDump",
+	"TableDump",
+	"ConnectOut",
+	"RegisterSlave",
+	"StmtPrepare",
+	"StmtExecute",
+	"StmtSendLongData",
+	"StmtClose",
+	"StmtReset",
+	"SetOption",
+	"StmtFetch",
+	"Daemon",
+	"BinlogDumpGtid",
+	"ResetConnect",
+}
+
+func (f Command) Byte() byte {
+	return byte(f)
+}
+
+func (f Command) String() string {
+	e := int(f)
+	if e >= len(commandStrs) {
+		return fmt.Sprintf("Not a command: %x", byte(f))
+	}
+	return commandStrs[e]
+}
+
+func (f *Command) MarshalText() ([]byte, error) {
+	return []byte(f.String()), nil
+}
+
+func (f *Command) UnmarshalText(o []byte) error {
+	for e, c := range commandStrs {
+		if c == string(o) {
+			*f = Command(e)
+			break
+		}
+	}
+	return nil
+}

--- a/pkg/proxy/net/const.go
+++ b/pkg/proxy/net/const.go
@@ -1,0 +1,20 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+const (
+	// MaxPayloadLen is the max packet payload length.
+	MaxPayloadLen = 1<<24 - 1
+)

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -49,7 +49,6 @@ import (
 	"github.com/pingcap/TiProxy/pkg/proxy/keepalive"
 	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 	"github.com/pingcap/tidb/errno"
-	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/dbterror"
 )
 
@@ -188,7 +187,7 @@ func (p *PacketIO) readOnePacket() ([]byte, bool, error) {
 		return nil, false, errors.Wrap(ErrReadConn, err)
 	}
 	p.inBytes += uint64(length)
-	return data, length == mysql.MaxPayloadLen, nil
+	return data, length == MaxPayloadLen, nil
 }
 
 // ReadPacket reads data and removes the header
@@ -208,10 +207,10 @@ func (p *PacketIO) ReadPacket() (data []byte, err error) {
 func (p *PacketIO) writeOnePacket(data []byte) (int, bool, error) {
 	more := false
 	length := len(data)
-	if length >= mysql.MaxPayloadLen {
+	if length >= MaxPayloadLen {
 		// we need another packet, this is true even if
 		// the current packet is of len(MaxPayloadLen) exactly
-		length = mysql.MaxPayloadLen
+		length = MaxPayloadLen
 		more = true
 	}
 

--- a/pkg/proxy/net/packetio_mysql.go
+++ b/pkg/proxy/net/packetio_mysql.go
@@ -97,8 +97,8 @@ func (p *PacketIO) ReadSSLRequestOrHandshakeResp() (pkt []byte, isSSL bool, err 
 		return
 	}
 
-	capability := binary.LittleEndian.Uint32(pkt[:4])
-	isSSL = capability&mysql.ClientSSL != 0
+	capability := Capability(binary.LittleEndian.Uint32(pkt[:4]))
+	isSSL = capability&ClientSSL != 0
 	return
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #248

Problem Summary: The current backend must convert from `*PacketIO` oriented to `[]byte/MysqlPacket` oriented. Command processor or authenticator should not read from the connection actively. To do this, we should provide a set of helpers that deals with packets, instead of `*PacketIO`.

What is changed and how it works:

1. This packet completes `mysql.ComXXX` definition. The next one will provide more helpers.
2. fix post merge CI.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
