### PR TITLE
backend: fix authenticator tests

### DIFF
--- a/pkg/proxy/backend/authenticator_test.go
+++ b/pkg/proxy/backend/authenticator_test.go
@@ -27,50 +27,50 @@ func TestUnsupportedCapability(t *testing.T) {
 	cfgs := [][]cfgOverrider{
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientSSL
+				cfg.clientConfig.capability &= ^pnet.ClientSSL
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientSSL
-			},
-		},
-		{
-			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestBackendCapability & ^pnet.ClientSSL
-			},
-			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestBackendCapability | pnet.ClientSSL
+				cfg.clientConfig.capability |= pnet.ClientSSL
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestBackendCapability & ^pnet.ClientDeprecateEOF
+				cfg.backendConfig.capability &= ^pnet.ClientSSL
 			},
 			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestBackendCapability | pnet.ClientDeprecateEOF
-			},
-		},
-		{
-			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientProtocol41
-			},
-			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientProtocol41
+				cfg.backendConfig.capability |= pnet.ClientSSL
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestClientCapability & ^pnet.ClientPSMultiResults
+				cfg.backendConfig.capability &= ^pnet.ClientDeprecateEOF
 			},
 			func(cfg *testConfig) {
-				cfg.backendConfig.capability = defaultTestClientCapability | pnet.ClientPSMultiResults
+				cfg.backendConfig.capability |= pnet.ClientDeprecateEOF
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientPSMultiResults
+				cfg.clientConfig.capability &= ^pnet.ClientProtocol41
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientPSMultiResults
+				cfg.clientConfig.capability |= pnet.ClientProtocol41
+			},
+		},
+		{
+			func(cfg *testConfig) {
+				cfg.backendConfig.capability &= ^pnet.ClientPSMultiResults
+			},
+			func(cfg *testConfig) {
+				cfg.backendConfig.capability |= pnet.ClientPSMultiResults
+			},
+		},
+		{
+			func(cfg *testConfig) {
+				cfg.clientConfig.capability &= ^pnet.ClientPSMultiResults
+			},
+			func(cfg *testConfig) {
+				cfg.clientConfig.capability |= pnet.ClientPSMultiResults
 			},
 		},
 	}
@@ -151,27 +151,27 @@ func TestCapability(t *testing.T) {
 	cfgs := [][]cfgOverrider{
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientConnectWithDB
+				cfg.clientConfig.capability &= ^pnet.ClientConnectWithDB
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientConnectWithDB
+				cfg.clientConfig.capability |= pnet.ClientConnectWithDB
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientConnectAttrs
+				cfg.clientConfig.capability &= ^pnet.ClientConnectAttrs
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientConnectAttrs
+				cfg.clientConfig.capability |= pnet.ClientConnectAttrs
 				cfg.clientConfig.attrs = map[string]string{"key": "value"}
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientSecureConnection
+				cfg.clientConfig.capability &= ^pnet.ClientSecureConnection
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.capability = defaultTestClientCapability | pnet.ClientSecureConnection
+				cfg.clientConfig.capability |= pnet.ClientSecureConnection
 			},
 		},
 	}

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -77,7 +77,10 @@ func getCfgCombinations(cfgs [][]cfgOverrider) [][]cfgOverrider {
 		// Append the cfg to each of the existing overrider list.
 		for _, cfg := range cfgList {
 			for _, o := range cfgOverriders {
-				newOverriders = append(newOverriders, append(o, cfg))
+				newOverrider := make([]cfgOverrider, 0, len(o)+1)
+				newOverrider = append(newOverrider, o...)
+				newOverrider = append(newOverrider, cfg)
+				newOverriders = append(newOverriders, newOverrider)
 			}
 		}
 		cfgOverriders = newOverriders
@@ -187,9 +190,13 @@ func (ts *testSuite) authenticateFirstTime(t *testing.T, c checker) {
 		// Check the data received by client equals to the data sent from the server and vice versa.
 		require.Equal(t, ts.mb.authSucceed, ts.mc.authSucceed)
 		require.Equal(t, ts.mc.username, ts.mb.username)
-		require.Equal(t, ts.mc.dbName, ts.mb.db)
+		if ts.mc.capability&pnet.ClientConnectWithDB > 0 {
+			require.Equal(t, ts.mc.dbName, ts.mb.db)
+		}
 		require.Equal(t, ts.mc.authData, ts.mb.authData)
-		require.Equal(t, ts.mc.attrs, ts.mb.attrs)
+		if ts.mc.capability&pnet.ClientConnectAttrs > 0 {
+			require.Equal(t, ts.mc.attrs, ts.mb.attrs)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #295

Problem Summary:
- The result of the function `getCfgCombinations` is wrong: the slice of `append(o, cfg)` is reused and thus overwrites previous slices, so the test doesn't cover all the cases.
- The cfgOverriders are wrong. E.g. `cfg.clientConfig.capability = defaultTestClientCapability & ^pnet.ClientPSMultiResults` overwrites other capabilities. It should be `cfg.clientConfig.capability &= ^pnet.ClientPSMultiResults` to only change the current capability. It also doesn't cover all the cases.

What is changed and how it works:
- Fix `getCfgCombinations`.
- Fix cfgOverriders.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
