### PR TITLE
infosync, router: register TiProxy to ETCD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ DEBUG ?=
 DOCKERPREFIX ?=
 BUILD_TAGS ?=
 LDFLAGS ?=
-BUILDFLAGS ?= -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS) -X main.Version=$(VERSION) -X main.Commit=$(COMMIT)' -tags '$(BUILD_TAGS)'
+BUILDFLAGS ?= -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS) -X github.com/pingcap/TiProxy/pkg/util/versioninfo.TiProxyVersion=$(VERSION) -X github.com/pingcap/TiProxy/pkg/util/versioninfo.TiProxyGitHash=$(COMMIT)' -tags '$(BUILD_TAGS)'
 ifneq ("$(DEBUG)", "")
 	BUILDFLAGS += -race
 endif

--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -13,19 +13,15 @@ import (
 	"github.com/pingcap/TiProxy/pkg/metrics"
 	"github.com/pingcap/TiProxy/pkg/sctx"
 	"github.com/pingcap/TiProxy/pkg/server"
+	"github.com/pingcap/TiProxy/pkg/util/versioninfo"
 	"github.com/spf13/cobra"
-)
-
-var (
-	Version = "test"
-	Commit  = "test commit"
 )
 
 func main() {
 	rootCmd := &cobra.Command{
 		Use:     os.Args[0],
 		Short:   "start the proxy server",
-		Version: fmt.Sprintf("%s, commit %s", Version, Commit),
+		Version: fmt.Sprintf("%s, commit %s", versioninfo.TiProxyVersion, versioninfo.TiProxyGitHash),
 	}
 	rootCmd.SetOutput(os.Stdout)
 	rootCmd.SetErr(os.Stderr)

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,13 @@ go 1.19
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/bahlo/generic-list-go v0.2.0
-	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-contrib/pprof v1.4.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-mysql-org/go-mysql v1.6.0
 	github.com/pingcap/TiProxy/lib v0.0.0-00010101000000-000000000000
+	github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32
 	github.com/pingcap/tidb v1.1.0-beta.0.20230103132820-3ccff46aa3bc
 	github.com/pingcap/tidb/parser v0.0.0-20230103132820-3ccff46aa3bc
 	github.com/prometheus/client_golang v1.14.0
@@ -83,7 +84,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0 // indirect
-	github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32 // indirect
 	github.com/pingcap/failpoint v0.0.0-20220423142525-ae43b7f4e5c3 // indirect
 	github.com/pingcap/kvproto v0.0.0-20221213093948-9ccc6beaf0aa // indirect
 	github.com/pingcap/log v1.1.1-0.20221116035753-734d527bc87c // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	github.com/tidwall/btree v1.5.2
+	go.etcd.io/etcd/client/pkg/v3 v3.5.6
 	go.etcd.io/etcd/client/v3 v3.5.6
 	go.etcd.io/etcd/server/v3 v3.5.6
 	go.uber.org/atomic v1.10.0
@@ -113,7 +114,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.6 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.6 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.6 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.6 // indirect
 	go.etcd.io/etcd/raft/v3 v3.5.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blacktear23/go-proxyprotocol v1.0.2 h1:zR7PZeoU0wAkElcIXenFiy3R56WB6A+UEVi4c6RH8wo=
 github.com/carlmjohnson/flagext v0.21.0 h1:/c4uK3ie786Z7caXLcIMvePNSSiH3bQVGDvmGLMme60=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
-github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
-github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -3,6 +3,7 @@ module github.com/pingcap/TiProxy/lib
 go 1.18
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/atomic v1.9.0

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lib/util/retry/retry.go
+++ b/lib/util/retry/retry.go
@@ -1,0 +1,44 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package retry
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+const (
+	InfiniteCnt = 0
+)
+
+func NewBackOff(ctx context.Context, retryInterval time.Duration, retryCnt uint64) backoff.BackOff {
+	var bo backoff.BackOff
+	bo = backoff.NewConstantBackOff(retryInterval)
+	if ctx != nil {
+		bo = backoff.WithContext(bo, ctx)
+	}
+	if retryCnt != InfiniteCnt {
+		bo = backoff.WithMaxRetries(bo, retryCnt)
+	}
+	return bo
+}
+
+func Retry(o backoff.Operation, ctx context.Context, retryInterval time.Duration, retryCnt uint64) error {
+	bo := NewBackOff(ctx, retryInterval, retryCnt)
+	return backoff.Retry(o, bo)
+}
+
+func RetryNotify(o backoff.Operation, ctx context.Context, retryInterval time.Duration, retryCnt uint64,
+	notify backoff.Notify, notifyInterval uint64) error {
+	bo := NewBackOff(ctx, retryInterval, retryCnt)
+	var cnt uint64
+	return backoff.RetryNotify(o, bo, func(err error, duration time.Duration) {
+		if cnt%notifyInterval == 0 {
+			notify(err, duration)
+		}
+		cnt++
+	})
+}

--- a/lib/util/sys/sys.go
+++ b/lib/util/sys/sys.go
@@ -1,0 +1,19 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sys
+
+import "net"
+
+func GetLocalIP() string {
+	addrs, err := net.InterfaceAddrs()
+	if err == nil {
+		for _, address := range addrs {
+			ipnet, ok := address.(*net.IPNet)
+			if ok && ipnet.IP.IsGlobalUnicast() {
+				return ipnet.IP.String()
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/manager/infosync/etcd.go
+++ b/pkg/manager/infosync/etcd.go
@@ -1,0 +1,52 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package infosync
+
+import (
+	"strings"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/errors"
+	"github.com/pingcap/TiProxy/pkg/manager/cert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/keepalive"
+)
+
+// InitEtcdClient initializes an etcd client that fetches TiDB instance topology from PD.
+func InitEtcdClient(logger *zap.Logger, cfg *config.Config, certMgr *cert.CertManager) (*clientv3.Client, error) {
+	pdAddr := cfg.Proxy.PDAddrs
+	if len(pdAddr) == 0 {
+		// use tidb server addresses directly
+		return nil, nil
+	}
+	pdEndpoints := strings.Split(pdAddr, ",")
+	logger.Info("connect ETCD servers", zap.Strings("addrs", pdEndpoints))
+	etcdClient, err := clientv3.New(clientv3.Config{
+		Endpoints:        pdEndpoints,
+		TLS:              certMgr.ClusterTLS(),
+		Logger:           logger.Named("etcdcli"),
+		AutoSyncInterval: 30 * time.Second,
+		DialTimeout:      5 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time:    10 * time.Second,
+				Timeout: 3 * time.Second,
+			}),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  time.Second,
+					Multiplier: 1.1,
+					Jitter:     0.1,
+					MaxDelay:   3 * time.Second,
+				},
+				MinConnectTimeout: 3 * time.Second,
+			}),
+		},
+	})
+	return etcdClient, errors.Wrapf(err, "init etcd client failed")
+}

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -1,0 +1,209 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package infosync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/retry"
+	"github.com/pingcap/TiProxy/lib/util/sys"
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
+	"github.com/pingcap/TiProxy/pkg/util/versioninfo"
+	"github.com/pingcap/errors"
+	"github.com/siddontang/go/hack"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.uber.org/zap"
+)
+
+const (
+	tiproxyTopologyPath = "/topology/tiproxy"
+
+	topologySessionTTL    = 45
+	topologyRefreshIntvl  = 30 * time.Second
+	topologyPutTimeout    = 2 * time.Second
+	topologyPutRetryIntvl = 1 * time.Second
+	topologyPutRetryCnt   = 3
+	logInterval           = 10
+
+	TTLSuffix  = "ttl"
+	InfoSuffix = "info"
+)
+
+// InfoSyncer syncs TiProxy topology to ETCD.
+// It writes 2 items: `/topology/tiproxy/.../info` and `/topology/tiproxy/.../ttl`.
+// `info` is written once and `ttl` will be erased automatically after TiProxy is down.
+// The code is modified from github.com/pingcap/tidb/domain/infosync/info.go.
+type InfoSyncer struct {
+	syncConfig      syncConfig
+	lg              *zap.Logger
+	etcdCli         *clientv3.Client
+	wg              waitgroup.WaitGroup
+	cancelFunc      context.CancelFunc
+	topologySession *concurrency.Session
+}
+
+type syncConfig struct {
+	sessionTTL    int
+	refreshIntvl  time.Duration
+	putTimeout    time.Duration
+	putRetryIntvl time.Duration
+	putRetryCnt   uint64
+}
+
+type TopologyInfo struct {
+	Version        string `json:"version"`
+	GitHash        string `json:"git_hash"`
+	IP             string `json:"ip"`
+	Port           string `json:"port"`
+	StatusPort     string `json:"status_port"`
+	DeployPath     string `json:"deploy_path"`
+	StartTimestamp int64  `json:"start_timestamp"`
+}
+
+func NewInfoSyncer(etcdCli *clientv3.Client, lg *zap.Logger) *InfoSyncer {
+	return &InfoSyncer{
+		etcdCli: etcdCli,
+		lg:      lg,
+		syncConfig: syncConfig{
+			sessionTTL:    topologySessionTTL,
+			refreshIntvl:  topologyRefreshIntvl,
+			putTimeout:    topologyPutTimeout,
+			putRetryIntvl: topologyPutRetryIntvl,
+			putRetryCnt:   topologyPutRetryCnt,
+		},
+	}
+}
+
+func (is *InfoSyncer) Init(ctx context.Context, cfg *config.Config) error {
+	topologyInfo, err := is.getTopologyInfo(cfg)
+	if err != nil {
+		is.lg.Error("get topology failed", zap.Error(err))
+		return err
+	}
+
+	childCtx, cancelFunc := context.WithCancel(ctx)
+	is.cancelFunc = cancelFunc
+	is.wg.Run(func() {
+		is.updateTopologyLivenessLoop(childCtx, topologyInfo)
+	})
+	return nil
+}
+
+func (is *InfoSyncer) updateTopologyLivenessLoop(ctx context.Context, topologyInfo *TopologyInfo) {
+	// We allow TiProxy to start before PD, so do not fail in the main goroutine.
+	if err := is.initTopologySession(ctx); err != nil {
+		return
+	}
+	_ = is.storeTopologyInfo(ctx, topologyInfo)
+	_ = is.updateTopologyAliveness(ctx, topologyInfo)
+	ticker := time.NewTicker(is.syncConfig.refreshIntvl)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Even if the topology is unchanged, the server may restart.
+			// We don't assume the server still persists data after restart, so we always store it again.
+			_ = is.storeTopologyInfo(ctx, topologyInfo)
+			_ = is.updateTopologyAliveness(ctx, topologyInfo)
+		case <-is.topologySession.Done():
+			is.lg.Warn("restart topology session")
+			if err := is.initTopologySession(ctx); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (is *InfoSyncer) initTopologySession(ctx context.Context) error {
+	// Infinitely retry until cancelled.
+	return retry.RetryNotify(func() error {
+		topologySession, err := concurrency.NewSession(is.etcdCli, concurrency.WithTTL(is.syncConfig.sessionTTL), concurrency.WithContext(ctx))
+		if err == nil {
+			is.topologySession = topologySession
+			is.lg.Info("topology session is initialized", zap.Error(err))
+		}
+		return err
+	}, ctx, is.syncConfig.putRetryIntvl, retry.InfiniteCnt,
+		func(err error, duration time.Duration) {
+			is.lg.Error("failed to init topology session, retrying", zap.Error(err))
+		}, logInterval)
+}
+
+func (is *InfoSyncer) getTopologyInfo(cfg *config.Config) (*TopologyInfo, error) {
+	s, err := os.Executable()
+	if err != nil {
+		s = ""
+	}
+	dir := path.Dir(s)
+	ip := sys.GetLocalIP()
+	_, port, err := net.SplitHostPort(cfg.Proxy.Addr)
+	if err != nil {
+		return nil, err
+	}
+	_, statusPort, err := net.SplitHostPort(cfg.API.Addr)
+	if err != nil {
+		return nil, err
+	}
+	return &TopologyInfo{
+		Version:        versioninfo.TiProxyVersion,
+		GitHash:        versioninfo.TiProxyGitHash,
+		IP:             ip,
+		Port:           port,
+		StatusPort:     statusPort,
+		DeployPath:     dir,
+		StartTimestamp: time.Now().Unix(),
+	}, nil
+}
+
+func (is *InfoSyncer) storeTopologyInfo(ctx context.Context, topologyInfo *TopologyInfo) error {
+	infoBuf, err := json.Marshal(topologyInfo)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	value := hack.String(infoBuf)
+	key := fmt.Sprintf("%s/%s/%s", tiproxyTopologyPath, net.JoinHostPort(topologyInfo.IP, topologyInfo.Port), InfoSuffix)
+	err = retry.Retry(func() error {
+		childCtx, cancel := context.WithTimeout(ctx, is.syncConfig.putTimeout)
+		_, err := is.etcdCli.Put(childCtx, key, value)
+		cancel()
+		return err
+	}, ctx, is.syncConfig.putRetryIntvl, is.syncConfig.putRetryCnt)
+	if err != nil {
+		is.lg.Error("failed to store topology info", zap.Error(err))
+	}
+	return err
+}
+
+func (is *InfoSyncer) updateTopologyAliveness(ctx context.Context, topologyInfo *TopologyInfo) error {
+	key := fmt.Sprintf("%s/%s/%s", tiproxyTopologyPath, net.JoinHostPort(topologyInfo.IP, topologyInfo.Port), TTLSuffix)
+	// The lease may be not found and the session won't be recreated, so do not retry infinitely.
+	err := retry.Retry(func() error {
+		value := fmt.Sprintf("%v", time.Now().UnixNano())
+		childCtx, cancel := context.WithTimeout(ctx, is.syncConfig.putTimeout)
+		_, err := is.etcdCli.Put(childCtx, key, value, clientv3.WithLease(is.topologySession.Lease()))
+		cancel()
+		return err
+	}, ctx, is.syncConfig.putRetryIntvl, is.syncConfig.putRetryCnt)
+	if err != nil {
+		is.lg.Error("failed to update topology ttl", zap.Error(err))
+	}
+	return err
+}
+
+func (is *InfoSyncer) Close() {
+	if is.cancelFunc != nil {
+		is.cancelFunc()
+	}
+	is.wg.Wait()
+}

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -1,0 +1,200 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package infosync
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/TiProxy/lib/config"
+	"github.com/pingcap/TiProxy/lib/util/logger"
+	"github.com/pingcap/TiProxy/pkg/manager/cert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
+)
+
+// TTL is refreshed periodically.
+func TestTTLRefresh(t *testing.T) {
+	ts := newEtcdTestSuite(t)
+	t.Cleanup(ts.close)
+	var ttl string
+	for i := 0; i < 10; i++ {
+		require.Eventually(t, func() bool {
+			newTTL, info := ts.getTTLAndInfo(tiproxyTopologyPath)
+			satisfied := newTTL != ttl && len(info) > 0
+			if satisfied {
+				ttl = newTTL
+			}
+			return satisfied
+		}, 3*time.Second, 100*time.Millisecond)
+	}
+}
+
+// InfoSyncer continues refreshing even after etcd server is down.
+func TestEtcdServerDown(t *testing.T) {
+	ts := newEtcdTestSuite(t)
+	t.Cleanup(ts.close)
+	var ttl string
+	for i := 0; i < 5; i++ {
+		// Make the server down for some time.
+		ts.restartServer(time.Second)
+		require.Eventually(t, func() bool {
+			newTTL, info := ts.getTTLAndInfo(tiproxyTopologyPath)
+			satisfied := newTTL != ttl && len(info) > 0
+			if satisfied {
+				ttl = newTTL
+			}
+			return satisfied
+		}, 5*time.Second, 100*time.Millisecond)
+	}
+}
+
+// TTL is erased after the client is down.
+func TestClientDown(t *testing.T) {
+	ts := newEtcdTestSuite(t)
+	t.Cleanup(ts.close)
+	require.Eventually(t, func() bool {
+		ttl, info := ts.getTTLAndInfo(tiproxyTopologyPath)
+		return len(ttl) > 0 && len(info) > 0
+	}, 3*time.Second, 100*time.Millisecond)
+	ts.closeInfoSyncer()
+	require.Eventually(t, func() bool {
+		ttl, _ := ts.getTTLAndInfo(tiproxyTopologyPath)
+		return len(ttl) == 0
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+type etcdTestSuite struct {
+	t      *testing.T
+	lg     *zap.Logger
+	server *embed.Etcd
+	client *clientv3.Client
+	kv     clientv3.KV
+	is     *InfoSyncer
+}
+
+func newEtcdTestSuite(t *testing.T) *etcdTestSuite {
+	lg := logger.CreateLoggerForTest(t)
+	etcd := createEtcdServer(t, lg, "0.0.0.0:0")
+	client := createEtcdClient(t, lg, etcd)
+	kv := clientv3.NewKV(client)
+	is := NewInfoSyncer(client, lg)
+	is.syncConfig = syncConfig{
+		sessionTTL:    1,
+		refreshIntvl:  50 * time.Millisecond,
+		putTimeout:    30 * time.Millisecond,
+		putRetryIntvl: 10 * time.Millisecond,
+		putRetryCnt:   3,
+	}
+	err := is.Init(context.Background(), newConfig())
+	require.NoError(t, err)
+	return &etcdTestSuite{
+		t:      t,
+		lg:     lg,
+		server: etcd,
+		client: client,
+		kv:     kv,
+		is:     is,
+	}
+}
+
+func (ts *etcdTestSuite) close() {
+	if ts.is != nil {
+		ts.is.Close()
+		ts.is = nil
+	}
+	if ts.server != nil {
+		ts.server.Close()
+		ts.server = nil
+	}
+	if ts.client != nil {
+		require.NoError(ts.t, ts.client.Close())
+		ts.client = nil
+	}
+}
+
+func (ts *etcdTestSuite) restartServer(waitTime time.Duration) {
+	require.NotNil(ts.t, ts.server)
+	addr := ts.server.Clients[0].Addr().String()
+	ts.server.Close()
+	time.Sleep(waitTime)
+	ts.server = createEtcdServer(ts.t, ts.lg, addr)
+}
+
+func (ts *etcdTestSuite) closeInfoSyncer() {
+	require.NotNil(ts.t, ts.is)
+	ts.is.Close()
+}
+
+func (ts *etcdTestSuite) getTTLAndInfo(prefix string) (string, string) {
+	var ttl, info string
+	rs, err := ts.kv.Get(context.Background(), prefix, clientv3.WithPrefix())
+	require.NoError(ts.t, err)
+	for _, kv := range rs.Kvs {
+		key := string(kv.Key)
+		if strings.HasSuffix(key, TTLSuffix) {
+			ttl = string(kv.Value)
+		} else if strings.HasSuffix(key, InfoSuffix) {
+			info = string(kv.Value)
+		}
+	}
+	return ttl, info
+}
+
+func createEtcdServer(t *testing.T, lg *zap.Logger, addr string) *embed.Etcd {
+	serverURL, err := url.Parse(fmt.Sprintf("http://%s", addr))
+	require.NoError(t, err)
+	cfg := embed.NewConfig()
+	cfg.Dir = t.TempDir()
+	cfg.LCUrls = []url.URL{*serverURL}
+	cfg.LPUrls = []url.URL{*serverURL}
+	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(lg)
+	cfg.LogLevel = "fatal"
+	// Reuse port so that it can reboot with the same port immediately.
+	cfg.SocketOpts = transport.SocketOpts{
+		ReuseAddress: true,
+		ReusePort:    true,
+	}
+	var etcd *embed.Etcd
+	require.Eventually(t, func() bool {
+		var err error
+		etcd, err = embed.StartEtcd(cfg)
+		return err == nil
+	}, 3*time.Second, time.Second)
+	<-etcd.Server.ReadyNotify()
+	return etcd
+}
+
+func createEtcdClient(t *testing.T, lg *zap.Logger, etcd *embed.Etcd) *clientv3.Client {
+	cfg := &config.Config{
+		Proxy: config.ProxyServer{
+			PDAddrs: etcd.Clients[0].Addr().String(),
+		},
+	}
+	certMgr := cert.NewCertManager()
+	err := certMgr.Init(cfg, lg, nil)
+	require.NoError(t, err)
+	lg = lg.WithOptions(zap.IncreaseLevel(zap.FatalLevel))
+	client, err := InitEtcdClient(lg, cfg, certMgr)
+	require.NoError(t, err)
+	return client
+}
+
+func newConfig() *config.Config {
+	return &config.Config{
+		Proxy: config.ProxyServer{
+			Addr: "0.0.0.0:6000",
+		},
+		API: config.API{
+			Addr: "0.0.0.0:3080",
+		},
+	}
+}

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -10,15 +10,10 @@ import (
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
-	"github.com/pingcap/TiProxy/lib/util/errors"
-	"github.com/pingcap/TiProxy/pkg/manager/cert"
 	"github.com/pingcap/tidb/domain/infosync"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/keepalive"
 )
 
 var _ BackendFetcher = (*PDFetcher)(nil)
@@ -27,40 +22,6 @@ var _ BackendFetcher = (*StaticFetcher)(nil)
 // BackendFetcher is an interface to fetch the backend list.
 type BackendFetcher interface {
 	GetBackendList(context.Context) (map[string]*BackendInfo, error)
-}
-
-// InitEtcdClient initializes an etcd client that fetches TiDB instance topology from PD.
-func InitEtcdClient(logger *zap.Logger, cfg *config.Config, certMgr *cert.CertManager) (*clientv3.Client, error) {
-	pdAddr := cfg.Proxy.PDAddrs
-	if len(pdAddr) == 0 {
-		// use tidb server addresses directly
-		return nil, nil
-	}
-	pdEndpoints := strings.Split(pdAddr, ",")
-	logger.Info("connect PD servers", zap.Strings("addrs", pdEndpoints))
-	etcdClient, err := clientv3.New(clientv3.Config{
-		Endpoints:        pdEndpoints,
-		TLS:              certMgr.ClusterTLS(),
-		Logger:           logger.Named("etcdcli"),
-		AutoSyncInterval: 30 * time.Second,
-		DialTimeout:      5 * time.Second,
-		DialOptions: []grpc.DialOption{
-			grpc.WithKeepaliveParams(keepalive.ClientParameters{
-				Time:    10 * time.Second,
-				Timeout: 3 * time.Second,
-			}),
-			grpc.WithConnectParams(grpc.ConnectParams{
-				Backoff: backoff.Config{
-					BaseDelay:  time.Second,
-					Multiplier: 1.1,
-					Jitter:     0.1,
-					MaxDelay:   3 * time.Second,
-				},
-				MinConnectTimeout: 3 * time.Second,
-			}),
-		},
-	})
-	return etcdClient, errors.Wrapf(err, "init etcd client failed")
 }
 
 type pdBackendInfo struct {

--- a/pkg/manager/router/backend_fetcher_test.go
+++ b/pkg/manager/router/backend_fetcher_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/pkg/manager/cert"
+	infosync2 "github.com/pingcap/TiProxy/pkg/manager/infosync"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -117,7 +118,7 @@ func createEtcdClient(t *testing.T, etcd *embed.Etcd) *clientv3.Client {
 	certMgr := cert.NewCertManager()
 	err := certMgr.Init(cfg, logger.CreateLoggerForTest(t), nil)
 	require.NoError(t, err)
-	client, err := InitEtcdClient(logger.CreateLoggerForTest(t), cfg, certMgr)
+	client, err := infosync2.InitEtcdClient(logger.CreateLoggerForTest(t), cfg, certMgr)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, client.Close())

--- a/pkg/util/versioninfo/versioninfo.go
+++ b/pkg/util/versioninfo/versioninfo.go
@@ -1,0 +1,10 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package versioninfo
+
+// These variables will be overwritten by Makefile.
+var (
+	TiProxyGitHash = "None"
+	TiProxyVersion = "None"
+)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #307

Problem Summary:
If we support self-hosted deployment, we need to support TiDB Dashboard and information_schema.cluster_xxx tables. These features require fetching TiProxy addresses. The most straightforward way is to register TiProxy in the ectd of PD, just like what TiDB does.

What is changed and how it works:
- Register info and ttl into PD by `InfoSyncer`
- Move `InitEtcdClient` from `router` to `infosync`

TODO:
- Move more etcd code from `router` to `infosync`. `PDFetcher` should call `infosync` to get TiDB topology.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Start TiProxy and check etcd entry from PD:
```
etcdctl get --prefix /topology/tiproxy
/topology/tiproxy/192.168.0.101:6000/info
{"version":"topo","git_hash":"66d42d553315fd26a3bbd677036ec211e2b49d86-dirty","ip":"192.168.0.101","port":"6000","status_port":"3080","deploy_path":"/Users/zhangming/gopath/src/github.com/pingcap/TiProxy/bin","start_timestamp":1686390578}
/topology/tiproxy/192.168.0.101:6000/ttl
1686390578299853000
```

And then shutdown TiProxy and check it again after 1 min:
```
/topology/tiproxy/192.168.0.101:6000/info
{"version":"topo","git_hash":"66d42d553315fd26a3bbd677036ec211e2b49d86-dirty","ip":"192.168.0.101","port":"6000","status_port":"3080","deploy_path":"/Users/zhangming/gopath/src/github.com/pingcap/TiProxy/bin","start_timestamp":1686390578}
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
