### PR TITLE
net: move OnConnClose before Swap

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -636,13 +636,13 @@ func (mgr *BackendConnManager) Close() error {
 	var connErr error
 	var addr string
 	mgr.processLock.Lock()
-	if backendIO := mgr.backendIO.Swap(nil); backendIO != nil {
+	if backendIO := mgr.backendIO.Load(); backendIO != nil {
 		addr = backendIO.RemoteAddr().String()
 		connErr = backendIO.Close()
 	}
-	mgr.processLock.Unlock()
-
 	handErr := mgr.handshakeHandler.OnConnClose(mgr)
+	mgr.backendIO.Store(nil)
+	mgr.processLock.Unlock()
 
 	eventReceiver := mgr.getEventReceiver()
 	if eventReceiver != nil {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -635,13 +635,12 @@ func (mgr *BackendConnManager) Close() error {
 
 	var connErr error
 	var addr string
+	handErr := mgr.handshakeHandler.OnConnClose(mgr)
 	mgr.processLock.Lock()
-	if backendIO := mgr.backendIO.Load(); backendIO != nil {
+	if backendIO := mgr.backendIO.Swap(nil); backendIO != nil {
 		addr = backendIO.RemoteAddr().String()
 		connErr = backendIO.Close()
 	}
-	handErr := mgr.handshakeHandler.OnConnClose(mgr)
-	mgr.backendIO.Store(nil)
 	mgr.processLock.Unlock()
 
 	eventReceiver := mgr.getEventReceiver()

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -633,9 +633,10 @@ func (mgr *BackendConnManager) Close() error {
 	}
 	mgr.wg.Wait()
 
+	handErr := mgr.handshakeHandler.OnConnClose(mgr)
+
 	var connErr error
 	var addr string
-	handErr := mgr.handshakeHandler.OnConnClose(mgr)
 	mgr.processLock.Lock()
 	if backendIO := mgr.backendIO.Swap(nil); backendIO != nil {
 		addr = backendIO.RemoteAddr().String()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary:
move OnConnClose before Swap, because OnConnClose may call backendIO conn like ServerAddr()

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
