### PR TITLE
backend: ignore parsing attrs error during handshake

### DIFF
--- a/lib/util/errors/error.go
+++ b/lib/util/errors/error.go
@@ -91,3 +91,20 @@ func (e *Error) As(target interface{}) bool {
 func (e *Error) Unwrap() error {
 	return errors.Unwrap(e.err)
 }
+
+type Warning struct {
+	Err error
+}
+
+func (e *Warning) Error() string {
+	return e.Err.Error()
+}
+
+func (e *Warning) Unwrap() error {
+	return e.Err
+}
+
+func (e *Warning) Is(target error) bool {
+	_, ok := target.(*Warning)
+	return ok
+}

--- a/lib/util/errors/error_test.go
+++ b/lib/util/errors/error_test.go
@@ -42,3 +42,10 @@ func TestUnwrap(t *testing.T) {
 	require.ErrorIs(t, e2, e1, "stacktrace does not affect Is")
 	require.ErrorAs(t, e2, &e1, "stacktrace does not affect As")
 }
+
+func TestWarning(t *testing.T) {
+	warning := &serr.Warning{Err: serr.Wrapf(serr.New("internal err"), "msg")}
+	var w *serr.Warning
+	require.True(t, serr.As(warning, &w))
+	require.Equal(t, "internal err: msg", warning.Error())
+}

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -154,7 +154,13 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	if isSSL {
 		cctx.SetValue(ConnContextKeyTLSState, clientIO.TLSConnectionState())
 	}
-	clientResp := pnet.ParseHandshakeResponse(pkt)
+	clientResp, err := pnet.ParseHandshakeResponse(pkt)
+	var warning *errors.Warning
+	if errors.As(err, &warning) {
+		logger.Warn("parse handshake response encounters error", zap.Error(err))
+	} else {
+		return WrapUserError(err, err.Error())
+	}
 	if err = handshakeHandler.HandleHandshakeResp(cctx, clientResp); err != nil {
 		return WrapUserError(err, err.Error())
 	}

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -158,7 +158,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	var warning *errors.Warning
 	if errors.As(err, &warning) {
 		logger.Warn("parse handshake response encounters error", zap.Error(err))
-	} else {
+	} else if err != nil {
 		return WrapUserError(err, parsePktErrMsg)
 	}
 	if err = handshakeHandler.HandleHandshakeResp(cctx, clientResp); err != nil {

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -159,7 +159,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	if errors.As(err, &warning) {
 		logger.Warn("parse handshake response encounters error", zap.Error(err))
 	} else {
-		return WrapUserError(err, err.Error())
+		return WrapUserError(err, parsePktErrMsg)
 	}
 	if err = handshakeHandler.HandleHandshakeResp(cctx, clientResp); err != nil {
 		return WrapUserError(err, err.Error())

--- a/pkg/proxy/backend/error.go
+++ b/pkg/proxy/backend/error.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	connectErrMsg    = "No available TiDB instances, please check TiDB cluster"
+	parsePktErrMsg   = "TiProxy fails to parse the packet, please contact PingCAP"
 	handshakeErrMsg  = "TiProxy fails to connect to TiDB, please check network"
 	capabilityErrMsg = "Verify TiDB capability failed, please upgrade TiDB"
 )

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -95,7 +95,10 @@ func (mb *mockBackend) authenticate(packetIO *pnet.PacketIO) error {
 			return err
 		}
 	}
-	resp := pnet.ParseHandshakeResponse(clientPkt)
+	resp, err := pnet.ParseHandshakeResponse(clientPkt)
+	if err != nil {
+		return err
+	}
 	mb.username = resp.User
 	mb.db = resp.DB
 	mb.authData = resp.AuthData

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -77,7 +77,7 @@ type HandshakeResp struct {
 	Collation  uint8
 }
 
-func ParseHandshakeResponse(data []byte) *HandshakeResp {
+func ParseHandshakeResponse(data []byte) (*HandshakeResp, error) {
 	resp := new(HandshakeResp)
 	pos := 0
 	// capability
@@ -138,18 +138,18 @@ func ParseHandshakeResponse(data []byte) *HandshakeResp {
 	}
 
 	// attrs
+	var err error
 	if resp.Capability&mysql.ClientConnectAtts > 0 {
 		if num, null, off := ParseLengthEncodedInt(data[pos:]); !null {
 			pos += off
 			row := data[pos : pos+int(num)]
-			attrs, err := parseAttrs(row)
+			resp.Attrs, err = parseAttrs(row)
 			if err != nil {
-				return nil
+				err = &errors.Warning{Err: errors.Wrapf(err, "parse attrs failed")}
 			}
-			resp.Attrs = attrs
 		}
 	}
-	return resp
+	return resp, err
 }
 
 func parseAttrs(data []byte) (map[string]string, error) {

--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -32,6 +32,7 @@ func TestHandshakeResp(t *testing.T) {
 		Collation:  0,
 	}
 	b := MakeHandshakeResponse(resp1)
-	resp2 := ParseHandshakeResponse(b)
+	resp2, err := ParseHandshakeResponse(b)
 	require.Equal(t, resp1, resp2)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #283

Problem Summary:
TiProxy encounters an error during parsing attributes and it panicked.

What is changed and how it works:
- Add a Warning type and a user error msg
- Ignore the error during parsing attrs

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
