### PR TITLE
router, backend: show server version from TiDB

### DIFF
--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -22,7 +22,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"go.uber.org/zap"
@@ -66,6 +68,20 @@ var statusScores = map[BackendStatus]int{
 	StatusSchemaOutdated: 10000000,
 }
 
+type backendHealth struct {
+	status        BackendStatus
+	pingErr       error
+	serverVersion string
+}
+
+func (bh *backendHealth) String() string {
+	str := fmt.Sprintf("status: %s", bh.status.String())
+	if bh.pingErr != nil {
+		str += fmt.Sprintf(", err: %s", bh.pingErr.Error())
+	}
+	return str
+}
+
 const (
 	ttlPathSuffix    = "/ttl"
 	infoPathSuffix   = "/info"
@@ -75,7 +91,7 @@ const (
 // BackendEventReceiver receives the event of backend status change.
 type BackendEventReceiver interface {
 	// OnBackendChanged is called when the backend list changes.
-	OnBackendChanged(backends map[string]BackendStatus, err error)
+	OnBackendChanged(backends map[string]*backendHealth, err error)
 }
 
 // BackendInfo stores the status info of each backend.
@@ -89,7 +105,7 @@ type BackendObserver struct {
 	logger            *zap.Logger
 	healthCheckConfig *config.HealthCheck
 	// The current backend status synced to the receiver.
-	curBackendInfo map[string]BackendStatus
+	curBackendInfo map[string]*backendHealth
 	fetcher        BackendFetcher
 	httpCli        *http.Client
 	httpTLS        bool
@@ -123,7 +139,7 @@ func NewBackendObserver(logger *zap.Logger, eventReceiver BackendEventReceiver, 
 	bo := &BackendObserver{
 		logger:            logger,
 		healthCheckConfig: config,
-		curBackendInfo:    make(map[string]BackendStatus),
+		curBackendInfo:    make(map[string]*backendHealth),
 		httpCli:           httpCli,
 		httpTLS:           httpTLS,
 		eventReceiver:     eventReceiver,
@@ -155,14 +171,14 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 	for ctx.Err() == nil {
 		backendInfo, err := bo.fetcher.GetBackendList(ctx)
 		if err != nil {
-			bo.logger.Warn("fetching backends encounters error", zap.Error(err))
+			bo.logger.Error("fetching backends encounters error", zap.Error(err))
 			bo.eventReceiver.OnBackendChanged(nil, err)
 		} else {
-			backendStatus := bo.checkHealth(ctx, backendInfo)
+			bhMap := bo.checkHealth(ctx, backendInfo)
 			if ctx.Err() != nil {
 				return
 			}
-			bo.notifyIfChanged(backendStatus)
+			bo.notifyIfChanged(bhMap)
 		}
 		select {
 		case <-time.After(bo.healthCheckConfig.Interval):
@@ -173,34 +189,29 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 	}
 }
 
-func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]*BackendInfo) map[string]BackendStatus {
-	curBackendStatus := make(map[string]BackendStatus, len(backends))
+func (bo *BackendObserver) connectWithRetry(ctx context.Context, connect func() error) error {
+	err := backoff.Retry(func() error {
+		err := connect()
+		if !isRetryableError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(bo.healthCheckConfig.RetryInterval), uint64(bo.healthCheckConfig.MaxRetries)), ctx))
+	return err
+}
+
+func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]*BackendInfo) map[string]*backendHealth {
+	curBackendHealth := make(map[string]*backendHealth, len(backends))
 	for addr, info := range backends {
+		bh := &backendHealth{
+			status: StatusHealthy,
+		}
+		curBackendHealth[addr] = bh
 		if !bo.healthCheckConfig.Enable {
-			curBackendStatus[addr] = StatusHealthy
 			continue
 		}
 		if ctx.Err() != nil {
 			return nil
-		}
-		retriedTimes := 0
-		connectWithRetry := func(connect func() error) error {
-			var err error
-			for ; retriedTimes < bo.healthCheckConfig.MaxRetries; retriedTimes++ {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if err = connect(); err == nil {
-					return nil
-				}
-				if !isRetryableError(err) {
-					break
-				}
-				if retriedTimes < bo.healthCheckConfig.MaxRetries-1 {
-					time.Sleep(bo.healthCheckConfig.RetryInterval)
-				}
-			}
-			return err
 		}
 
 		// Skip checking the status port if it's not fetched.
@@ -214,68 +225,88 @@ func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]
 			httpCli := *bo.httpCli
 			httpCli.Timeout = bo.healthCheckConfig.DialTimeout
 			url := fmt.Sprintf("%s://%s:%d%s", schema, info.IP, info.StatusPort, statusPathSuffix)
-			var resp *http.Response
-			err := connectWithRetry(func() error {
-				var err error
-				if resp, err = httpCli.Get(url); err == nil {
-					if err := resp.Body.Close(); err != nil {
-						bo.logger.Error("close http response in health check failed", zap.Error(err))
+			err := bo.connectWithRetry(ctx, func() error {
+				resp, err := httpCli.Get(url)
+				if err == nil {
+					if resp.StatusCode != http.StatusOK {
+						err = backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
+					}
+					if ignoredErr := resp.Body.Close(); ignoredErr != nil {
+						bo.logger.Warn("close http response in health check failed", zap.Error(ignoredErr))
 					}
 				}
 				return err
 			})
-			if err != nil || resp.StatusCode != http.StatusOK {
+			if err != nil {
+				bh.status = StatusCannotConnect
+				bh.pingErr = err
 				continue
 			}
 		}
 
 		// Also dial the SQL port just in case that the SQL port hangs.
-		err := connectWithRetry(func() error {
+		var serverVersion string
+		err := bo.connectWithRetry(ctx, func() error {
 			startTime := time.Now()
 			conn, err := net.DialTimeout("tcp", addr, bo.healthCheckConfig.DialTimeout)
 			setPingBackendMetrics(addr, err == nil, startTime)
-			if err == nil {
-				if err := conn.Close(); err != nil && !pnet.IsDisconnectError(err) {
-					bo.logger.Error("close connection in health check failed", zap.Error(err))
-				}
+			if err != nil {
+				return err
 			}
+			if err = conn.SetReadDeadline(time.Now().Add(bo.healthCheckConfig.DialTimeout)); err != nil {
+				return err
+			}
+			serverVersion, err = pnet.ReadServerVersion(conn)
+			if ignoredErr := conn.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
+				bo.logger.Warn("close connection in health check failed", zap.Error(ignoredErr))
+			}
+			bh.serverVersion = serverVersion
 			return err
 		})
-		if err == nil {
-			curBackendStatus[addr] = StatusHealthy
+		if err != nil {
+			bh.status = StatusCannotConnect
+			bh.pingErr = err
 		}
 	}
-	return curBackendStatus
+	return curBackendHealth
 }
 
-func (bo *BackendObserver) notifyIfChanged(backendStatus map[string]BackendStatus) {
-	updatedBackends := make(map[string]BackendStatus)
-	for addr, lastStatus := range bo.curBackendInfo {
-		if lastStatus == StatusHealthy {
-			if newStatus, ok := backendStatus[addr]; !ok {
-				updatedBackends[addr] = StatusCannotConnect
-				updateBackendStatusMetrics(addr, lastStatus, StatusCannotConnect)
-			} else if newStatus != StatusHealthy {
-				updatedBackends[addr] = newStatus
-				updateBackendStatusMetrics(addr, lastStatus, newStatus)
+func (bo *BackendObserver) notifyIfChanged(bhMap map[string]*backendHealth) {
+	updatedBackends := make(map[string]*backendHealth)
+	for addr, lastHealth := range bo.curBackendInfo {
+		if lastHealth.status == StatusHealthy {
+			if newHealth, ok := bhMap[addr]; !ok {
+				updatedBackends[addr] = &backendHealth{
+					status:  StatusCannotConnect,
+					pingErr: errors.New("removed from backend list"),
+				}
+				updateBackendStatusMetrics(addr, lastHealth.status, StatusCannotConnect)
+			} else if newHealth.status != StatusHealthy {
+				updatedBackends[addr] = newHealth
+				updateBackendStatusMetrics(addr, lastHealth.status, newHealth.status)
 			}
 		}
 	}
-	for addr, newStatus := range backendStatus {
-		if newStatus == StatusHealthy {
-			lastStatus, ok := bo.curBackendInfo[addr]
+	for addr, newHealth := range bhMap {
+		if newHealth.status == StatusHealthy {
+			lastHealth, ok := bo.curBackendInfo[addr]
 			if !ok {
-				lastStatus = StatusCannotConnect
+				lastHealth = &backendHealth{
+					status: StatusCannotConnect,
+				}
 			}
-			if lastStatus != StatusHealthy {
-				updatedBackends[addr] = newStatus
-				updateBackendStatusMetrics(addr, lastStatus, newStatus)
+			if lastHealth.status != StatusHealthy {
+				updatedBackends[addr] = newHealth
+				updateBackendStatusMetrics(addr, lastHealth.status, newHealth.status)
+			} else if lastHealth.serverVersion != newHealth.serverVersion {
+				// Not possible here: the backend finishes upgrading between two health checks.
+				updatedBackends[addr] = newHealth
 			}
 		}
 	}
 	// Notify it even when the updatedBackends is empty, in order to clear the last error.
 	bo.eventReceiver.OnBackendChanged(updatedBackends, nil)
-	bo.curBackendInfo = backendStatus
+	bo.curBackendInfo = bhMap
 }
 
 // Close releases all resources.

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -239,7 +239,7 @@ func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]
 			})
 			if err != nil {
 				bh.status = StatusCannotConnect
-				bh.pingErr = err
+				bh.pingErr = errors.Wrapf(err, "connect status port failed")
 				continue
 			}
 		}
@@ -265,7 +265,7 @@ func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]
 		})
 		if err != nil {
 			bh.status = StatusCannotConnect
-			bh.pingErr = err
+			bh.pingErr = errors.Wrapf(err, "connect sql port failed")
 		}
 	}
 	return curBackendHealth

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -34,12 +34,14 @@ type ConnEventReceiver interface {
 
 // Router routes client connections to backends.
 type Router interface {
-	// Router will handle connection events to balance connections if possible.
+	// ConnEventReceiver handles connection events to balance connections if possible.
 	ConnEventReceiver
 
 	GetBackendSelector() BackendSelector
 	RedirectConnections() error
 	ConnCount() int
+	// ServerVersion returns the TiDB version.
+	ServerVersion() string
 	Close()
 }
 
@@ -82,8 +84,8 @@ type RedirectableConn interface {
 
 // backendWrapper contains the connections on the backend.
 type backendWrapper struct {
-	status BackendStatus
-	addr   string
+	*backendHealth
+	addr string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
 	// connScore = connList.Len() + incoming connections - outgoing connections.
 	connScore int

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -58,6 +58,10 @@ func (r *StaticRouter) ConnCount() int {
 	return r.cnt
 }
 
+func (r *StaticRouter) ServerVersion() string {
+	return ""
+}
+
 func (r *StaticRouter) Close() {
 }
 

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -136,11 +136,13 @@ func (tester *routerTester) createConn() *mockRedirectableConn {
 }
 
 func (tester *routerTester) addBackends(num int) {
-	backends := make(map[string]BackendStatus)
+	backends := make(map[string]*backendHealth)
 	for i := 0; i < num; i++ {
 		tester.backendID++
 		addr := strconv.Itoa(tester.backendID)
-		backends[addr] = StatusHealthy
+		backends[addr] = &backendHealth{
+			status: StatusHealthy,
+		}
 		metrics.BackendConnGauge.WithLabelValues(addr).Set(0)
 	}
 	tester.router.OnBackendChanged(backends, nil)
@@ -148,7 +150,7 @@ func (tester *routerTester) addBackends(num int) {
 }
 
 func (tester *routerTester) killBackends(num int) {
-	backends := make(map[string]BackendStatus)
+	backends := make(map[string]*backendHealth)
 	indexes := rand.Perm(tester.router.backends.Len())
 	for _, index := range indexes {
 		if len(backends) >= num {
@@ -159,15 +161,19 @@ func (tester *routerTester) killBackends(num int) {
 		if backend.status == StatusCannotConnect {
 			continue
 		}
-		backends[backend.addr] = StatusCannotConnect
+		backends[backend.addr] = &backendHealth{
+			status: StatusCannotConnect,
+		}
 	}
 	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
 }
 
 func (tester *routerTester) updateBackendStatusByAddr(addr string, status BackendStatus) {
-	backends := map[string]BackendStatus{
-		addr: status,
+	backends := map[string]*backendHealth{
+		addr: {
+			status: status,
+		},
 	}
 	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
@@ -645,13 +651,19 @@ func TestConcurrency(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	// Create 3 backends.
-	backends := map[string]BackendStatus{
-		"0": StatusHealthy,
-		"1": StatusHealthy,
-		"2": StatusHealthy,
+	backends := map[string]*backendHealth{
+		"0": &backendHealth{
+			status: StatusHealthy,
+		},
+		"1": &backendHealth{
+			status: StatusHealthy,
+		},
+		"2": &backendHealth{
+			status: StatusHealthy,
+		},
 	}
 	router.OnBackendChanged(backends, nil)
-	for addr, status := range backends {
+	for addr, health := range backends {
 		func(addr string, status BackendStatus) {
 			wg.Run(func() {
 				for {
@@ -666,12 +678,14 @@ func TestConcurrency(t *testing.T) {
 					} else {
 						status = StatusHealthy
 					}
-					router.OnBackendChanged(map[string]BackendStatus{
-						addr: status,
+					router.OnBackendChanged(map[string]*backendHealth{
+						addr: {
+							status: status,
+						},
 					}, nil)
 				}
 			})
-		}(addr, status)
+		}(addr, health.status)
 	}
 
 	// Create 20 connections.
@@ -875,4 +889,22 @@ func TestSetBackendStatus(t *testing.T) {
 	for _, conn := range tester.conns {
 		require.Equal(t, StatusHealthy, conn.status)
 	}
+}
+
+func TestGetServerVersion(t *testing.T) {
+	rt := NewScoreBasedRouter(logger.CreateLoggerForTest(t))
+	t.Cleanup(rt.Close)
+	backends := map[string]*backendHealth{
+		"0": {
+			status:        StatusHealthy,
+			serverVersion: "1.0",
+		},
+		"1": {
+			status:        StatusHealthy,
+			serverVersion: "2.0",
+		},
+	}
+	rt.OnBackendChanged(backends, nil)
+	version := rt.ServerVersion()
+	require.True(t, version == "1.0" || version == "2.0")
 }

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -652,13 +652,13 @@ func TestConcurrency(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	// Create 3 backends.
 	backends := map[string]*backendHealth{
-		"0": &backendHealth{
+		"0": {
 			status: StatusHealthy,
 		},
-		"1": &backendHealth{
+		"1": {
 			status: StatusHealthy,
 		},
-		"2": &backendHealth{
+		"2": {
 			status: StatusHealthy,
 		},
 	}

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -134,6 +134,15 @@ func (handler *DefaultHandshakeHandler) GetServerVersion() string {
 	if len(handler.serverVersion) > 0 {
 		return handler.serverVersion
 	}
+	// TiProxy sends the server version before getting the router, so we don't know which router to get.
+	// Just get the default one.
+	if ns, ok := handler.nsManager.GetNamespace("default"); ok {
+		if rt := ns.GetRouter(); rt != nil {
+			if serverVersion := rt.ServerVersion(); len(serverVersion) > 0 {
+				return serverVersion
+			}
+		}
+	}
 	return pnet.ServerVersion
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #272, #217

Problem Summary:
- When a client connects to the dedicated tier, the server version is always `5.7.25-TiDB-None`
- We can't see why TiProxy thinks a TiDB is down when troubleshooting

What is changed and how it works:
- Replace `BackendStatus` with `backendHealth` to store `serverVersion` and `pingErr`
- Read the server version from the backend during health checks
- Send the server version of any backend to the client when handshake. It may be wrong when there are multiple versions running
- Log the error why TiProxy can't connect to TiDB when TiDB is removed from the router

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Start a TiDB cluster with v7.0.0
2. Start a MySQL client to connect to it and the client shows `Server version: 5.7.25-TiDB-v7.0.0 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible`
3. Scale in one TiDB and TiProxy logs `[update backend] [namespace=default] [backend_addr=127.0.0.1:4000] [prev="status: healthy"] [cur="status: down, err: http status 500: connect status port failed"]`

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
