### PR TITLE
metrics: fix metrics `Get Backend Count` and `Ping Backend Duration` 

### DIFF
--- a/pkg/manager/router/metrics.go
+++ b/pkg/manager/router/metrics.go
@@ -62,6 +62,5 @@ func readMigrateCounter(from, to string, succeed bool) (int, error) {
 
 func setPingBackendMetrics(addr string, succeed bool, startTime time.Time) {
 	cost := time.Since(startTime)
-	resLabel := succeedToLabel(succeed)
-	metrics.PingBackendGauge.WithLabelValues(addr, resLabel).Set(cost.Seconds())
+	metrics.PingBackendGauge.WithLabelValues(addr).Set(cost.Seconds())
 }

--- a/pkg/metrics/backend.go
+++ b/pkg/metrics/backend.go
@@ -53,5 +53,5 @@ var (
 			Subsystem: LabelBackend,
 			Name:      "ping_duration_seconds",
 			Help:      "Time (s) of pinging the SQL port of each backend.",
-		}, []string{LblBackend, LblRes})
+		}, []string{LblBackend})
 )

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -1225,7 +1225,7 @@
                      "expr": "tiproxy_backend_get_backend{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{res}}",
+                     "legendFormat": "{{instance}} : {{res}}",
                      "refId": "A"
                   }
                ],

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -358,7 +358,7 @@ local bGetBeP = graphPanel.new(
 .addTarget(
   prometheus.target(
     'tiproxy_backend_get_backend{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster"}',
-    legendFormat='{{res}}',
+    legendFormat='{{instance}} : {{res}}',
   )
 );
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #279 

Problem Summary:
- `Get Backend Count` shows 2 `succeed` without instance names
- `Ping Backend Duration` shows double legends, one is 2s and one is a normal value

What is changed and how it works:
- Add instance name to `Get Backend Count`
- Remove `res` label from `Ping Backend Duration`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![screenshot-20230515-220511](https://github.com/pingcap/TiProxy/assets/29590578/45e21d1d-464f-4861-b2ef-f37e805027d4)


Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
