### PR TITLE
lib: configurable TLS version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ gocovmerge:
 	GOBIN=$(GOBIN) go install github.com/wadey/gocovmerge@master
 
 tidy:
-	go mod tidy
 	cd lib && go mod tidy
+	go mod tidy
 
 build:
-	go build ./...
 	cd lib && go build ./...
+	go build ./...
 
 metrics:
 	go install github.com/google/go-jsonnet/cmd/jsonnet@latest

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -61,7 +61,8 @@
 #   auto-certs = true # mostly used by tests. It will generate certs if no cert/key is specified.
 # 	rsa-key-size = 4096 # generated RSA keysize if auto-certs is enabled.
 # 	autocert-expire-duration = "72h" # default expire duration for auto certs.
-#   skip-ca = trure
+#   skip-ca = true
+#   min-tls-version = "1.1" # specify minimum TLS version
 # client object:
 #   1. requires: ca or skip-ca(skip verify server certs)
 #   2. optionally: cert/key will be used if server asks, i.e. server-side client verification

--- a/go.sum
+++ b/go.sum
@@ -710,7 +710,6 @@ go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.6 h1:Cy2qx3npLcYqTKqGJzMypnMv2tiRyifZJ17BlWIWA7A=
 go.etcd.io/etcd/api/v3 v3.5.6/go.mod h1:KFtNaxGDw4Yx/BA4iPPwevUTAuqcsPxzyX8PHydchN8=
-go.etcd.io/etcd/client/pkg/v3 v3.5.5/go.mod h1:ggrwbk069qxpKPq8/FKkQ3Xq9y39kbFR4LnKszpRXeQ=
 go.etcd.io/etcd/client/pkg/v3 v3.5.6 h1:TXQWYceBKqLp4sa87rcPs11SXxUA/mHwH975v+BDvLU=
 go.etcd.io/etcd/client/pkg/v3 v3.5.6/go.mod h1:ggrwbk069qxpKPq8/FKkQ3Xq9y39kbFR4LnKszpRXeQ=
 go.etcd.io/etcd/client/v2 v2.305.6 h1:fIDR0p4KMjw01MJMfUIDWdQbjo06PD6CeYM5z4EHLi0=

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -17,8 +17,10 @@ package config
 
 import (
 	"bytes"
+	"crypto/tls"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -108,6 +110,7 @@ type TLSConfig struct {
 	Cert               string `yaml:"cert,omitempty" toml:"cert,omitempty" json:"cert,omitempty"`
 	Key                string `yaml:"key,omitempty" toml:"key,omitempty" json:"key,omitempty"`
 	CA                 string `yaml:"ca,omitempty" toml:"ca,omitempty" json:"ca,omitempty"`
+	MinTLSVersion      string `yaml:"min-tls-version,omitempty" toml:"min-tls-version,omitempty" json:"min-tls-version,omitempty"`
 	AutoCerts          bool   `yaml:"auto-certs,omitempty" toml:"auto-certs,omitempty" json:"auto-certs,omitempty"`
 	RSAKeySize         int    `yaml:"rsa-key-size,omitempty" toml:"rsa-key-size,omitempty" json:"rsa-key-size,omitempty"`
 	AutoExpireDuration string `yaml:"autocert-expire-duration,omitempty" toml:"autocert-expire-duration,omitempty" json:"autocert-expire-duration,omitempty"`
@@ -116,6 +119,21 @@ type TLSConfig struct {
 
 func (c TLSConfig) HasCert() bool {
 	return !(c.Cert == "" && c.Key == "")
+}
+
+func (c TLSConfig) MinTLSVer() uint16 {
+	switch {
+	case strings.HasSuffix(c.MinTLSVersion, "1.0"):
+		return tls.VersionTLS10
+	case strings.HasSuffix(c.MinTLSVersion, "1.1"):
+		return tls.VersionTLS11
+	case strings.HasSuffix(c.MinTLSVersion, "1.2"):
+		return tls.VersionTLS12
+	case strings.HasSuffix(c.MinTLSVersion, "1.3"):
+		return tls.VersionTLS13
+	default:
+		return tls.VersionTLS12
+	}
 }
 
 func (c TLSConfig) HasCA() bool {
@@ -161,6 +179,10 @@ func NewConfig() *Config {
 	cfg.Log.LogFile.MaxBackups = 3
 
 	cfg.Advance.IgnoreWrongNamespace = true
+	cfg.Security.SQLTLS.MinTLSVersion = "1.1"
+	cfg.Security.PeerTLS.MinTLSVersion = "1.1"
+	cfg.Security.ServerTLS.MinTLSVersion = "1.1"
+	cfg.Security.ClusterTLS.MinTLSVersion = "1.1"
 
 	return &cfg
 }

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.1
-	go.etcd.io/etcd/client/pkg/v3 v3.5.5
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.23.0
 )
@@ -15,7 +14,6 @@ require (
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -2,13 +2,11 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -41,8 +39,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.etcd.io/etcd/client/pkg/v3 v3.5.5 h1:9S0JUVvmrVl7wCF39iTQthdaaNIiAaQbmK75ogO6GU8=
-go.etcd.io/etcd/client/pkg/v3 v3.5.5/go.mod h1:ggrwbk069qxpKPq8/FKkQ3Xq9y39kbFR4LnKszpRXeQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -51,7 +47,6 @@ go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.23.0 h1:OjGQ5KQDEUawVHxNwQgPpiypGHOxo2mNZsOqTak4fFY=
 go.uber.org/zap v1.23.0/go.mod h1:D+nX8jyLsMHMYrln8A0rJjFt/T/9/bGgIhAqxv5URuY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -68,10 +63,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -89,7 +81,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lib/util/security/cert.go
+++ b/lib/util/security/cert.go
@@ -167,7 +167,7 @@ func (ci *CertInfo) buildServerConfig(lg *zap.Logger) (*tls.Config, error) {
 	}
 
 	tcfg := &tls.Config{
-		MinVersion:            tls.VersionTLS11,
+		MinVersion:            ci.cfg.MinTLSVer(),
 		GetCertificate:        ci.getCert,
 		GetClientCertificate:  ci.getClientCert,
 		VerifyPeerCertificate: ci.verifyPeerCertificate,
@@ -243,7 +243,7 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 			// still enable TLS without verify server certs
 			return &tls.Config{
 				InsecureSkipVerify: true,
-				MinVersion:         tls.VersionTLS11,
+				MinVersion:         ci.cfg.MinTLSVer(),
 			}, nil
 		}
 		lg.Info("no CA to verify server connections, disable TLS")
@@ -251,7 +251,7 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 	}
 
 	tcfg := &tls.Config{
-		MinVersion:            tls.VersionTLS11,
+		MinVersion:            ci.cfg.MinTLSVer(),
 		GetCertificate:        ci.getCert,
 		GetClientCertificate:  ci.getClientCert,
 		InsecureSkipVerify:    true,

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -73,7 +73,7 @@ func TestCertServer(t *testing.T) {
 				require.NotNil(t, c)
 				require.Nil(t, ci.ca.Load())
 				require.NotNil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -87,7 +87,7 @@ func TestCertServer(t *testing.T) {
 				require.NotNil(t, c)
 				require.Nil(t, ci.ca.Load())
 				require.NotNil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -97,6 +97,23 @@ func TestCertServer(t *testing.T) {
 				Cert: certPath,
 				Key:  keyPath,
 				CA:   caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Equal(t, tls.RequireAnyClientCert, c.ClientAuth)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				Cert:          certPath,
+				Key:           keyPath,
+				CA:            caPath,
+				MinTLSVersion: "1.1",
 			},
 			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
 				require.NotNil(t, c)
@@ -120,7 +137,7 @@ func TestCertServer(t *testing.T) {
 				require.Equal(t, tls.RequestClientCert, c.ClientAuth)
 				require.NotNil(t, ci.ca.Load())
 				require.NotNil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -129,6 +146,22 @@ func TestCertServer(t *testing.T) {
 			TLSConfig: config.TLSConfig{
 				AutoCerts: true,
 				CA:        caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.Equal(t, tls.RequireAnyClientCert, c.ClientAuth)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
+			},
+			err: "",
+		},
+		{
+			server: true,
+			TLSConfig: config.TLSConfig{
+				AutoCerts:     true,
+				CA:            caPath,
+				MinTLSVersion: "1.1",
 			},
 			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
 				require.NotNil(t, c)
@@ -167,7 +200,7 @@ func TestCertServer(t *testing.T) {
 				require.NotNil(t, c)
 				require.Nil(t, ci.ca.Load())
 				require.Nil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -180,7 +213,7 @@ func TestCertServer(t *testing.T) {
 				require.NotNil(t, c)
 				require.Nil(t, ci.ca.Load())
 				require.Nil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -192,7 +225,7 @@ func TestCertServer(t *testing.T) {
 				require.NotNil(t, c)
 				require.NotNil(t, ci.ca.Load())
 				require.Nil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS11, int(c.MinVersion))
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
 			},
 			err: "",
 		},
@@ -201,6 +234,21 @@ func TestCertServer(t *testing.T) {
 				Cert: certPath,
 				Key:  keyPath,
 				CA:   caPath,
+			},
+			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
+				require.NotNil(t, c)
+				require.NotNil(t, ci.ca.Load())
+				require.NotNil(t, ci.cert.Load())
+				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
+			},
+			err: "",
+		},
+		{
+			TLSConfig: config.TLSConfig{
+				Cert:          certPath,
+				Key:           keyPath,
+				CA:            caPath,
+				MinTLSVersion: "1.1",
 			},
 			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
 				require.NotNil(t, c)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #264

Problem Summary: Make min-tls-version configurable. Also removed two useless functions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add `min-tls-version` config in security config
```
