### PR TITLE
backend, net: return handshake errors to the client

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -111,7 +111,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	if err := clientIO.WriteInitialHandshake(proxyCapability, auth.salt, mysql.AuthNativePassword, handshakeHandler.GetServerVersion()); err != nil {
 		return err
 	}
-	pkt, isSSL, err := clientIO.ReadSSLRequestOrHandshakeResp(logger)
+	pkt, isSSL, err := clientIO.ReadSSLRequestOrHandshakeResp()
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 		if _, err = clientIO.ServerTLSHandshake(frontendTLSConfig); err != nil {
 			return pnet.WrapUserError(err, err.Error())
 		}
-		pkt, _, err = clientIO.ReadSSLRequestOrHandshakeResp(logger)
+		pkt, _, err = clientIO.ReadSSLRequestOrHandshakeResp()
 		if err != nil {
 			return err
 		}

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -111,21 +111,18 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	if err := clientIO.WriteInitialHandshake(proxyCapability, auth.salt, mysql.AuthNativePassword, handshakeHandler.GetServerVersion()); err != nil {
 		return err
 	}
-	pkt, isSSL, err := clientIO.ReadSSLRequestOrHandshakeResp()
+	pkt, isSSL, err := clientIO.ReadSSLRequestOrHandshakeResp(logger)
 	if err != nil {
 		return err
 	}
 	frontendCapability := pnet.Capability(binary.LittleEndian.Uint32(pkt))
 	if isSSL {
 		if _, err = clientIO.ServerTLSHandshake(frontendTLSConfig); err != nil {
-			return err
+			return pnet.WrapUserError(err, err.Error())
 		}
-		pkt, _, err = clientIO.ReadSSLRequestOrHandshakeResp()
+		pkt, _, err = clientIO.ReadSSLRequestOrHandshakeResp(logger)
 		if err != nil {
 			return err
-		}
-		if len(pkt) <= 32 {
-			return errors.WithStack(errors.New("expect handshake resp"))
 		}
 		frontendCapabilityResponse := pnet.Capability(binary.LittleEndian.Uint32(pkt))
 		if frontendCapability != frontendCapabilityResponse {
@@ -137,7 +134,11 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	}
 	if commonCaps := frontendCapability & requiredFrontendCaps; commonCaps != requiredFrontendCaps {
 		logger.Error("require frontend capabilities", zap.Stringer("common", commonCaps), zap.Stringer("required", requiredFrontendCaps))
-		return errors.Wrapf(ErrCapabilityNegotiation, "require %s from frontend", requiredFrontendCaps&^commonCaps)
+		mysqlErr := mysql.NewErr(mysql.ErrNotSupportedAuthMode)
+		if writeErr := clientIO.WriteErrPacket(mysqlErr); writeErr != nil {
+			return writeErr
+		}
+		return mysqlErr
 	}
 	commonCaps := frontendCapability & proxyCapability
 	if frontendCapability^commonCaps != 0 {
@@ -159,10 +160,10 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	if errors.As(err, &warning) {
 		logger.Warn("parse handshake response encounters error", zap.Error(err))
 	} else if err != nil {
-		return WrapUserError(err, parsePktErrMsg)
+		return pnet.WrapUserError(err, parsePktErrMsg)
 	}
 	if err = handshakeHandler.HandleHandshakeResp(cctx, clientResp); err != nil {
-		return WrapUserError(err, err.Error())
+		return pnet.WrapUserError(err, err.Error())
 	}
 	auth.user = clientResp.User
 	auth.dbname = clientResp.DB
@@ -172,13 +173,13 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	// In case of testing, backendIO is passed manually that we don't want to bother with the routing logic.
 	backendIO, err := getBackendIO(cctx, auth, clientResp, 15*time.Second)
 	if err != nil {
-		return WrapUserError(err, connectErrMsg)
+		return pnet.WrapUserError(err, connectErrMsg)
 	}
 	backendIO.ResetSequence()
 
 	// write proxy header
 	if err := auth.writeProxyProtocol(clientIO, backendIO); err != nil {
-		return WrapUserError(err, handshakeErrMsg)
+		return pnet.WrapUserError(err, handshakeErrMsg)
 	}
 
 	// read backend initial handshake
@@ -190,11 +191,11 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 			}
 			return err
 		}
-		return WrapUserError(err, handshakeErrMsg)
+		return pnet.WrapUserError(err, handshakeErrMsg)
 	}
 
 	if err := auth.verifyBackendCaps(logger, backendCapability); err != nil {
-		return WrapUserError(err, capabilityErrMsg)
+		return pnet.WrapUserError(err, capabilityErrMsg)
 	}
 
 	if common := proxyCapability & backendCapability; (proxyCapability^common)&^pnet.ClientSSL != 0 {
@@ -215,7 +216,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 		// send an unknown auth plugin so that the backend will request the auth data again.
 		unknownAuthPlugin, nil, 0,
 	); err != nil {
-		return WrapUserError(err, handshakeErrMsg)
+		return pnet.WrapUserError(err, handshakeErrMsg)
 	}
 
 	// forward other packets

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -134,11 +134,10 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	}
 	if commonCaps := frontendCapability & requiredFrontendCaps; commonCaps != requiredFrontendCaps {
 		logger.Error("require frontend capabilities", zap.Stringer("common", commonCaps), zap.Stringer("required", requiredFrontendCaps))
-		mysqlErr := mysql.NewErr(mysql.ErrNotSupportedAuthMode)
-		if writeErr := clientIO.WriteErrPacket(mysqlErr); writeErr != nil {
+		if writeErr := clientIO.WriteErrPacket(mysql.NewErr(mysql.ErrNotSupportedAuthMode)); writeErr != nil {
 			return writeErr
 		}
-		return mysqlErr
+		return errors.Wrapf(ErrCapabilityNegotiation, "require %s from frontend", requiredFrontendCaps&^commonCaps)
 	}
 	commonCaps := frontendCapability & proxyCapability
 	if frontendCapability^commonCaps != 0 {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -174,7 +174,7 @@ func (mgr *BackendConnManager) Connect(ctx context.Context, clientIO *pnet.Packe
 	if err != nil {
 		mgr.setQuitSourceByErr(err)
 		mgr.handshakeHandler.OnHandshake(mgr, mgr.ServerAddr(), err)
-		WriteUserError(clientIO, err, mgr.logger)
+		clientIO.WriteUserError(err, mgr.logger)
 		return err
 	}
 	mgr.resetQuitSource()
@@ -193,7 +193,7 @@ func (mgr *BackendConnManager) Connect(ctx context.Context, clientIO *pnet.Packe
 func (mgr *BackendConnManager) getBackendIO(cctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp, timeout time.Duration) (*pnet.PacketIO, error) {
 	r, err := mgr.handshakeHandler.GetRouter(cctx, resp)
 	if err != nil {
-		return nil, WrapUserError(err, err.Error())
+		return nil, pnet.WrapUserError(err, err.Error())
 	}
 	// Reasons to wait:
 	// - The TiDB instances may not be initialized yet
@@ -213,7 +213,7 @@ func (mgr *BackendConnManager) getBackendIO(cctx ConnContext, auth *Authenticato
 				addr, err = selector.Next()
 			}
 			if err != nil {
-				return nil, backoff.Permanent(WrapUserError(err, err.Error()))
+				return nil, backoff.Permanent(pnet.WrapUserError(err, err.Error()))
 			}
 			if addr == "" {
 				return nil, router.ErrNoInstanceToSelect

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -28,6 +28,7 @@ import (
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 const (
@@ -92,6 +93,7 @@ type runner struct {
 type backendMgrTester struct {
 	*testSuite
 	t      *testing.T
+	lg     *zap.Logger
 	closed bool
 }
 
@@ -104,6 +106,7 @@ func newBackendMgrTester(t *testing.T, cfg ...cfgOverrider) *backendMgrTester {
 	tester := &backendMgrTester{
 		testSuite: ts,
 		t:         t,
+		lg:        logger.CreateLoggerForTest(t),
 	}
 	t.Cleanup(func() {
 		clean()
@@ -132,7 +135,7 @@ func (ts *backendMgrTester) firstHandshake4Proxy(clientIO, backendIO *pnet.Packe
 func (ts *backendMgrTester) handshake4Backend(packetIO *pnet.PacketIO) error {
 	conn, err := ts.tc.backendListener.Accept()
 	require.NoError(ts.t, err)
-	ts.tc.backendIO = pnet.NewPacketIO(conn)
+	ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg)
 	return ts.mb.authenticate(ts.tc.backendIO)
 }
 
@@ -382,7 +385,7 @@ func TestConnectFail(t *testing.T) {
 			backend: func(_ *pnet.PacketIO) error {
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(ts.t, err)
-				ts.tc.backendIO = pnet.NewPacketIO(conn)
+				ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg)
 				ts.mb.authSucceed = false
 				return ts.mb.authenticate(ts.tc.backendIO)
 			},
@@ -426,7 +429,7 @@ func TestRedirectFail(t *testing.T) {
 				require.NoError(t, err)
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(t, err)
-				tmpBackendIO := pnet.NewPacketIO(conn)
+				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg)
 				// auth fails
 				ts.mb.authSucceed = false
 				err = ts.mb.authenticate(tmpBackendIO)
@@ -447,7 +450,7 @@ func TestRedirectFail(t *testing.T) {
 				require.NoError(ts.t, err)
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(ts.t, err)
-				tmpBackendIO := pnet.NewPacketIO(conn)
+				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg)
 				ts.mb.authSucceed = true
 				err = ts.mb.authenticate(tmpBackendIO)
 				require.NoError(t, err)

--- a/pkg/proxy/backend/cmd_processor_test.go
+++ b/pkg/proxy/backend/cmd_processor_test.go
@@ -1037,7 +1037,7 @@ func TestNetworkError(t *testing.T) {
 	clientErrChecker := func(t *testing.T, ts *testSuite) {
 		require.True(t, pnet.IsDisconnectError(ts.mp.err))
 		require.True(t, pnet.IsDisconnectError(ts.mc.err))
-		require.NotNil(t, ts.mp.err.(*UserError))
+		require.NotNil(t, ts.mp.err.(*pnet.UserError))
 	}
 	backendErrChecker := func(t *testing.T, ts *testSuite) {
 		require.True(t, pnet.IsDisconnectError(ts.mp.err))

--- a/pkg/proxy/backend/error.go
+++ b/pkg/proxy/backend/error.go
@@ -16,9 +16,6 @@ package backend
 
 import (
 	"github.com/pingcap/TiProxy/lib/util/errors"
-	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
-	"github.com/pingcap/tidb/parser/mysql"
-	"go.uber.org/zap"
 )
 
 const (
@@ -32,50 +29,3 @@ var (
 	ErrClientConn  = errors.New("this is an error from client")
 	ErrBackendConn = errors.New("this is an error from backend")
 )
-
-// UserError is returned to the client.
-// err is used to log and userMsg is used to report to the user.
-type UserError struct {
-	err     error
-	userMsg string
-}
-
-func WrapUserError(err error, userMsg string) *UserError {
-	if err == nil {
-		return nil
-	}
-	if ue, ok := err.(*UserError); ok {
-		return ue
-	}
-	return &UserError{
-		err:     err,
-		userMsg: userMsg,
-	}
-}
-
-func (ue *UserError) UserMsg() string {
-	return ue.userMsg
-}
-
-func (ue *UserError) Unwrap() error {
-	return ue.err
-}
-
-func (ue *UserError) Error() string {
-	return ue.err.Error()
-}
-
-// WriteUserError writes an unknown error to the client.
-func WriteUserError(clientIO *pnet.PacketIO, err error, lg *zap.Logger) {
-	if err == nil {
-		return
-	}
-	var ue *UserError
-	if !errors.As(err, &ue) {
-		return
-	}
-	myErr := mysql.NewErrf(mysql.ErrUnknown, "%s", nil, ue.UserMsg())
-	if writeErr := clientIO.WriteErrPacket(myErr); writeErr != nil {
-		lg.Error("writing error to client failed", zap.NamedError("mysql_err", err), zap.NamedError("write_err", writeErr))
-	}
-}

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -41,7 +41,7 @@ func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *t
 	if bcConfig.ProxyProtocol {
 		opts = append(opts, pnet.WithProxy)
 	}
-	pkt := pnet.NewPacketIO(conn, opts...)
+	pkt := pnet.NewPacketIO(conn, logger, opts...)
 	return &ClientConnection{
 		logger:            logger.With(zap.Bool("proxy-protocol", bcConfig.ProxyProtocol)),
 		frontendTLSConfig: frontendTLSConfig,

--- a/pkg/proxy/net/error.go
+++ b/pkg/proxy/net/error.go
@@ -14,7 +14,9 @@
 
 package net
 
-import "github.com/pingcap/TiProxy/lib/util/errors"
+import (
+	"github.com/pingcap/TiProxy/lib/util/errors"
+)
 
 var (
 	ErrExpectSSLRequest = errors.New("expect a SSLRequest packet")
@@ -24,3 +26,35 @@ var (
 	ErrCloseConn        = errors.New("failed to close the connection")
 	ErrHandshakeTLS     = errors.New("failed to complete tls handshake")
 )
+
+// UserError is returned to the client.
+// err is used to log and userMsg is used to report to the user.
+type UserError struct {
+	err     error
+	userMsg string
+}
+
+func WrapUserError(err error, userMsg string) *UserError {
+	if err == nil {
+		return nil
+	}
+	if ue, ok := err.(*UserError); ok {
+		return ue
+	}
+	return &UserError{
+		err:     err,
+		userMsg: userMsg,
+	}
+}
+
+func (ue *UserError) UserMsg() string {
+	return ue.userMsg
+}
+
+func (ue *UserError) Unwrap() error {
+	return ue.err
+}
+
+func (ue *UserError) Error() string {
+	return ue.err.Error()
+}

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/TiProxy/pkg/proxy/proxyprotocol"
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/util/dbterror"
+	"go.uber.org/zap"
 )
 
 var (
@@ -84,12 +85,13 @@ type PacketIO struct {
 	buf           *bufio.ReadWriter
 	proxyInited   atomic.Bool
 	proxy         *proxyprotocol.Proxy
+	logger        *zap.Logger
 	remoteAddr    net.Addr
 	wrap          error
 	sequence      uint8
 }
 
-func NewPacketIO(conn net.Conn, opts ...PacketIOption) *PacketIO {
+func NewPacketIO(conn net.Conn, lg *zap.Logger, opts ...PacketIOption) *PacketIO {
 	buf := bufio.NewReadWriter(
 		bufio.NewReaderSize(conn, defaultReaderSize),
 		bufio.NewWriterSize(conn, defaultWriterSize),
@@ -100,6 +102,7 @@ func NewPacketIO(conn net.Conn, opts ...PacketIOption) *PacketIO {
 			conn,
 			buf.Reader,
 		},
+		logger:   lg,
 		sequence: 0,
 		buf:      buf,
 	}

--- a/pkg/proxy/net/packetio_mysql.go
+++ b/pkg/proxy/net/packetio_mysql.go
@@ -87,14 +87,14 @@ func (p *PacketIO) WriteShaCommand() error {
 	return p.WritePacket([]byte{ShaCommand, FastAuthFail}, true)
 }
 
-func (p *PacketIO) ReadSSLRequestOrHandshakeResp(lg *zap.Logger) (pkt []byte, isSSL bool, err error) {
+func (p *PacketIO) ReadSSLRequestOrHandshakeResp() (pkt []byte, isSSL bool, err error) {
 	pkt, err = p.ReadPacket()
 	if err != nil {
 		return
 	}
 
 	if len(pkt) < 32 {
-		lg.Error("got malformed handshake response", zap.ByteString("packetData", pkt))
+		p.logger.Error("got malformed handshake response", zap.ByteString("packetData", pkt))
 		err = WrapUserError(mysql.ErrMalformPacket, mysql.ErrMalformPacket.Error())
 		return
 	}
@@ -138,7 +138,7 @@ func (p *PacketIO) WriteEOFPacket(status uint16) error {
 }
 
 // WriteUserError writes an unknown error to the client.
-func (p *PacketIO) WriteUserError(err error, lg *zap.Logger) {
+func (p *PacketIO) WriteUserError(err error) {
 	if err == nil {
 		return
 	}
@@ -148,6 +148,6 @@ func (p *PacketIO) WriteUserError(err error, lg *zap.Logger) {
 	}
 	myErr := mysql.NewErrf(mysql.ErrUnknown, "%s", nil, ue.UserMsg())
 	if writeErr := p.WriteErrPacket(myErr); writeErr != nil {
-		lg.Error("writing error to client failed", zap.NamedError("mysql_err", err), zap.NamedError("write_err", writeErr))
+		p.logger.Error("writing error to client failed", zap.NamedError("mysql_err", err), zap.NamedError("write_err", writeErr))
 	}
 }

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/security"
 	"github.com/pingcap/TiProxy/pkg/testkit"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -54,6 +55,7 @@ func testTCPConn(t *testing.T, a func(*testing.T, *PacketIO), b func(*testing.T,
 func TestPacketIO(t *testing.T) {
 	expectMsg := []byte("test")
 	pktLengths := []int{0, mysql.MaxPayloadLen + 212, mysql.MaxPayloadLen, mysql.MaxPayloadLen * 2}
+	lg := logger.CreateLoggerForTest(t).Named("TestPacketIO")
 	testPipeConn(t,
 		func(t *testing.T, cli *PacketIO) {
 			var err error
@@ -107,10 +109,10 @@ func TestPacketIO(t *testing.T) {
 			require.ErrorIs(t, srv.WriteInitialHandshake(0, make([]byte, 4), mysql.AuthNativePassword, ServerVersion), ErrSaltNotLongEnough)
 
 			// expect correct and wrong capability flags
-			_, isSSL, err := srv.ReadSSLRequestOrHandshakeResp()
+			_, isSSL, err := srv.ReadSSLRequestOrHandshakeResp(lg)
 			require.NoError(t, err)
 			require.True(t, isSSL)
-			_, isSSL, err = srv.ReadSSLRequestOrHandshakeResp()
+			_, isSSL, err = srv.ReadSSLRequestOrHandshakeResp(lg)
 			require.NoError(t, err)
 			require.False(t, isSSL)
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #188 

Problem Summary:
Some errors are not returned to the client, compared with TiDB.

What is changed and how it works:
- Move `UserError` from package `backend` to `net` because `net` uses it.
- Return `ErrNotSupportedAuthMode` to the client when frontend capability mismatches. This is consistent with TiDB.
- Return `ErrMalformPacket` when packet size is less than 32. This is consistent with TiDB.
- Return error to the client when TLS handshake fails. This is consistent with TiDB.
- Embed logger into PacketIO.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
