### PR TITLE
router: fix backends are unbalanced when the workload starts

### DIFF
--- a/pkg/manager/router/backend_selector.go
+++ b/pkg/manager/router/backend_selector.go
@@ -18,7 +18,7 @@ type BackendSelector struct {
 	excluded  []string
 	cur       string
 	routeOnce func(excluded []string) (string, error)
-	addConn   func(addr string, conn RedirectableConn) error
+	onCreate  func(addr string, conn RedirectableConn, succeed bool)
 }
 
 func (bs *BackendSelector) Reset() {
@@ -37,6 +37,6 @@ func (bs *BackendSelector) Next() (string, error) {
 	return bs.cur, nil
 }
 
-func (bs *BackendSelector) Succeed(conn RedirectableConn) error {
-	return bs.addConn(bs.cur, conn)
+func (bs *BackendSelector) Finish(conn RedirectableConn, succeed bool) {
+	bs.onCreate(bs.cur, conn, succeed)
 }

--- a/pkg/manager/router/metrics.go
+++ b/pkg/manager/router/metrics.go
@@ -33,12 +33,8 @@ func checkBackendStatusMetrics(addr string, status BackendStatus) bool {
 	return val == 1
 }
 
-func addBackendConnMetrics(addr string) {
-	metrics.BackendConnGauge.WithLabelValues(addr).Add(1)
-}
-
-func subBackendConnMetrics(addr string) {
-	metrics.BackendConnGauge.WithLabelValues(addr).Sub(1)
+func setBackendConnMetrics(addr string, conns int) {
+	metrics.BackendConnGauge.WithLabelValues(addr).Set(float64(conns))
 }
 
 func readBackendConnMetrics(addr string) (int, error) {

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -42,9 +42,10 @@ func (r *StaticRouter) GetBackendSelector() BackendSelector {
 			}
 			return "", nil
 		},
-		addConn: func(addr string, conn RedirectableConn) error {
-			r.cnt++
-			return nil
+		onCreate: func(addr string, conn RedirectableConn, succeed bool) {
+			if succeed {
+				r.cnt++
+			}
 		},
 	}
 }

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -198,7 +198,6 @@ func (ts *backendMgrTester) redirectAfterCmd4Proxy(clientIO, backendIO *pnet.Pac
 	require.NoError(ts.t, err)
 	ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(ts.t, eventSucceed)
 	require.NotEqual(ts.t, backend1, ts.mp.backendIO.Load())
-	require.Len(ts.t, ts.mp.GetRedirectingAddr(), 0)
 	return nil
 }
 
@@ -207,7 +206,6 @@ func (ts *backendMgrTester) redirectFail4Proxy(clientIO, backendIO *pnet.PacketI
 	ts.mp.Redirect(ts.tc.backendListener.Addr().String())
 	ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(ts.t, eventFail)
 	require.Equal(ts.t, backend1, ts.mp.backendIO.Load())
-	require.Len(ts.t, ts.mp.GetRedirectingAddr(), 0)
 	return nil
 }
 
@@ -553,7 +551,6 @@ func TestCloseWhileRedirect(t *testing.T) {
 				// Redirect() should not panic after Close().
 				ts.mp.Redirect(addr)
 				eventReceiver.checkEvent(t, eventSucceed)
-				require.Equal(t, addr, ts.mp.GetRedirectingAddr())
 				wg.Wait()
 				eventReceiver.checkEvent(t, eventClose)
 				return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #262 

Problem Summary:
The backends are unbalanced when the workload starts because the router doesn't update the backend scores in time.

What is changed and how it works:
- Add `backendWrapper.connScore` to indicate the scores of backends to replace `connList.Len()` and update it in time.
- `backendWrapper.connList` now only contains the connections that are currently on the backend, which is more straightforward and easier to read.
- Only remove the backend from the list when it's really useless. Do not return error when the backend is not found, add it back and log it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Start a cluster with 2 backends
2. Run sysbench with 100 threads
3. Grep the connection count of each backend from the log, and it's 50-50.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
