### PR TITLE
net: fix proxy protocol

### DIFF
--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -103,12 +103,15 @@ func NewPacketIO(conn net.Conn, opts ...PacketIOption) *PacketIO {
 		sequence: 0,
 		buf:      buf,
 	}
-	// TODO: disable it by default now
 	p.proxyInited.Store(true)
+	p.ApplyOpts(opts...)
+	return p
+}
+
+func (p *PacketIO) ApplyOpts(opts ...PacketIOption) {
 	for _, opt := range opts {
 		opt(p)
 	}
-	return p
 }
 
 func (p *PacketIO) wrapErr(err error) error {
@@ -117,10 +120,7 @@ func (p *PacketIO) wrapErr(err error) error {
 
 // Proxy returned parsed proxy header from clients if any.
 func (p *PacketIO) Proxy() *proxyprotocol.Proxy {
-	if p.proxyInited.Load() {
-		return p.proxy
-	}
-	return nil
+	return p.proxy
 }
 
 func (p *PacketIO) LocalAddr() net.Addr {

--- a/pkg/proxy/net/packetio_options.go
+++ b/pkg/proxy/net/packetio_options.go
@@ -23,7 +23,7 @@ import (
 type PacketIOption = func(*PacketIO)
 
 func WithProxy(pi *PacketIO) {
-	pi.proxyInited.Store(true)
+	pi.proxyInited.Store(false)
 }
 
 func WithWrapError(err error) func(pi *PacketIO) {

--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyParse(t *testing.T) {
+	tcpaddr, err := net.ResolveTCPAddr("tcp", "192.168.1.1:34")
+	require.NoError(t, err)
+
+	testPipeConn(t,
+		func(t *testing.T, cli *PacketIO) {
+			p := &proxyprotocol.Proxy{
+				Version:    proxyprotocol.ProxyVersion2,
+				Command:    proxyprotocol.ProxyCommandLocal,
+				SrcAddress: tcpaddr,
+				DstAddress: tcpaddr,
+				TLV: []proxyprotocol.ProxyTlv{
+					{
+						Typ:     proxyprotocol.ProxyTlvALPN,
+						Content: nil,
+					},
+					{
+						Typ:     proxyprotocol.ProxyTlvUniqueID,
+						Content: []byte("test"),
+					},
+				},
+			}
+			b, err := p.ToBytes()
+			require.NoError(t, err)
+			_, err = io.Copy(cli.conn, bytes.NewReader(b))
+			require.NoError(t, err)
+			err = cli.WritePacket([]byte("hello"), true)
+			require.NoError(t, err)
+		},
+		func(t *testing.T, srv *PacketIO) {
+			srv.ApplyOpts(WithProxy)
+			b, err := srv.ReadPacket()
+			require.NoError(t, err)
+			require.Equal(t, "hello", string(b))
+			require.Equal(t, tcpaddr.String(), srv.RemoteAddr().String())
+		},
+		1,
+	)
+}

--- a/pkg/proxy/proxyprotocol/definition.go
+++ b/pkg/proxy/proxyprotocol/definition.go
@@ -63,8 +63,8 @@ const (
 )
 
 type ProxyTlv struct {
-	content []byte
-	typ     ProxyTlvType
+	Content []byte
+	Typ     ProxyTlvType
 }
 
 type Proxy struct {

--- a/pkg/proxy/proxyprotocol/listener_test.go
+++ b/pkg/proxy/proxyprotocol/listener_test.go
@@ -43,12 +43,12 @@ func TestProxyListener(t *testing.T) {
 				DstAddress: tcpaddr,
 				TLV: []ProxyTlv{
 					{
-						typ:     ProxyTlvALPN,
-						content: nil,
+						Typ:     ProxyTlvALPN,
+						Content: nil,
 					},
 					{
-						typ:     ProxyTlvUniqueID,
-						content: []byte("test"),
+						Typ:     ProxyTlvUniqueID,
+						Content: []byte("test"),
 					},
 				},
 			}

--- a/pkg/proxy/proxyprotocol/proxy.go
+++ b/pkg/proxy/proxyprotocol/proxy.go
@@ -92,10 +92,10 @@ func (p *Proxy) ToBytes() ([]byte, error) {
 	buf[magicLen+1] = byte(addressFamily<<4) | byte(network&0xF)
 
 	for _, tlv := range p.TLV {
-		buf = append(buf, byte(tlv.typ))
-		tlen := len(tlv.content)
+		buf = append(buf, byte(tlv.Typ))
+		tlen := len(tlv.Content)
 		buf = append(buf, byte(tlen>>8), byte(tlen))
-		buf = append(buf, tlv.content...)
+		buf = append(buf, tlv.Content...)
 	}
 
 	length := len(buf) - 4 - magicLen
@@ -205,8 +205,8 @@ func ParseProxyV2(rd io.Reader) (m *Proxy, n int, err error) {
 			length = len(buf) - 3
 		}
 		m.TLV = append(m.TLV, ProxyTlv{
-			typ:     typ,
-			content: buf[3 : 3+length],
+			Typ:     typ,
+			Content: buf[3 : 3+length],
 		})
 		buf = buf[3+length:]
 	}

--- a/pkg/proxy/proxyprotocol/proxy_test.go
+++ b/pkg/proxy/proxyprotocol/proxy_test.go
@@ -37,12 +37,12 @@ func TestProxyParse(t *testing.T) {
 				DstAddress: tcpaddr,
 				TLV: []ProxyTlv{
 					{
-						typ:     ProxyTlvALPN,
-						content: nil,
+						Typ:     ProxyTlvALPN,
+						Content: nil,
 					},
 					{
-						typ:     ProxyTlvUniqueID,
-						content: []byte("test"),
+						Typ:     ProxyTlvUniqueID,
+						Content: []byte("test"),
 					},
 				},
 			}
@@ -66,9 +66,9 @@ func TestProxyParse(t *testing.T) {
 			require.Equal(t, ProxyVersion2, p.Version)
 			require.Equal(t, ProxyCommandLocal, p.Command)
 			require.Len(t, p.TLV, 2)
-			require.Equal(t, ProxyTlvALPN, p.TLV[0].typ)
-			require.Equal(t, ProxyTlvUniqueID, p.TLV[1].typ)
-			require.Equal(t, []byte("test"), p.TLV[1].content)
+			require.Equal(t, ProxyTlvALPN, p.TLV[0].Typ)
+			require.Equal(t, ProxyTlvUniqueID, p.TLV[1].Typ)
+			require.Equal(t, []byte("test"), p.TLV[1].Content)
 		},
 		1,
 	)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #273 

Problem Summary: tiproxy did not try to parse PP headers. PP is disabled  by default during introducing serverless support. Since then it is always disabled, and never get fixed. 

What is changed and how it works:

1. `WithProxy` should set `proxyInited = false`.
2. Add unit tests to prevent regression.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
