### PR TITLE
server: add proxyprotocol to http

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -34,6 +34,9 @@
 # user = ""
 # password = ""
 
+# same as [proxy.proxy-protocol], but for HTTP port
+# proxy-protocol = ""
+
 [log]
 
 # level = "info"

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -81,6 +81,7 @@ type API struct {
 	User            string `yaml:"user,omitempty" toml:"user,omitempty" json:"user,omitempty"`
 	Password        string `yaml:"password,omitempty" toml:"password,omitempty" json:"password,omitempty"`
 	EnableBasicAuth bool   `yaml:"enable-basic-auth,omitempty" toml:"enable-basic-auth,omitempty" json:"enable-basic-auth,omitempty"`
+	ProxyProtocol   string `yaml:"proxy-protocol,omitempty" toml:"proxy-protocol,omitempty" json:"proxy-protocol,omitempty"`
 }
 
 type Advance struct {

--- a/pkg/proxy/proxyprotocol/listener.go
+++ b/pkg/proxy/proxyprotocol/listener.go
@@ -62,7 +62,7 @@ func (c *proxyConn) Read(b []byte) (n int, err error) {
 				return 0, err
 			}
 		}
-		// prefixes mismatched
+		// prefixes mismatched, or we have parsed PP header
 		c.inited = true
 	}
 	if c.buf.Len() > 0 {

--- a/pkg/proxy/proxyprotocol/listener.go
+++ b/pkg/proxy/proxyprotocol/listener.go
@@ -1,0 +1,77 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import (
+	"bytes"
+	"io"
+	"net"
+)
+
+var _ net.Listener = (*Listener)(nil)
+var _ net.Conn = (*proxyConn)(nil)
+
+type Listener struct {
+	net.Listener
+}
+
+func NewListener(o net.Listener) *Listener {
+	return &Listener{o}
+}
+
+func (n *Listener) Accept() (net.Conn, error) {
+	conn, err := n.Listener.Accept()
+	return &proxyConn{Conn: conn}, err
+}
+
+type proxyConn struct {
+	net.Conn
+	proxyHdr []byte
+	proxy    *Proxy
+	inited   bool
+}
+
+func (c *proxyConn) Read(b []byte) (n int, err error) {
+	if !c.inited {
+		if len(c.proxyHdr) == 0 {
+			c.proxyHdr = make([]byte, len(MagicV2))
+		}
+		n, err = io.ReadFull(c.Conn, c.proxyHdr)
+		if err != nil {
+			return
+		}
+		if bytes.Equal(c.proxyHdr, MagicV2) {
+			c.proxyHdr = nil
+			c.proxy, _, err = ParseProxyV2(c.Conn)
+			if err != nil {
+				return 0, err
+			}
+		}
+		c.inited = true
+	}
+	if len(c.proxyHdr) > 0 {
+		n = copy(b, c.proxyHdr)
+		c.proxyHdr = c.proxyHdr[n:]
+		return n, nil
+	}
+	return c.Conn.Read(b)
+}
+
+func (c *proxyConn) RemoteAddr() net.Addr {
+	if c.proxy != nil && c.proxy.DstAddress != nil {
+		return c.proxy.DstAddress
+	}
+	return c.Conn.RemoteAddr()
+}

--- a/pkg/proxy/proxyprotocol/listener.go
+++ b/pkg/proxy/proxyprotocol/listener.go
@@ -16,6 +16,7 @@ package proxyprotocol
 
 import (
 	"bytes"
+	"io"
 	"net"
 )
 
@@ -44,7 +45,7 @@ type proxyConn struct {
 
 func (c *proxyConn) Read(b []byte) (n int, err error) {
 	if !c.inited {
-		_, err = c.buf.ReadFrom(c.Conn)
+		_, err = c.buf.ReadFrom(io.LimitReader(c.Conn, int64(len(MagicV2)-c.buf.Len())))
 		if err != nil {
 			return
 		}
@@ -55,7 +56,7 @@ func (c *proxyConn) Read(b []byte) (n int, err error) {
 				return 0, nil
 			}
 			// it is proxy protocol
-			c.buf = nil
+			c.buf.Reset()
 			c.proxy, _, err = ParseProxyV2(c.Conn)
 			if err != nil {
 				return 0, err

--- a/pkg/proxy/proxyprotocol/listener_test.go
+++ b/pkg/proxy/proxyprotocol/listener_test.go
@@ -63,7 +63,22 @@ func TestProxyListener(t *testing.T) {
 			all, err := io.ReadAll(c)
 			require.NoError(t, err)
 			require.Equal(t, []byte("test"), all)
-			require.Equal(t, []byte("test"), all)
 			require.Equal(t, tcpaddr.String(), c.RemoteAddr().String())
+		}, 1)
+
+	testkit.TestTCPConnWithListener(t,
+		func(t *testing.T, network, addr string) net.Listener {
+			ln, err := net.Listen(network, addr)
+			require.NoError(t, err)
+			return NewListener(ln)
+		},
+		func(t *testing.T, c net.Conn) {
+			_, err = io.Copy(c, strings.NewReader("test"))
+			require.NoError(t, err)
+		},
+		func(t *testing.T, c net.Conn) {
+			all, err := io.ReadAll(c)
+			require.NoError(t, err)
+			require.Equal(t, []byte("test"), all)
 		}, 1)
 }

--- a/pkg/proxy/proxyprotocol/listener_test.go
+++ b/pkg/proxy/proxyprotocol/listener_test.go
@@ -1,0 +1,69 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxyprotocol
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/TiProxy/pkg/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyListener(t *testing.T) {
+	tcpaddr, err := net.ResolveTCPAddr("tcp", "192.168.1.1:34")
+	require.NoError(t, err)
+
+	testkit.TestTCPConnWithListener(t,
+		func(t *testing.T, network, addr string) net.Listener {
+			ln, err := net.Listen(network, addr)
+			require.NoError(t, err)
+			return NewListener(ln)
+		},
+		func(t *testing.T, c net.Conn) {
+			p := &Proxy{
+				Version:    ProxyVersion2,
+				Command:    ProxyCommandLocal,
+				SrcAddress: tcpaddr,
+				DstAddress: tcpaddr,
+				TLV: []ProxyTlv{
+					{
+						typ:     ProxyTlvALPN,
+						content: nil,
+					},
+					{
+						typ:     ProxyTlvUniqueID,
+						content: []byte("test"),
+					},
+				},
+			}
+			b, err := p.ToBytes()
+			require.NoError(t, err)
+			_, err = io.Copy(c, bytes.NewReader(b))
+			require.NoError(t, err)
+			_, err = io.Copy(c, strings.NewReader("test"))
+			require.NoError(t, err)
+		},
+		func(t *testing.T, c net.Conn) {
+			all, err := io.ReadAll(c)
+			require.NoError(t, err)
+			require.Equal(t, []byte("test"), all)
+			require.Equal(t, []byte("test"), all)
+			require.Equal(t, tcpaddr.String(), c.RemoteAddr().String())
+		}, 1)
+}

--- a/pkg/server/api/http.go
+++ b/pkg/server/api/http.go
@@ -29,6 +29,7 @@ import (
 	mgrcfg "github.com/pingcap/TiProxy/pkg/manager/config"
 	mgrns "github.com/pingcap/TiProxy/pkg/manager/namespace"
 	"github.com/pingcap/TiProxy/pkg/proxy"
+	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 	"go.uber.org/atomic"
 	"go.uber.org/ratelimit"
 	"go.uber.org/zap"
@@ -79,6 +80,10 @@ func NewHTTPServer(cfg config.API, lg *zap.Logger,
 	h.listener, err = net.Listen("tcp", cfg.Addr)
 	if err != nil {
 		return nil, err
+	}
+	switch cfg.ProxyProtocol {
+	case "v2":
+		h.listener = proxyprotocol.NewListener(h.listener)
 	}
 
 	gin.SetMode(gin.ReleaseMode)

--- a/pkg/testkit/main.go
+++ b/pkg/testkit/main.go
@@ -43,8 +43,15 @@ func TestPipeConn(t *testing.T, a, b func(*testing.T, net.Conn), loop int) {
 }
 
 func TestTCPConn(t *testing.T, a, b func(*testing.T, net.Conn), loop int) {
-	listener, err := net.Listen("tcp", "127.0.0.0:0")
-	require.NoError(t, err)
+	TestTCPConnWithListener(t, func(t *testing.T, network, addr string) net.Listener {
+		ln, err := net.Listen(network, addr)
+		require.NoError(t, err)
+		return ln
+	}, a, b, loop)
+}
+
+func TestTCPConnWithListener(t *testing.T, listen func(*testing.T, string, string) net.Listener, a, b func(*testing.T, net.Conn), loop int) {
+	listener := listen(t, "tcp", "localhost:0")
 	defer func() {
 		require.NoError(t, listener.Close())
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #245

Problem Summary: If `NLB` enabled with proxy-protocol, the HTTP port may be sent PPv2 headers. This PR added the support.

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add support of proxy-protocol for HTTP API port
```
