### PR TITLE
infosync, router: remove tombstone check for TiDB topology

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	go.uber.org/atomic v1.10.0
 	go.uber.org/ratelimit v0.2.0
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e
 	google.golang.org/grpc v1.51.0
 )
 
@@ -128,6 +127,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.4.0 // indirect
+	golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -33,30 +33,27 @@ const (
 	healthCheckMaxRetries    = 3
 	healthCheckRetryInterval = 1 * time.Second
 	healthCheckTimeout       = 2 * time.Second
-	tombstoneThreshold       = 5 * time.Minute
 )
 
 // HealthCheck contains some configurations for health check.
 // Some general configurations of them may be exposed to users in the future.
 // We can use shorter durations to speed up unit tests.
 type HealthCheck struct {
-	Enable             bool          `yaml:"enable" json:"enable" toml:"enable"`
-	Interval           time.Duration `yaml:"interval" json:"interval" toml:"interval"`
-	MaxRetries         int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
-	RetryInterval      time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
-	DialTimeout        time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
-	TombstoneThreshold time.Duration `yaml:"tombstone-threshold" json:"tombstone-threshold" toml:"tombstone-threshold"`
+	Enable        bool          `yaml:"enable" json:"enable" toml:"enable"`
+	Interval      time.Duration `yaml:"interval" json:"interval" toml:"interval"`
+	MaxRetries    int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
+	RetryInterval time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
+	DialTimeout   time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
 }
 
 // NewDefaultHealthCheckConfig creates a default HealthCheck.
 func NewDefaultHealthCheckConfig() *HealthCheck {
 	return &HealthCheck{
-		Enable:             true,
-		Interval:           healthCheckInterval,
-		MaxRetries:         healthCheckMaxRetries,
-		RetryInterval:      healthCheckRetryInterval,
-		DialTimeout:        healthCheckTimeout,
-		TombstoneThreshold: tombstoneThreshold,
+		Enable:        true,
+		Interval:      healthCheckInterval,
+		MaxRetries:    healthCheckMaxRetries,
+		RetryInterval: healthCheckRetryInterval,
+		DialTimeout:   healthCheckTimeout,
 	}
 }
 
@@ -72,9 +69,6 @@ func (hc *HealthCheck) Check() {
 	}
 	if hc.DialTimeout == 0 {
 		hc.DialTimeout = healthCheckTimeout
-	}
-	if hc.TombstoneThreshold == 0 {
-		hc.TombstoneThreshold = tombstoneThreshold
 	}
 }
 

--- a/pkg/manager/infosync/etcd.go
+++ b/pkg/manager/infosync/etcd.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// InitEtcdClient initializes an etcd client that fetches TiDB instance topology from PD.
+// InitEtcdClient initializes an etcd client that connects to PD ETCD server.
 func InitEtcdClient(logger *zap.Logger, cfg *config.Config, certMgr *cert.CertManager) (*clientv3.Client, error) {
 	pdAddr := cfg.Proxy.PDAddrs
 	if len(pdAddr) == 0 {

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -5,15 +5,19 @@ package infosync
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/logger"
+	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	"github.com/pingcap/TiProxy/pkg/manager/cert"
+	tidbinfo "github.com/pingcap/tidb/domain/infosync"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -39,13 +43,15 @@ func TestTTLRefresh(t *testing.T) {
 }
 
 // InfoSyncer continues refreshing even after etcd server is down.
-func TestEtcdServerDown(t *testing.T) {
+func TestEtcdServerDown4Sync(t *testing.T) {
 	ts := newEtcdTestSuite(t)
 	t.Cleanup(ts.close)
 	var ttl string
 	for i := 0; i < 5; i++ {
 		// Make the server down for some time.
-		ts.restartServer(time.Second)
+		addr := ts.shutdownServer()
+		time.Sleep(time.Second)
+		ts.startServer(addr)
 		require.Eventually(t, func() bool {
 			newTTL, info := ts.getTTLAndInfo(tiproxyTopologyPath)
 			satisfied := newTTL != ttl && len(info) > 0
@@ -58,7 +64,7 @@ func TestEtcdServerDown(t *testing.T) {
 }
 
 // TTL is erased after the client is down.
-func TestClientDown(t *testing.T) {
+func TestClientDown4Sync(t *testing.T) {
 	ts := newEtcdTestSuite(t)
 	t.Cleanup(ts.close)
 	require.Eventually(t, func() bool {
@@ -72,6 +78,106 @@ func TestClientDown(t *testing.T) {
 	}, 3*time.Second, 100*time.Millisecond)
 }
 
+// Test that the result of GetTiDBTopology is right.
+func TestFetchTiDBTopology(t *testing.T) {
+	ts := newEtcdTestSuite(t)
+	t.Cleanup(ts.close)
+
+	tests := []struct {
+		update func()
+		check  func(info map[string]*TiDBInfo)
+	}{
+		{
+			// No backends.
+			check: func(info map[string]*TiDBInfo) {
+				require.Empty(t, info)
+			},
+		},
+		{
+			// Only update TTL.
+			update: func() {
+				ts.updateTTL("1.1.1.1:4000", []byte("123456789"))
+			},
+			check: func(info map[string]*TiDBInfo) {
+				require.Len(ts.t, info, 1)
+				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
+				require.Nil(ts.t, info["1.1.1.1:4000"].TopologyInfo)
+			},
+		},
+		{
+			// Then update info.
+			update: func() {
+				ts.updateInfo("1.1.1.1:4000", &tidbinfo.TopologyInfo{
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+				})
+			},
+			check: func(info map[string]*TiDBInfo) {
+				require.Len(ts.t, info, 1)
+				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
+				require.NotNil(ts.t, info["1.1.1.1:4000"].TopologyInfo)
+				require.Equal(ts.t, "1.1.1.1", info["1.1.1.1:4000"].IP)
+				require.Equal(ts.t, uint(10080), info["1.1.1.1:4000"].StatusPort)
+			},
+		},
+		{
+			// Add another backend.
+			update: func() {
+				ts.updateTTL("2.2.2.2:4000", []byte("123456789"))
+				ts.updateInfo("2.2.2.2:4000", &tidbinfo.TopologyInfo{
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
+				})
+			},
+			check: func(info map[string]*TiDBInfo) {
+				require.Len(ts.t, info, 2)
+				require.Equal(ts.t, "123456789", info["2.2.2.2:4000"].TTL)
+				require.NotNil(ts.t, info["2.2.2.2:4000"].TopologyInfo)
+				require.Equal(ts.t, "2.2.2.2", info["2.2.2.2:4000"].IP)
+				require.Equal(ts.t, uint(10080), info["2.2.2.2:4000"].StatusPort)
+			},
+		},
+		{
+			// Remove the backend TTL.
+			update: func() {
+				ts.deleteTTL("2.2.2.2:4000")
+			},
+			check: func(info map[string]*TiDBInfo) {
+				require.Len(ts.t, info, 2)
+				require.Empty(ts.t, info["2.2.2.2:4000"].TTL)
+				require.NotNil(ts.t, info["2.2.2.2:4000"].TopologyInfo)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if test.update != nil {
+			test.update()
+		}
+		info, err := ts.is.GetTiDBTopology(context.Background())
+		require.NoError(t, err)
+		test.check(info)
+	}
+}
+
+// Test that fetching retries when etcd server is down until the server is up again.
+func TestEtcdServerDown4Fetch(t *testing.T) {
+	ts := newEtcdTestSuite(t)
+	t.Cleanup(ts.close)
+	addr := ts.shutdownServer()
+
+	var wg waitgroup.WaitGroup
+	wg.Run(func() {
+		info, err := ts.is.GetTiDBTopology(context.Background())
+		require.NoError(t, err)
+		require.Len(ts.t, info, 0)
+	})
+
+	time.Sleep(time.Second)
+	ts.startServer(addr)
+	wg.Wait()
+}
+
 type etcdTestSuite struct {
 	t      *testing.T
 	lg     *zap.Logger
@@ -83,10 +189,19 @@ type etcdTestSuite struct {
 
 func newEtcdTestSuite(t *testing.T) *etcdTestSuite {
 	lg := logger.CreateLoggerForTest(t)
-	etcd := createEtcdServer(t, lg, "0.0.0.0:0")
-	client := createEtcdClient(t, lg, etcd)
-	kv := clientv3.NewKV(client)
-	is := NewInfoSyncer(client, lg)
+	ts := &etcdTestSuite{
+		t:  t,
+		lg: lg,
+	}
+
+	ts.startServer("0.0.0.0:0")
+	endpoint := ts.server.Clients[0].Addr().String()
+	cfg := newConfig(endpoint)
+
+	certMgr := cert.NewCertManager()
+	err := certMgr.Init(cfg, lg, nil)
+	require.NoError(t, err)
+	is := NewInfoSyncer(lg)
 	is.syncConfig = syncConfig{
 		sessionTTL:    1,
 		refreshIntvl:  50 * time.Millisecond,
@@ -94,44 +209,46 @@ func newEtcdTestSuite(t *testing.T) *etcdTestSuite {
 		putRetryIntvl: 10 * time.Millisecond,
 		putRetryCnt:   3,
 	}
-	err := is.Init(context.Background(), newConfig())
+	err = is.Init(context.Background(), cfg, certMgr)
 	require.NoError(t, err)
-	return &etcdTestSuite{
-		t:      t,
-		lg:     lg,
-		server: etcd,
-		client: client,
-		kv:     kv,
-		is:     is,
-	}
+	ts.is = is
+
+	ts.client, err = InitEtcdClient(ts.lg, cfg, certMgr)
+	ts.kv = clientv3.NewKV(ts.client)
+	return ts
 }
 
 func (ts *etcdTestSuite) close() {
 	if ts.is != nil {
-		ts.is.Close()
+		require.NoError(ts.t, ts.is.Close())
 		ts.is = nil
-	}
-	if ts.server != nil {
-		ts.server.Close()
-		ts.server = nil
 	}
 	if ts.client != nil {
 		require.NoError(ts.t, ts.client.Close())
 		ts.client = nil
 	}
+	if ts.server != nil {
+		ts.server.Close()
+		ts.server = nil
+	}
 }
 
-func (ts *etcdTestSuite) restartServer(waitTime time.Duration) {
+func (ts *etcdTestSuite) startServer(addr string) {
+	ts.createEtcdServer(addr)
+}
+
+func (ts *etcdTestSuite) shutdownServer() string {
 	require.NotNil(ts.t, ts.server)
 	addr := ts.server.Clients[0].Addr().String()
 	ts.server.Close()
-	time.Sleep(waitTime)
-	ts.server = createEtcdServer(ts.t, ts.lg, addr)
+	ts.server = nil
+	return addr
 }
 
 func (ts *etcdTestSuite) closeInfoSyncer() {
 	require.NotNil(ts.t, ts.is)
-	ts.is.Close()
+	require.NoError(ts.t, ts.is.Close())
+	ts.is = nil
 }
 
 func (ts *etcdTestSuite) getTTLAndInfo(prefix string) (string, string) {
@@ -140,23 +257,42 @@ func (ts *etcdTestSuite) getTTLAndInfo(prefix string) (string, string) {
 	require.NoError(ts.t, err)
 	for _, kv := range rs.Kvs {
 		key := string(kv.Key)
-		if strings.HasSuffix(key, TTLSuffix) {
+		if strings.HasSuffix(key, ttlSuffix) {
 			ttl = string(kv.Value)
-		} else if strings.HasSuffix(key, InfoSuffix) {
+		} else if strings.HasSuffix(key, infoSuffix) {
 			info = string(kv.Value)
 		}
 	}
 	return ttl, info
 }
 
-func createEtcdServer(t *testing.T, lg *zap.Logger, addr string) *embed.Etcd {
+// Update the TTL for a backend.
+func (ts *etcdTestSuite) updateTTL(addr string, ttl []byte) {
+	_, err := ts.kv.Put(context.Background(), path.Join(tidbinfo.TopologyInformationPath, addr, ttlSuffix), string(ttl))
+	require.NoError(ts.t, err)
+}
+
+func (ts *etcdTestSuite) deleteTTL(addr string) {
+	_, err := ts.kv.Delete(context.Background(), path.Join(tidbinfo.TopologyInformationPath, addr, ttlSuffix))
+	require.NoError(ts.t, err)
+}
+
+// Update the TopologyInfo for a backend.
+func (ts *etcdTestSuite) updateInfo(sqlAddr string, info *tidbinfo.TopologyInfo) {
+	data, err := json.Marshal(info)
+	require.NoError(ts.t, err)
+	_, err = ts.kv.Put(context.Background(), path.Join(tidbinfo.TopologyInformationPath, sqlAddr, infoSuffix), string(data))
+	require.NoError(ts.t, err)
+}
+
+func (ts *etcdTestSuite) createEtcdServer(addr string) {
 	serverURL, err := url.Parse(fmt.Sprintf("http://%s", addr))
-	require.NoError(t, err)
+	require.NoError(ts.t, err)
 	cfg := embed.NewConfig()
-	cfg.Dir = t.TempDir()
+	cfg.Dir = ts.t.TempDir()
 	cfg.LCUrls = []url.URL{*serverURL}
 	cfg.LPUrls = []url.URL{*serverURL}
-	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(lg)
+	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(ts.lg)
 	cfg.LogLevel = "fatal"
 	// Reuse port so that it can reboot with the same port immediately.
 	cfg.SocketOpts = transport.SocketOpts{
@@ -164,34 +300,20 @@ func createEtcdServer(t *testing.T, lg *zap.Logger, addr string) *embed.Etcd {
 		ReusePort:    true,
 	}
 	var etcd *embed.Etcd
-	require.Eventually(t, func() bool {
+	require.Eventually(ts.t, func() bool {
 		var err error
 		etcd, err = embed.StartEtcd(cfg)
 		return err == nil
 	}, 3*time.Second, time.Second)
 	<-etcd.Server.ReadyNotify()
-	return etcd
+	ts.server = etcd
 }
 
-func createEtcdClient(t *testing.T, lg *zap.Logger, etcd *embed.Etcd) *clientv3.Client {
-	cfg := &config.Config{
-		Proxy: config.ProxyServer{
-			PDAddrs: etcd.Clients[0].Addr().String(),
-		},
-	}
-	certMgr := cert.NewCertManager()
-	err := certMgr.Init(cfg, lg, nil)
-	require.NoError(t, err)
-	lg = lg.WithOptions(zap.IncreaseLevel(zap.FatalLevel))
-	client, err := InitEtcdClient(lg, cfg, certMgr)
-	require.NoError(t, err)
-	return client
-}
-
-func newConfig() *config.Config {
+func newConfig(endpoint string) *config.Config {
 	return &config.Config{
 		Proxy: config.ProxyServer{
-			Addr: "0.0.0.0:6000",
+			Addr:    "0.0.0.0:6000",
+			PDAddrs: endpoint,
 		},
 		API: config.API{
 			Addr: "0.0.0.0:3080",

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -214,6 +214,7 @@ func newEtcdTestSuite(t *testing.T) *etcdTestSuite {
 	ts.is = is
 
 	ts.client, err = InitEtcdClient(ts.lg, cfg, certMgr)
+	require.NoError(t, err)
 	ts.kv = clientv3.NewKV(ts.client)
 	return ts
 }

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -304,7 +304,9 @@ func (ts *etcdTestSuite) createEtcdServer(addr string) {
 	require.Eventually(ts.t, func() bool {
 		var err error
 		etcd, err = embed.StartEtcd(cfg)
-		ts.t.Logf("start etcd failed, error: %s", err.Error())
+		if err != nil {
+			ts.t.Logf("start etcd failed, error: %s", err.Error())
+		}
 		return err == nil
 	}, 5*time.Second, 10*time.Millisecond)
 	<-etcd.Server.ReadyNotify()

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -304,8 +304,9 @@ func (ts *etcdTestSuite) createEtcdServer(addr string) {
 	require.Eventually(ts.t, func() bool {
 		var err error
 		etcd, err = embed.StartEtcd(cfg)
+		ts.t.Logf("start etcd failed, error: %s", err.Error())
 		return err == nil
-	}, 3*time.Second, time.Second)
+	}, 5*time.Second, 10*time.Millisecond)
 	<-etcd.Server.ReadyNotify()
 	ts.server = etcd
 }

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -14,16 +14,15 @@ import (
 	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/pkg/manager/router"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
 type NamespaceManager struct {
 	sync.RWMutex
-	client  *clientv3.Client
-	httpCli *http.Client
-	logger  *zap.Logger
-	nsm     map[string]*Namespace
+	tpFetcher router.TopologyFetcher
+	httpCli   *http.Client
+	logger    *zap.Logger
+	nsm       map[string]*Namespace
 }
 
 func NewNamespaceManager() *NamespaceManager {
@@ -34,8 +33,8 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	logger := mgr.logger.With(zap.String("namespace", cfg.Namespace))
 
 	var fetcher router.BackendFetcher
-	if mgr.client != nil {
-		fetcher = router.NewPDFetcher(mgr.client, logger.Named("be_fetcher"), config.NewDefaultHealthCheckConfig())
+	if mgr.tpFetcher != nil {
+		fetcher = router.NewPDFetcher(mgr.tpFetcher, logger.Named("be_fetcher"), config.NewDefaultHealthCheckConfig())
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
@@ -77,9 +76,9 @@ func (mgr *NamespaceManager) CommitNamespaces(nss []*config.Namespace, nss_delet
 	return nil
 }
 
-func (mgr *NamespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, client *clientv3.Client, httpCli *http.Client) error {
+func (mgr *NamespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher router.TopologyFetcher, httpCli *http.Client) error {
 	mgr.Lock()
-	mgr.client = client
+	mgr.tpFetcher = tpFetcher
 	mgr.httpCli = httpCli
 	mgr.logger = logger
 	mgr.Unlock()

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -5,15 +5,12 @@ package router
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
-	"github.com/pingcap/tidb/domain/infosync"
-	clientv3 "go.etcd.io/etcd/client/v3"
+	"github.com/pingcap/TiProxy/lib/util/retry"
+	"github.com/pingcap/TiProxy/pkg/manager/infosync"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 var _ BackendFetcher = (*PDFetcher)(nil)
@@ -24,135 +21,68 @@ type BackendFetcher interface {
 	GetBackendList(context.Context) (map[string]*BackendInfo, error)
 }
 
-type pdBackendInfo struct {
-	// The TopologyInfo received from the /info path.
-	*infosync.TopologyInfo
-	// The TTL time in the topology info.
-	ttl []byte
-	// Last time the TTL time is refreshed.
-	// If the TTL stays unchanged for a long time, the backend might be a tombstone.
-	lastUpdate time.Time
+// TopologyFetcher is an interface to fetch the tidb topology from ETCD.
+type TopologyFetcher interface {
+	GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error)
 }
 
 // PDFetcher fetches backend list from PD.
 type PDFetcher struct {
-	// All the backend info in the topology, including tombstones.
-	backendInfo map[string]*pdBackendInfo
-	client      *clientv3.Client
-	logger      *zap.Logger
-	config      *config.HealthCheck
+	tpFetcher TopologyFetcher
+	logger    *zap.Logger
+	config    *config.HealthCheck
 }
 
-func NewPDFetcher(client *clientv3.Client, logger *zap.Logger, config *config.HealthCheck) *PDFetcher {
+func NewPDFetcher(tpFetcher TopologyFetcher, logger *zap.Logger, config *config.HealthCheck) *PDFetcher {
 	config.Check()
 	return &PDFetcher{
-		backendInfo: make(map[string]*pdBackendInfo),
-		client:      client,
-		logger:      logger,
-		config:      config,
+		tpFetcher: tpFetcher,
+		logger:    logger,
+		config:    config,
 	}
 }
 
 func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInfo, error) {
-	pf.fetchBackendList(ctx)
-	backendInfo := pf.filterTombstoneBackends()
-	return backendInfo, nil
-}
-
-func (pf *PDFetcher) fetchBackendList(ctx context.Context) {
-	// We query the etcd periodically instead of watching events from etcd because:
-	// - When a new backend starts and writes etcd, the HTTP status port is not ready yet.
-	// - When a backend shuts down, it doesn't delete itself from the etcd.
-	var response *clientv3.GetResponse
-	var err error
-	// It's a critical problem if the proxy cannot connect to the server, so we always retry.
-	for ctx.Err() == nil {
-		// In case there are too many tombstone backends, the query would be slow, so no need to set a timeout here.
-		if response, err = pf.client.Get(ctx, infosync.TopologyInformationPath, clientv3.WithPrefix()); err == nil {
-			break
-		}
-		// Ignore errors when TiProxy shuts down.
-		if ctx.Err() != nil {
-			return
-		}
-		pf.logger.Error("fetch backend list failed, will retry later", zap.Error(err))
-		time.Sleep(pf.config.RetryInterval)
-	}
-
-	if ctx.Err() != nil {
-		return
-	}
-
-	allBackendInfo := make(map[string]*pdBackendInfo, len(response.Kvs))
-	now := time.Now()
-	for _, kv := range response.Kvs {
-		key := string(kv.Key)
-		if strings.HasSuffix(key, ttlPathSuffix) {
-			addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len(ttlPathSuffix)]
-			info, ok := allBackendInfo[addr]
-			if !ok {
-				info, ok = pf.backendInfo[addr]
-			}
-			if ok {
-				if slices.Compare(info.ttl, kv.Value) != 0 {
-					// The TTL is updated this time.
-					info.lastUpdate = now
-					info.ttl = kv.Value
-				}
-			} else {
-				// A new backend.
-				info = &pdBackendInfo{
-					lastUpdate: now,
-					ttl:        kv.Value,
-				}
-			}
-			allBackendInfo[addr] = info
-		} else if strings.HasSuffix(key, infoPathSuffix) {
-			addr := key[len(infosync.TopologyInformationPath)+1 : len(key)-len(infoPathSuffix)]
-			// A backend may restart with a same address but a different status port in a short time, so
-			// we still need to marshal and update the topology even if the address exists in the map.
-			var topo *infosync.TopologyInfo
-			if err = json.Unmarshal(kv.Value, &topo); err != nil {
-				pf.logger.Error("unmarshal topology info failed", zap.String("key", string(kv.Key)),
-					zap.ByteString("value", kv.Value), zap.Error(err))
-				continue
-			}
-			info, ok := allBackendInfo[addr]
-			if !ok {
-				info, ok = pf.backendInfo[addr]
-			}
-			if ok {
-				info.TopologyInfo = topo
-			} else {
-				info = &pdBackendInfo{
-					TopologyInfo: topo,
-				}
-			}
-			allBackendInfo[addr] = info
-		}
-	}
-	pf.backendInfo = allBackendInfo
-}
-
-func (pf *PDFetcher) filterTombstoneBackends() map[string]*BackendInfo {
-	now := time.Now()
-	aliveBackends := make(map[string]*BackendInfo, len(pf.backendInfo))
-	for addr, info := range pf.backendInfo {
-		if info.TopologyInfo == nil || info.ttl == nil {
+	backends := pf.fetchBackendList(ctx)
+	infos := make(map[string]*BackendInfo, len(backends))
+	for addr, backend := range backends {
+		// If ttl is empty, maybe the backend is down.
+		if len(backend.TTL) == 0 {
 			continue
 		}
-		// After running for a long time, there might be many tombstones because failed TiDB instances
-		// don't delete themselves from the Etcd. Checking their health is a waste of time, leading to
-		// longer and longer checking interval. So tombstones won't be added to aliveBackends.
-		if info.lastUpdate.Add(pf.config.TombstoneThreshold).Before(now) {
+		// If topology is empty, maybe the backend is not ready yet.
+		if backend.TopologyInfo == nil {
 			continue
 		}
-		aliveBackends[addr] = &BackendInfo{
-			IP:         info.IP,
-			StatusPort: info.StatusPort,
+		infos[addr] = &BackendInfo{
+			IP:         backend.IP,
+			StatusPort: backend.StatusPort,
 		}
 	}
-	return aliveBackends
+	return infos, nil
+}
+
+func (pf *PDFetcher) fetchBackendList(ctx context.Context) map[string]*infosync.TiDBInfo {
+	var backends map[string]*infosync.TiDBInfo
+	// The jobs of PDFetcher all rely on the topology, so we retry infinitely.
+	err := retry.RetryNotify(func() error {
+		var err error
+		backends, err = pf.tpFetcher.GetTiDBTopology(ctx)
+		return err
+	}, ctx, pf.config.RetryInterval, retry.InfiniteCnt,
+		func(err error, duration time.Duration) {
+			// Ignore errors when TiProxy shuts down.
+			if ctx.Err() != nil {
+				return
+			}
+			pf.logger.Error("fetch backend list failed, retrying", zap.Error(err))
+		}, 10)
+
+	// Must be cancelled if err != nil, we do not log errors.
+	if err != nil {
+		return nil
+	}
+	return backends
 }
 
 // StaticFetcher uses configured static addrs. This is only used for testing.

--- a/pkg/manager/router/backend_fetcher_test.go
+++ b/pkg/manager/router/backend_fetcher_test.go
@@ -5,167 +5,129 @@ package router
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/url"
-	"path"
-	"strconv"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/pingcap/TiProxy/lib/config"
 	"github.com/pingcap/TiProxy/lib/util/logger"
-	"github.com/pingcap/TiProxy/pkg/manager/cert"
-	infosync2 "github.com/pingcap/TiProxy/pkg/manager/infosync"
-	"github.com/pingcap/tidb/domain/infosync"
+	"github.com/pingcap/TiProxy/pkg/manager/infosync"
+	tidbinfo "github.com/pingcap/tidb/domain/infosync"
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
 )
 
-// Test that the health of tombstone backends won't be checked.
-func TestTombstoneBackends(t *testing.T) {
-	etcd := createEtcdServer(t, "127.0.0.1:0")
-	client := createEtcdClient(t, etcd)
-	kv := clientv3.NewKV(client)
-	pf := NewPDFetcher(client, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
-
-	now := time.Now()
-	oldTTL, newTTL := []byte("123456789"), []byte("999999999")
-	pf.backendInfo = map[string]*pdBackendInfo{
-		"dead_addr": {
-			TopologyInfo: &infosync.TopologyInfo{},
-			ttl:          oldTTL,
-			lastUpdate:   now.Add(-pf.config.TombstoneThreshold * 2),
+func TestPDFetcher(t *testing.T) {
+	tests := []struct {
+		infos map[string]*infosync.TiDBInfo
+		ctx   context.Context
+		check func(map[string]*BackendInfo)
+	}{
+		{
+			check: func(m map[string]*BackendInfo) {
+				require.Empty(t, m)
+			},
 		},
-		"restart_addr": {
-			TopologyInfo: &infosync.TopologyInfo{},
-			ttl:          oldTTL,
-			lastUpdate:   now.Add(-pf.config.TombstoneThreshold * 2),
+		{
+			infos: map[string]*infosync.TiDBInfo{
+				"1.1.1.1:4000": {
+					TTL: "123456789",
+				},
+			},
+			check: func(m map[string]*BackendInfo) {
+				require.Empty(t, m)
+			},
 		},
-		"removed_addr": {
-			TopologyInfo: &infosync.TopologyInfo{},
-			ttl:          oldTTL,
-			lastUpdate:   now,
+		{
+			infos: map[string]*infosync.TiDBInfo{
+				"1.1.1.1:4000": {
+					TopologyInfo: &tidbinfo.TopologyInfo{
+						IP:         "1.1.1.1",
+						StatusPort: 10080,
+					},
+				},
+			},
+			check: func(m map[string]*BackendInfo) {
+				require.Empty(t, m)
+			},
 		},
-		"alive_addr": {
-			TopologyInfo: &infosync.TopologyInfo{},
-			ttl:          oldTTL,
-			lastUpdate:   now,
+		{
+			infos: map[string]*infosync.TiDBInfo{
+				"1.1.1.1:4000": {
+					TTL: "123456789",
+					TopologyInfo: &tidbinfo.TopologyInfo{
+						IP:         "1.1.1.1",
+						StatusPort: 10080,
+					},
+				},
+			},
+			check: func(m map[string]*BackendInfo) {
+				require.Len(t, m, 1)
+				require.NotNil(t, m["1.1.1.1:4000"])
+				require.Equal(t, "1.1.1.1", m["1.1.1.1:4000"].IP)
+				require.Equal(t, uint(10080), m["1.1.1.1:4000"].StatusPort)
+			},
 		},
-	}
-
-	updateTTL(t, kv, "dead_addr", oldTTL)
-	updateTopologyInfo(t, kv, "dead_addr", "dead_addr:0")
-	updateTTL(t, kv, "restart_addr", newTTL)
-	updateTopologyInfo(t, kv, "restart_addr", "restart_addr:0")
-	updateTTL(t, kv, "alive_addr", newTTL)
-	updateTopologyInfo(t, kv, "alive_addr", "alive_addr:0")
-	updateTTL(t, kv, "new_addr", newTTL)
-	updateTopologyInfo(t, kv, "new_addr", "new_addr:0")
-	updateTTL(t, kv, "no_tp_addr", newTTL)
-	updateTopologyInfo(t, kv, "no_ttl_addr", "no_ttl_addr:0")
-
-	pf.fetchBackendList(context.Background())
-	// removed_addr doesn't exist.
-	require.Equal(t, 6, len(pf.backendInfo))
-	checkAddrAndTTL := func(addr string, ttl []byte) {
-		info, ok := pf.backendInfo[addr]
-		require.True(t, ok)
-		require.Equal(t, ttl, info.ttl)
-	}
-	checkAddrAndTTL("dead_addr", oldTTL)
-	checkAddrAndTTL("restart_addr", newTTL)
-	checkAddrAndTTL("alive_addr", newTTL)
-	checkAddrAndTTL("new_addr", newTTL)
-	checkAddrAndTTL("no_tp_addr", newTTL)
-	checkAddrAndTTL("no_ttl_addr", nil)
-
-	// dead_addr and removed_addr won't be checked.
-	backendStatus := pf.filterTombstoneBackends()
-	checkAddr := func(addr string) {
-		_, ok := backendStatus[addr]
-		require.True(t, ok)
-	}
-	checkAddr("restart_addr")
-	checkAddr("alive_addr")
-	checkAddr("new_addr")
-}
-
-func createEtcdServer(t *testing.T, addr string) *embed.Etcd {
-	serverURL, err := url.Parse(fmt.Sprintf("http://%s", addr))
-	require.NoError(t, err)
-	cfg := embed.NewConfig()
-	cfg.Dir = t.TempDir()
-	cfg.LCUrls = []url.URL{*serverURL}
-	cfg.LPUrls = []url.URL{*serverURL}
-	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(logger.CreateLoggerForTest(t))
-	cfg.LogLevel = "fatal"
-	etcd, err := embed.StartEtcd(cfg)
-	require.NoError(t, err)
-	<-etcd.Server.ReadyNotify()
-	t.Cleanup(etcd.Close)
-	return etcd
-}
-
-func createEtcdClient(t *testing.T, etcd *embed.Etcd) *clientv3.Client {
-	cfg := &config.Config{
-		Proxy: config.ProxyServer{
-			PDAddrs: etcd.Clients[0].Addr().String(),
+		{
+			infos: map[string]*infosync.TiDBInfo{
+				"1.1.1.1:4000": {
+					TTL: "123456789",
+					TopologyInfo: &tidbinfo.TopologyInfo{
+						IP:         "1.1.1.1",
+						StatusPort: 10080,
+					},
+				},
+				"2.2.2.2:4000": {
+					TTL: "123456789",
+					TopologyInfo: &tidbinfo.TopologyInfo{
+						IP:         "2.2.2.2",
+						StatusPort: 10080,
+					},
+				},
+			},
+			check: func(m map[string]*BackendInfo) {
+				require.Len(t, m, 2)
+				require.NotNil(t, m["1.1.1.1:4000"])
+				require.Equal(t, "1.1.1.1", m["1.1.1.1:4000"].IP)
+				require.Equal(t, uint(10080), m["1.1.1.1:4000"].StatusPort)
+				require.NotNil(t, m["2.2.2.2:4000"])
+				require.Equal(t, "2.2.2.2", m["2.2.2.2:4000"].IP)
+				require.Equal(t, uint(10080), m["2.2.2.2:4000"].StatusPort)
+			},
+		},
+		{
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			check: func(m map[string]*BackendInfo) {
+				require.Empty(t, m)
+			},
 		},
 	}
-	certMgr := cert.NewCertManager()
-	err := certMgr.Init(cfg, logger.CreateLoggerForTest(t), nil)
-	require.NoError(t, err)
-	client, err := infosync2.InitEtcdClient(logger.CreateLoggerForTest(t), cfg, certMgr)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, client.Close())
-	})
-	return client
-}
 
-// A new healthy backend is added to etcd.
-func addBackend(t *testing.T, kv clientv3.KV) *backendServer {
-	backend := newBackendServer(t)
-	updateTTL(t, kv, backend.sqlAddr, []byte("123456789"))
-	updateTopologyInfo(t, kv, backend.sqlAddr, backend.statusAddr)
-	return backend
-}
-
-// Update the path prefix but it doesn't affect the topology.
-func addFakeTopology(t *testing.T, kv clientv3.KV, addr string) {
-	_, err := kv.Put(context.Background(), path.Join(infosync.TopologyInformationPath, addr, "/fake"), "{}")
-	require.NoError(t, err)
-}
-
-// A backend is removed from Etcd.
-func removeBackend(t *testing.T, kv clientv3.KV, backend *backendServer) {
-	_, err := kv.Delete(context.Background(), path.Join(infosync.TopologyInformationPath, backend.sqlAddr, ttlPathSuffix))
-	require.NoError(t, err)
-	_, err = kv.Delete(context.Background(), path.Join(infosync.TopologyInformationPath, backend.sqlAddr, infoPathSuffix))
-	require.NoError(t, err)
-}
-
-// Update the TTL for a backend.
-func updateTTL(t *testing.T, kv clientv3.KV, addr string, ttl []byte) {
-	_, err := kv.Put(context.Background(), path.Join(infosync.TopologyInformationPath, addr, ttlPathSuffix), string(ttl))
-	require.NoError(t, err)
-}
-
-// Update the TopologyInfo for a backend.
-func updateTopologyInfo(t *testing.T, kv clientv3.KV, sqlAddr, statusAddr string) {
-	hostAndPort := strings.Split(statusAddr, ":")
-	require.Equal(t, 2, len(hostAndPort))
-	port, err := strconv.ParseUint(hostAndPort[1], 10, 32)
-	require.NoError(t, err)
-	topology := &infosync.TopologyInfo{
-		IP:         hostAndPort[0],
-		StatusPort: uint(port),
+	tpFetcher := newMockTpFetcher(t)
+	pf := NewPDFetcher(tpFetcher, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
+	for _, test := range tests {
+		tpFetcher.infos = test.infos
+		if test.ctx == nil {
+			test.ctx = context.Background()
+		}
+		info, err := pf.GetBackendList(test.ctx)
+		test.check(info)
+		require.NoError(t, err)
 	}
-	data, err := json.Marshal(topology)
-	require.NoError(t, err)
-	_, err = kv.Put(context.Background(), path.Join(infosync.TopologyInformationPath, sqlAddr, infoPathSuffix), string(data))
-	require.NoError(t, err)
+}
+
+type mockTpFetcher struct {
+	t     *testing.T
+	infos map[string]*infosync.TiDBInfo
+	err   error
+}
+
+func newMockTpFetcher(t *testing.T) *mockTpFetcher {
+	return &mockTpFetcher{
+		t: t,
+	}
+}
+
+func (ft *mockTpFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error) {
+	return ft.infos, ft.err
 }

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -72,8 +72,6 @@ func (bh *backendHealth) String() string {
 }
 
 const (
-	ttlPathSuffix    = "/ttl"
-	infoPathSuffix   = "/info"
 	statusPathSuffix = "/status"
 )
 

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -7,20 +7,16 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"sync"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
-	"github.com/pingcap/TiProxy/lib/util/errors"
 	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/pingcap/TiProxy/lib/util/waitgroup"
 	pnet "github.com/pingcap/TiProxy/pkg/proxy/net"
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
 	"go.uber.org/atomic"
-	"golang.org/x/exp/slices"
 )
 
 type mockEventReceiver struct {
@@ -45,204 +41,159 @@ func newMockEventReceiver(backendChan chan map[string]*backendHealth, errChan ch
 
 func newHealthCheckConfigForTest() *config.HealthCheck {
 	return &config.HealthCheck{
-		Enable:             true,
-		Interval:           500 * time.Millisecond,
-		MaxRetries:         3,
-		RetryInterval:      100 * time.Millisecond,
-		DialTimeout:        100 * time.Millisecond,
-		TombstoneThreshold: 5 * time.Minute,
+		Enable:        true,
+		Interval:      300 * time.Millisecond,
+		MaxRetries:    3,
+		RetryInterval: 30 * time.Millisecond,
+		DialTimeout:   100 * time.Millisecond,
 	}
 }
 
 // Test that the notified backend status is correct when the backend starts or shuts down.
 func TestObserveBackends(t *testing.T) {
-	runETCDTest(t, func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]*backendHealth) {
-		bo.Start()
+	ts := newObserverTestSuite(t)
+	t.Cleanup(ts.close)
+	ts.bo.Start()
 
-		backend1 := addBackend(t, kv)
-		checkStatus(t, backendChan, backend1, StatusHealthy)
-		addFakeTopology(t, kv, backend1.sqlAddr)
-		backend1.stopSQLServer()
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend1.startSQLServer()
-		checkStatus(t, backendChan, backend1, StatusHealthy)
-		backend1.setHTTPResp(false)
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend1.setHTTPResp(true)
-		checkStatus(t, backendChan, backend1, StatusHealthy)
-		backend1.setHTTPWait(bo.healthCheckConfig.DialTimeout + time.Second)
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend1.setHTTPWait(time.Duration(0))
-		checkStatus(t, backendChan, backend1, StatusHealthy)
-		backend1.stopHTTPServer()
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend1.startHTTPServer()
-		checkStatus(t, backendChan, backend1, StatusHealthy)
+	backend1 := ts.addBackend()
+	ts.checkStatus(backend1, StatusHealthy)
+	backend1.stopSQLServer()
+	ts.checkStatus(backend1, StatusCannotConnect)
+	backend1.startSQLServer()
+	ts.checkStatus(backend1, StatusHealthy)
+	backend1.setHTTPResp(false)
+	ts.checkStatus(backend1, StatusCannotConnect)
+	backend1.setHTTPResp(true)
+	ts.checkStatus(backend1, StatusHealthy)
+	backend1.setHTTPWait(ts.bo.healthCheckConfig.DialTimeout + time.Second)
+	ts.checkStatus(backend1, StatusCannotConnect)
+	backend1.setHTTPWait(time.Duration(0))
+	ts.checkStatus(backend1, StatusHealthy)
+	backend1.stopHTTPServer()
+	ts.checkStatus(backend1, StatusCannotConnect)
+	backend1.startHTTPServer()
+	ts.checkStatus(backend1, StatusHealthy)
 
-		backend2 := addBackend(t, kv)
-		checkStatus(t, backendChan, backend2, StatusHealthy)
-		removeBackend(t, kv, backend2)
-		checkStatus(t, backendChan, backend2, StatusCannotConnect)
+	backend2 := ts.addBackend()
+	ts.checkStatus(backend2, StatusHealthy)
+	ts.removeBackend(backend2)
+	ts.checkStatus(backend2, StatusCannotConnect)
 
-		backend1.close()
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend2.close()
-	})
-}
-
-// Test that the observer can exit during health check.
-func TestCancelObserver(t *testing.T) {
-	runETCDTest(t, func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]*backendHealth) {
-		backends := make([]*backendServer, 0, 3)
-		for i := 0; i < 3; i++ {
-			backends = append(backends, addBackend(t, kv))
-		}
-		backendInfo, err := bo.fetcher.GetBackendList(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, 3, len(backendInfo))
-
-		// Try 10 times.
-		for i := 0; i < 10; i++ {
-			childCtx, cancelFunc := context.WithCancel(context.Background())
-			var wg waitgroup.WaitGroup
-			wg.Run(func() {
-				for childCtx.Err() != nil {
-					bo.checkHealth(childCtx, backendInfo)
-				}
-			})
-			time.Sleep(10 * time.Millisecond)
-			cancelFunc()
-			wg.Wait()
-		}
-
-		for _, backend := range backends {
-			backend.close()
-		}
-	})
-}
-
-// Test that it won't hang or panic when the Etcd server fails.
-func TestEtcdUnavailable(t *testing.T) {
-	runETCDTest(t, func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]*backendHealth) {
-		bo.Start()
-		etcd.Server.Stop()
-		<-etcd.Server.StopNotify()
-		// The observer will retry indefinitely. We verify it won't panic or hang here.
-		// There's no other way than modifying the code or just sleeping.
-		time.Sleep(bo.healthCheckConfig.Interval + bo.healthCheckConfig.DialTimeout + bo.healthCheckConfig.RetryInterval)
-		require.Equal(t, 0, len(backendChan))
-	})
-}
-
-// Test that the notified backend status is correct for external fetcher.
-func TestExternalFetcher(t *testing.T) {
-	backendAddrs := make([]string, 0)
-	var observeError error
-	var mutex sync.Mutex
-	backendGetter := func() ([]string, error) {
-		mutex.Lock()
-		defer mutex.Unlock()
-		return backendAddrs, observeError
-	}
-	addBackend := func() *backendServer {
-		backend := newBackendServer(t)
-		mutex.Lock()
-		backendAddrs = append(backendAddrs, backend.sqlAddr)
-		mutex.Unlock()
-		return backend
-	}
-	removeBackend := func(backend *backendServer) {
-		mutex.Lock()
-		idx := slices.Index(backendAddrs, backend.sqlAddr)
-		backendAddrs = append(backendAddrs[:idx], backendAddrs[idx+1:]...)
-		mutex.Unlock()
-	}
-	mockError := func() {
-		mutex.Lock()
-		observeError = errors.New("mock observe error")
-		mutex.Unlock()
-	}
-
-	backendChan := make(chan map[string]*backendHealth, 1)
-	errChan := make(chan error, 1)
-	mer := newMockEventReceiver(backendChan, errChan)
-	fetcher := NewExternalFetcher(backendGetter)
-	bo, err := NewBackendObserver(logger.CreateLoggerForTest(t), mer, nil, newHealthCheckConfigForTest(), fetcher)
-	require.NoError(t, err)
-	bo.Start()
-	defer bo.Close()
-
-	backend1 := addBackend()
-	checkStatus(t, backendChan, backend1, StatusHealthy)
-	backend2 := addBackend()
-	checkStatus(t, backendChan, backend2, StatusHealthy)
-
-	// remove from the list but it's still alive
-	removeBackend(backend1)
-	checkStatus(t, backendChan, backend1, StatusCannotConnect)
 	backend1.close()
-
-	// kill it but it's still in the list
+	ts.checkStatus(backend1, StatusCannotConnect)
 	backend2.close()
-	checkStatus(t, backendChan, backend2, StatusCannotConnect)
-	removeBackend(backend2)
+}
 
-	// returns observe error
-	require.Len(t, errChan, 0)
-	mockError()
-	err = <-errChan
-	require.Error(t, err)
+// Test that the health check can exit when the context is cancelled.
+func TestCancelObserver(t *testing.T) {
+	ts := newObserverTestSuite(t)
+	t.Cleanup(ts.close)
+
+	backends := make([]*backendServer, 0, 3)
+	for i := 0; i < 3; i++ {
+		backends = append(backends, ts.addBackend())
+	}
+	info, err := ts.fetcher.GetBackendList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, info, 3)
+
+	// Try 10 times.
+	for i := 0; i < 10; i++ {
+		childCtx, cancelFunc := context.WithCancel(context.Background())
+		var wg waitgroup.WaitGroup
+		wg.Run(func() {
+			for childCtx.Err() != nil {
+				ts.bo.checkHealth(childCtx, info)
+			}
+		})
+		time.Sleep(10 * time.Millisecond)
+		cancelFunc()
+		wg.Wait()
+	}
+
+	for _, backend := range backends {
+		backend.close()
+	}
 }
 
 func TestReadServerVersion(t *testing.T) {
-	runETCDTest(t, func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]*backendHealth) {
-		bo.Start()
+	ts := newObserverTestSuite(t)
+	t.Cleanup(ts.close)
 
-		backend1 := addBackend(t, kv)
-		backend1.serverVersion.Store("1.0")
-		addFakeTopology(t, kv, backend1.sqlAddr)
-		backends := getBackendsFromCh(t, backendChan)
-		require.Equal(t, "1.0", backends[backend1.sqlAddr].serverVersion)
-		backend1.stopSQLServer()
-		checkStatus(t, backendChan, backend1, StatusCannotConnect)
-		backend1.serverVersion.Store("2.0")
-		backend1.startSQLServer()
-		backends = getBackendsFromCh(t, backendChan)
-		require.Equal(t, "2.0", backends[backend1.sqlAddr].serverVersion)
-		backend1.close()
-	})
+	backend1 := ts.addBackend()
+	backend1.serverVersion.Store("1.0")
+	ts.bo.Start()
+	backends := ts.getBackendsFromCh()
+	require.Equal(t, "1.0", backends[backend1.sqlAddr].serverVersion)
+	backend1.stopSQLServer()
+	ts.checkStatus(backend1, StatusCannotConnect)
+	backend1.serverVersion.Store("2.0")
+	backend1.startSQLServer()
+	backends = ts.getBackendsFromCh()
+	require.Equal(t, "2.0", backends[backend1.sqlAddr].serverVersion)
+	backend1.close()
 }
 
-func runETCDTest(t *testing.T, f func(etcd *embed.Etcd, kv clientv3.KV, bo *BackendObserver, backendChan chan map[string]*backendHealth)) {
-	etcd := createEtcdServer(t, "127.0.0.1:0")
-	client := createEtcdClient(t, etcd)
-	kv := clientv3.NewKV(client)
+type observerTestSuite struct {
+	t           *testing.T
+	bo          *BackendObserver
+	fetcher     *mockBackendFetcher
+	backendChan chan map[string]*backendHealth
+}
+
+func newObserverTestSuite(t *testing.T) *observerTestSuite {
 	backendChan := make(chan map[string]*backendHealth, 1)
 	mer := newMockEventReceiver(backendChan, make(chan error, 1))
-	fetcher := NewPDFetcher(client, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
+	fetcher := &mockBackendFetcher{
+		backends: make(map[string]*BackendInfo),
+	}
 	bo, err := NewBackendObserver(logger.CreateLoggerForTest(t), mer, nil, newHealthCheckConfigForTest(), fetcher)
 	require.NoError(t, err)
-	f(etcd, kv, bo, backendChan)
-	bo.Close()
+	return &observerTestSuite{
+		t:           t,
+		bo:          bo,
+		fetcher:     fetcher,
+		backendChan: backendChan,
+	}
 }
 
-func checkStatus(t *testing.T, backendChan chan map[string]*backendHealth, backend *backendServer, expectedStatus BackendStatus) {
-	backends := getBackendsFromCh(t, backendChan)
-	require.Equal(t, 1, len(backends))
+func (ts *observerTestSuite) close() {
+	if ts.bo != nil {
+		ts.bo.Close()
+		ts.bo = nil
+	}
+}
+
+func (ts *observerTestSuite) checkStatus(backend *backendServer, expectedStatus BackendStatus) {
+	backends := ts.getBackendsFromCh()
+	require.Equal(ts.t, 1, len(backends))
 	health, ok := backends[backend.sqlAddr]
-	require.True(t, ok)
-	require.Equal(t, expectedStatus, health.status)
-	require.True(t, checkBackendStatusMetrics(backend.sqlAddr, health.status))
+	require.True(ts.t, ok)
+	require.Equal(ts.t, expectedStatus, health.status)
+	require.True(ts.t, checkBackendStatusMetrics(backend.sqlAddr, health.status))
 }
 
-func getBackendsFromCh(t *testing.T, backendChan chan map[string]*backendHealth) map[string]*backendHealth {
+func (ts *observerTestSuite) getBackendsFromCh() map[string]*backendHealth {
 	var backends map[string]*backendHealth
 	select {
-	case backends = <-backendChan:
+	case backends = <-ts.backendChan:
 	case <-time.After(3 * time.Second):
-		t.Fatal("timeout")
+		ts.t.Fatal("timeout")
 	}
 	return backends
+}
+
+func (ts *observerTestSuite) addBackend() *backendServer {
+	backend := newBackendServer(ts.t)
+	ts.fetcher.backends[backend.sqlAddr] = &BackendInfo{
+		IP:         backend.ip,
+		StatusPort: backend.statusPort,
+	}
+	return backend
+}
+
+func (ts *observerTestSuite) removeBackend(backend *backendServer) {
+	delete(ts.fetcher.backends, backend.sqlAddr)
 }
 
 type backendServer struct {
@@ -253,7 +204,9 @@ type backendServer struct {
 	statusAddr    string
 	serverVersion atomic.String
 	*mockHttpHandler
-	wg waitgroup.WaitGroup
+	wg         waitgroup.WaitGroup
+	ip         string
+	statusPort uint
 }
 
 func newBackendServer(t *testing.T) *backendServer {
@@ -300,6 +253,7 @@ func (srv *backendServer) startHTTPServer() {
 	}
 	var statusListener net.Listener
 	statusListener, srv.statusAddr = startListener(srv.t, srv.statusAddr)
+	srv.ip, srv.statusPort = parseHostPort(srv.t, srv.statusAddr)
 	srv.statusServer = &http.Server{Addr: srv.statusAddr, Handler: srv.mockHttpHandler}
 	srv.wg.Run(func() {
 		_ = srv.statusServer.Serve(statusListener)
@@ -346,6 +300,22 @@ func startListener(t *testing.T, addr string) (net.Listener, string) {
 	listener, err := net.Listen("tcp", addr)
 	require.NoError(t, err)
 	return listener, listener.Addr().String()
+}
+
+func parseHostPort(t *testing.T, addr string) (string, uint) {
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 32)
+	require.NoError(t, err)
+	return host, uint(p)
+}
+
+type mockBackendFetcher struct {
+	backends map[string]*BackendInfo
+}
+
+func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+	return mbf.backends, nil
 }
 
 // ExternalFetcher fetches backend list from a given callback.

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -628,55 +628,41 @@ func TestRebalanceCornerCase(t *testing.T) {
 
 // Test all kinds of events occur concurrently.
 func TestConcurrency(t *testing.T) {
-	// Router.observer doesn't work because the etcd is always empty.
-	// We create other goroutines to change backends easily.
-	etcd := createEtcdServer(t, "127.0.0.1:0")
-	client := createEtcdClient(t, etcd)
-	healthCheckConfig := newHealthCheckConfigForTest()
-	fetcher := NewPDFetcher(client, logger.CreateLoggerForTest(t), healthCheckConfig)
+	// Disable health check so that it just reads BackendFetcher.
+	healthCheckConfig := &config.HealthCheck{
+		Enable:   false,
+		Interval: 10 * time.Millisecond,
+	}
+	fetcher := &mockBackendFetcher{}
 	router := NewScoreBasedRouter(logger.CreateLoggerForTest(t))
 	err := router.Init(nil, fetcher, healthCheckConfig)
 	require.NoError(t, err)
 
 	var wg waitgroup.WaitGroup
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	// Create 3 backends.
-	backends := map[string]*backendHealth{
-		"0": {
-			status: StatusHealthy,
-		},
-		"1": {
-			status: StatusHealthy,
-		},
-		"2": {
-			status: StatusHealthy,
-		},
+	// Create 3 backends and change their status randomly.
+	fetcher.backends = map[string]*BackendInfo{
+		"0": {},
+		"1": {},
+		"2": {},
 	}
-	router.OnBackendChanged(backends, nil)
-	for addr, health := range backends {
-		func(addr string, status BackendStatus) {
-			wg.Run(func() {
-				for {
-					waitTime := rand.Intn(50) + 30
-					select {
-					case <-time.After(time.Duration(waitTime) * time.Millisecond):
-					case <-ctx.Done():
-						return
-					}
-					if status == StatusHealthy {
-						status = StatusCannotConnect
-					} else {
-						status = StatusHealthy
-					}
-					router.OnBackendChanged(map[string]*backendHealth{
-						addr: {
-							status: status,
-						},
-					}, nil)
-				}
-			})
-		}(addr, health.status)
-	}
+	wg.Run(func() {
+		for {
+			waitTime := rand.Intn(20) + 10
+			select {
+			case <-time.After(time.Duration(waitTime) * time.Millisecond):
+			case <-ctx.Done():
+				return
+			}
+			idx := rand.Intn(3)
+			addr := strconv.Itoa(idx)
+			if _, ok := fetcher.backends[addr]; ok {
+				delete(fetcher.backends, addr)
+			} else {
+				fetcher.backends[addr] = &BackendInfo{}
+			}
+		}
+	})
 
 	// Create 20 connections.
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #308

Problem Summary:
- If TiDB is down, its TTL info is erased automatically after TTL, so there's no need to check tombstone topologies.
- `PDFetcher` is coupled with etcdClient, making it hard to test.

What is changed and how it works:
- Remove tombstone check
- Move all etcd related code into `infosync`
- `PDFetcher` uses `InfoSyncer` to fetch topologies
- Mock a `TopologyFetcher` in the router tests so that it's unware of etcd

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Start a TiDB cluster and TiProxy
2. TiProxy logs `update backend`
3. Scale out a TiDB
4. TiProxy logs `update backend`

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
