### PR TITLE
metrics: add uptime and cpu limit to grafana

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -18,9 +18,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/pingcap/TiProxy/lib/util/cmd"
 	"github.com/pingcap/TiProxy/lib/util/errors"
+	"github.com/pingcap/TiProxy/pkg/metrics"
 	"github.com/pingcap/TiProxy/pkg/sctx"
 	"github.com/pingcap/TiProxy/pkg/server"
 	"github.com/spf13/cobra"
@@ -45,6 +47,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&sctx.ConfigFile, "config", "", "proxy config file path")
 	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Log.Encoder, "log_encoder", "", "log in format of tidb, console, or json")
 	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Log.Level, "log_level", "", "log level")
+
+	metrics.MaxProcsGauge.Set(float64(runtime.GOMAXPROCS(0)))
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		srv, err := server.NewServer(cmd.Context(), sctx)

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -79,6 +79,13 @@
                      "intervalFactor": 2,
                      "legendFormat": "{{instance}}",
                      "refId": "A"
+                  },
+                  {
+                     "expr": "tiproxy_server_maxprocs{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tiproxy\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "limit-{{instance}}",
+                     "refId": "B"
                   }
                ],
                "thresholds": [ ],
@@ -388,6 +395,92 @@
                      "show": true
                   }
                ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_TEST-CLUSTER}",
+               "description": "TiProxy uptime since the last restart.",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 7,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "time() - process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\", job=\"tiproxy\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Uptime",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
             }
          ],
          "repeat": null,
@@ -407,7 +500,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 7,
+         "id": 8,
          "panels": [
             {
                "aliasColors": { },
@@ -424,7 +517,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 8,
+               "id": 9,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -524,7 +617,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 9,
+               "id": 10,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -610,7 +703,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 10,
+               "id": 11,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -696,7 +789,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 11,
+               "id": 12,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -785,7 +878,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 12,
+         "id": 13,
          "panels": [
             {
                "aliasColors": { },
@@ -802,7 +895,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 13,
+               "id": 14,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -888,7 +981,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 14,
+               "id": 15,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -974,7 +1067,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1077,7 +1170,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 16,
+         "id": 17,
          "panels": [
             {
                "aliasColors": { },
@@ -1094,7 +1187,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 17,
+               "id": 18,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -134,6 +134,12 @@ local cpuP = graphPanel.new(
     'rate(process_cpu_seconds_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance", job="tiproxy"}[1m])',
     legendFormat='{{instance}}',
   )
+)
+.addTarget(
+  prometheus.target(
+    'tiproxy_server_maxprocs{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance", job="tiproxy"}',
+    legendFormat='limit-{{instance}}',
+  )
 );
 
 local memP = graphPanel.new(
@@ -153,6 +159,20 @@ local memP = graphPanel.new(
   prometheus.target(
     'go_memory_classes_heap_objects_bytes{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance", job="tiproxy"} + go_memory_classes_heap_unused_bytes{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance", job="tiproxy"}',
     legendFormat='HeapInuse-{{instance}}',
+  )
+);
+
+local uptimeP = graphPanel.new(
+  title='Uptime',
+  datasource=myDS,
+  legend_rightSide=true,
+  format='s',
+  description='TiProxy uptime since the last restart.',
+)
+.addTarget(
+  prometheus.target(
+    'time() - process_start_time_seconds{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance", job="tiproxy"}',
+    legendFormat='{{instance}}',
   )
 );
 
@@ -327,6 +347,7 @@ newDash
   .addPanel(memP, gridPos=rightPanelPos)
   .addPanel(connectionP, gridPos=leftPanelPos)
   .addPanel(goroutineP, gridPos=rightPanelPos)
+  .addPanel(uptimeP, gridPos=leftPanelPos)
   ,
   gridPos=rowPos
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -116,6 +116,7 @@ func registerProxyMetrics() {
 	prometheus.MustRegister(ConnGauge)
 	prometheus.MustRegister(TimeJumpBackCounter)
 	prometheus.MustRegister(KeepAliveCounter)
+	prometheus.MustRegister(MaxProcsGauge)
 	prometheus.MustRegister(BackendStatusGauge)
 	prometheus.MustRegister(BackendConnGauge)
 	prometheus.MustRegister(QueryTotalCounter)

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -28,6 +28,14 @@ var (
 			Help:      "Number of connections.",
 		})
 
+	MaxProcsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelServer,
+			Name:      "maxprocs",
+			Help:      "The value of GOMAXPROCS.",
+		})
+
 	TimeJumpBackCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: ModuleProxy,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #256

Problem Summary:
Add uptime and cpu limit to grafana to help diagnosis.

What is changed and how it works:
Add uptime and cpu limit to grafana.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

From `http://127.0.0.1:3080/api/metrics/`:

```
# HELP tiproxy_server_maxprocs The value of GOMAXPROCS.
# TYPE tiproxy_server_maxprocs gauge
tiproxy_server_maxprocs 8
```

![screenshot-20230330-151646](https://user-images.githubusercontent.com/29590578/228759031-9ef14d6e-361a-4971-b61d-73e04a66579d.png)


The grafana doesn't show cpu or uptime data when I start it from TiUP.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
