### PR TITLE
backend: keep backend TLS config consistent with frontend TLS config

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -300,7 +300,8 @@ func (auth *Authenticator) writeAuthHandshake(
 	}
 
 	var pkt []byte
-	if backendCapability&pnet.ClientSSL != 0 && backendTLSConfig != nil {
+	// When client TLS is disabled, also disables proxy TLS.
+	if pnet.Capability(auth.capability)&pnet.ClientSSL != 0 && backendCapability&pnet.ClientSSL != 0 && backendTLSConfig != nil {
 		resp.Capability |= mysql.ClientSSL
 		pkt = pnet.MakeHandshakeResponse(resp)
 		// write SSL Packet

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	ErrCapabilityNegotiation = errors.New("capability negotiation failed")
+	ErrTLSConfigRequired     = errors.New("require TLS config on TiProxy when require-backend-tls=true")
 )
 
 const unknownAuthPlugin = "auth_unknown_plugin"
@@ -300,8 +301,17 @@ func (auth *Authenticator) writeAuthHandshake(
 	}
 
 	var pkt []byte
-	// When client TLS is disabled, also disables proxy TLS.
-	if pnet.Capability(auth.capability)&pnet.ClientSSL != 0 && backendCapability&pnet.ClientSSL != 0 && backendTLSConfig != nil {
+	var enableTLS bool
+	if auth.requireBackendTLS {
+		if backendTLSConfig == nil {
+			return ErrTLSConfigRequired
+		}
+		enableTLS = true
+	} else {
+		// When client TLS is disabled, also disables proxy TLS.
+		enableTLS = pnet.Capability(auth.capability)&pnet.ClientSSL != 0 && backendCapability&pnet.ClientSSL != 0 && backendTLSConfig != nil
+	}
+	if enableTLS {
 		resp.Capability |= mysql.ClientSSL
 		pkt = pnet.MakeHandshakeResponse(resp)
 		// write SSL Packet


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #302

Problem Summary:
Currently, the TLS config between client and TiProxy is specified by the client, the TLS between TiProxy and TiDB is always disabled.

In the current implementation, the TLS config between TiProxy and TiDB is specified by TiProxy config. However, what we want is to keep consistent with client -> TiProxy. That is:
- If client->TiProxy is enabled, TiProxy -> TiDB is also enabled
- If client->TiProxy is disabled, TiProxy -> TiDB is also disabled

What is changed and how it works:
Enable TLS between TiProxy and TiDB when:
- client enables TLS
- proxy configured TLS certs.
- backend supports TLS

This is compatible with both serverless and dedicated tiers.

However, this makes `RequireBackendTLS` sometimes useless: it requires TLS from the backend but it doesn't need TLS.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
