### PR TITLE
docker: fix script on some older docker builder

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,8 @@ RUN export VERSION=${VERSION} && export COMMIT=${COMMIT} && export GOPROXY=${GOP
 
 FROM alpine:latest
 
-COPY --from=builder /proxy/bin/* /bin
-COPY --from=builder /proxy/conf/* /etc/proxy
+COPY --from=builder /proxy/bin/* /bin/
+COPY --from=builder /proxy/conf/* /etc/proxy/
 
 EXPOSE 3080
 EXPOSE 3081


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: It does not build on old docker.

What is changed and how it works: Directory needs to end with a `/`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
