### PR TITLE
config: skip irrelevant config file events

### DIFF
--- a/lib/util/logger/logger.go
+++ b/lib/util/logger/logger.go
@@ -26,17 +26,8 @@ func (t *testingLog) String() string {
 	return t.buf.String()
 }
 
-// CreateLoggerForTest creates a logger for unit tests.
-func CreateLoggerForTest(t *testing.T) *zap.Logger {
-	return zap.New(zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-		zapcore.AddSync(&testingLog{T: t}),
-		zap.InfoLevel,
-	)).Named(t.Name())
-}
-
-// CreateLoggerAndStringerForTest returns both the logger and its content.
-func CreateLoggerAndStringerForTest(t *testing.T) (*zap.Logger, fmt.Stringer) {
+// CreateLoggerForTest returns both the logger and its content.
+func CreateLoggerForTest(t *testing.T) (*zap.Logger, fmt.Stringer) {
 	log := &testingLog{T: t}
 	return zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),

--- a/lib/util/logger/logger.go
+++ b/lib/util/logger/logger.go
@@ -4,6 +4,8 @@
 package logger
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"go.uber.org/zap"
@@ -12,18 +14,33 @@ import (
 
 type testingLog struct {
 	*testing.T
+	buf bytes.Buffer
 }
 
 func (t *testingLog) Write(b []byte) (int, error) {
 	t.Logf("%s", b)
-	return len(b), nil
+	return t.buf.Write(b)
+}
+
+func (t *testingLog) String() string {
+	return t.buf.String()
 }
 
 // CreateLoggerForTest creates a logger for unit tests.
 func CreateLoggerForTest(t *testing.T) *zap.Logger {
 	return zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-		zapcore.AddSync(&testingLog{t}),
+		zapcore.AddSync(&testingLog{T: t}),
 		zap.InfoLevel,
 	)).Named(t.Name())
+}
+
+// CreateLoggerAndStringerForTest returns both the logger and its content.
+func CreateLoggerAndStringerForTest(t *testing.T) (*zap.Logger, fmt.Stringer) {
+	log := &testingLog{T: t}
+	return zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		zapcore.AddSync(log),
+		zap.InfoLevel,
+	)).Named(t.Name()), log
 }

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCertServer(t *testing.T) {
-	logger := logger.CreateLoggerForTest(t)
+	logger, _ := logger.CreateLoggerForTest(t)
 	tmpdir := t.TempDir()
 	certPath := filepath.Join(tmpdir, "cert")
 	keyPath := filepath.Join(tmpdir, "key")
@@ -267,7 +267,7 @@ func TestCertServer(t *testing.T) {
 }
 
 func TestReload(t *testing.T) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	tmpdir := t.TempDir()
 	certPath := filepath.Join(tmpdir, "cert")
 	keyPath := filepath.Join(tmpdir, "key")
@@ -297,7 +297,7 @@ func TestReload(t *testing.T) {
 }
 
 func TestAutoCerts(t *testing.T) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	cfg := config.TLSConfig{
 		AutoCerts: true,
 	}
@@ -338,7 +338,7 @@ func getExpireTime(t *testing.T, ci *CertInfo) time.Time {
 }
 
 func TestSetConfig(t *testing.T) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	ci := NewCert(false)
 	cfg := config.TLSConfig{
 		SkipCA: true,

--- a/lib/util/systimemon/systime_mon_test.go
+++ b/lib/util/systimemon/systime_mon_test.go
@@ -17,7 +17,7 @@ import (
 func TestSystimeMonitor(t *testing.T) {
 	errTriggered := atomic.NewBool(false)
 	nowTriggered := atomic.NewBool(false)
-	log := logger.CreateLoggerForTest(t)
+	log, _ := logger.CreateLoggerForTest(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg waitgroup.WaitGroup
 	wg.Run(func() {

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -58,7 +58,7 @@ func connectWithTLS(ctls, stls *tls.Config) (clientErr, serverErr error) {
 
 // Test various configurations.
 func TestInit(t *testing.T) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	tmpdir := t.TempDir()
 
 	type testcase struct {
@@ -139,7 +139,7 @@ func TestInit(t *testing.T) {
 // Test rotation works.
 func TestRotate(t *testing.T) {
 	tmpdir := t.TempDir()
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	caPath := filepath.Join(tmpdir, "ca")
 	keyPath := filepath.Join(tmpdir, "key")
 	certPath := filepath.Join(tmpdir, "cert")
@@ -321,7 +321,7 @@ func TestRotate(t *testing.T) {
 
 func TestBidirectional(t *testing.T) {
 	tmpdir := t.TempDir()
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	caPath1 := filepath.Join(tmpdir, "c1", "ca")
 	keyPath1 := filepath.Join(tmpdir, "c1", "key")
 	certPath1 := filepath.Join(tmpdir, "c1", "cert")
@@ -359,7 +359,7 @@ func TestBidirectional(t *testing.T) {
 
 func TestWatchConfig(t *testing.T) {
 	tmpdir := t.TempDir()
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	caPath1 := filepath.Join(tmpdir, "c1", "ca")
 	keyPath1 := filepath.Join(tmpdir, "c1", "key")
 	certPath1 := filepath.Join(tmpdir, "c1", "cert")

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -28,7 +28,9 @@ func (e *ConfigManager) reloadConfigFile(file string) error {
 func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
 	switch {
 	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
-		// The file may be the log file, triggering reload will cause more logs and thus cause reload again.
+		// The file may be the log file, triggering reload will cause more logs and thus cause reload again,
+		// so we need to filter the wrong files.
+		// Linux is case-sensitive but macOS is case-insensitive.
 		if !strings.EqualFold(ev.Name, f) {
 			break
 		}

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"hash/crc32"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -30,8 +29,15 @@ func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
 	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
 		// The file may be the log file, triggering reload will cause more logs and thus cause reload again,
 		// so we need to filter the wrong files.
-		// Linux is case-sensitive but macOS is case-insensitive.
-		if !strings.EqualFold(ev.Name, f) {
+		f1, err := os.Stat(ev.Name)
+		if err != nil {
+			break
+		}
+		f2, err := os.Stat(f)
+		if err != nil {
+			break
+		}
+		if !os.SameFile(f1, f2) {
 			break
 		}
 		if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -29,6 +29,7 @@ func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
 	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
 		// The file may be the log file, triggering reload will cause more logs and thus cause reload again,
 		// so we need to filter the wrong files.
+		// The filesystem differs from OS to OS, so don't use string comparison.
 		f1, err := os.Stat(ev.Name)
 		if err != nil {
 			break

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -28,6 +28,7 @@ func (e *ConfigManager) reloadConfigFile(file string) error {
 func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
 	switch {
 	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
+		// The file may be the log file, triggering reload will cause more logs and thus cause reload again.
 		if !strings.EqualFold(ev.Name, f) {
 			break
 		}

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -199,6 +199,11 @@ func TestFilePath(t *testing.T) {
 				f, err := os.Create(filepath.Join(tmpdir, "CFG"))
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
+				// Linux is case-sensitive but macOS is case-insensitive.
+				// For linux, it creates another file. For macOS, it doesn't touch the file.
+				f, err = os.Create(filepath.Join(tmpdir, "cfg"))
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
 			},
 		},
 		{

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -211,6 +211,10 @@ func TestFilePath(t *testing.T) {
 			filename: "cfg",
 		},
 		{
+			// Test relative path.
+			filename: "./cfg",
+		},
+		{
 			// Test uncleaned path.
 			filename: fmt.Sprintf("%s%c%ccfg", tmpdir, filepath.Separator, filepath.Separator),
 		},
@@ -227,11 +231,11 @@ func TestFilePath(t *testing.T) {
 			},
 			cleanFile: func() {
 				require.NoError(t, os.RemoveAll("_tmp"))
-				checkLog(true)
 			},
 			checker: func(filename string) {
 				require.NoError(t, os.RemoveAll("_tmp"))
-				checkLog(true)
+				// To update `count`.
+				checkLog(false)
 
 				require.NoError(t, os.Mkdir("_tmp", 0755))
 				f, err := os.Create("_tmp/cfg")
@@ -268,8 +272,8 @@ func TestFilePath(t *testing.T) {
 		if test.cleanFile != nil {
 			test.cleanFile()
 		} else {
+			// It doesn't matter whether it triggers reload or not.
 			require.NoError(t, os.Remove(test.filename))
-			checkLog(true)
 		}
 		require.NoError(t, cfgmgr.Close())
 	}

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -208,6 +208,7 @@ func TestFilePath(t *testing.T) {
 		},
 		{
 			// Test relative path.
+			// `event.Name` is `cfg` on MacOS, but it's `./cfg` on Linux.
 			filename: "cfg",
 		},
 		{
@@ -219,7 +220,7 @@ func TestFilePath(t *testing.T) {
 			filename: fmt.Sprintf("%s%c%ccfg", tmpdir, filepath.Separator, filepath.Separator),
 		},
 		{
-			// Test removing and creating the directory.
+			// Test removing and recreating the directory.
 			filename: "_tmp/cfg",
 			createFile: func() {
 				if err := os.Mkdir("_tmp", 0755); err != nil {
@@ -239,6 +240,19 @@ func TestFilePath(t *testing.T) {
 
 				require.NoError(t, os.Mkdir("_tmp", 0755))
 				f, err := os.Create("_tmp/cfg")
+				require.NoError(t, err)
+				require.NoError(t, f.Close())
+				checkLog(true)
+			},
+		},
+		{
+			// Test removing and recreating the file.
+			filename: "cfg",
+			checker: func(filename string) {
+				require.NoError(t, os.Remove(filename))
+				checkLog(false)
+
+				f, err := os.Create(filename)
 				require.NoError(t, err)
 				require.NoError(t, f.Close())
 				checkLog(true)

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -78,7 +78,6 @@ func (e *ConfigManager) Init(ctx context.Context, logger *zap.Logger, configFile
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		configFile = filepath.Clean(configFile)
 
 		// Watch the parent dir, because vim/k8s or other apps may not edit files in-place:
 		// e.g. k8s configmap is a symlink of a symlink to a file, which will only trigger

--- a/pkg/manager/config/manager_test.go
+++ b/pkg/manager/config/manager_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, fmt.Stringer, context.Context) {
-	logger, text := logger.CreateLoggerAndStringerForTest(t)
+	logger, text := logger.CreateLoggerForTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	if ddl, ok := t.Deadline(); ok {

--- a/pkg/manager/config/manager_test.go
+++ b/pkg/manager/config/manager_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/TiProxy/lib/config"
@@ -12,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, context.Context) {
-	logger := logger.CreateLoggerForTest(t)
+func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, fmt.Stringer, context.Context) {
+	logger, text := logger.CreateLoggerAndStringerForTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	if ddl, ok := t.Deadline(); ok {
@@ -29,5 +30,5 @@ func testConfigManager(t *testing.T, configFile string, overlays ...*config.Conf
 
 	t.Cleanup(cancel)
 
-	return cfgmgr, ctx
+	return cfgmgr, text, ctx
 }

--- a/pkg/manager/config/namespace_test.go
+++ b/pkg/manager/config/namespace_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBase(t *testing.T) {
-	cfgmgr, ctx := testConfigManager(t, "")
+	cfgmgr, _, ctx := testConfigManager(t, "")
 
 	nsNum := 10
 	valNum := 30
@@ -74,7 +74,7 @@ func TestBase(t *testing.T) {
 }
 
 func TestBaseConcurrency(t *testing.T) {
-	cfgmgr, ctx := testConfigManager(t, "")
+	cfgmgr, _, ctx := testConfigManager(t, "")
 
 	var wg waitgroup.WaitGroup
 	batchNum := 16

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -207,7 +207,7 @@ type etcdTestSuite struct {
 }
 
 func newEtcdTestSuite(t *testing.T) *etcdTestSuite {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	ts := &etcdTestSuite{
 		t:  t,
 		lg: lg,

--- a/pkg/manager/router/backend_fetcher_test.go
+++ b/pkg/manager/router/backend_fetcher_test.go
@@ -104,7 +104,8 @@ func TestPDFetcher(t *testing.T) {
 	}
 
 	tpFetcher := newMockTpFetcher(t)
-	pf := NewPDFetcher(tpFetcher, logger.CreateLoggerForTest(t), newHealthCheckConfigForTest())
+	lg, _ := logger.CreateLoggerForTest(t)
+	pf := NewPDFetcher(tpFetcher, lg, newHealthCheckConfigForTest())
 	for _, test := range tests {
 		tpFetcher.infos = test.infos
 		if test.ctx == nil {

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -147,7 +147,8 @@ func newObserverTestSuite(t *testing.T) *observerTestSuite {
 	fetcher := &mockBackendFetcher{
 		backends: make(map[string]*BackendInfo),
 	}
-	bo, err := NewBackendObserver(logger.CreateLoggerForTest(t), mer, nil, newHealthCheckConfigForTest(), fetcher)
+	lg, _ := logger.CreateLoggerForTest(t)
+	bo, err := NewBackendObserver(lg, mer, nil, newHealthCheckConfigForTest(), fetcher)
 	require.NoError(t, err)
 	return &observerTestSuite{
 		t:           t,

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -111,7 +111,8 @@ type routerTester struct {
 }
 
 func newRouterTester(t *testing.T) *routerTester {
-	router := NewScoreBasedRouter(logger.CreateLoggerForTest(t))
+	lg, _ := logger.CreateLoggerForTest(t)
+	router := NewScoreBasedRouter(lg)
 	t.Cleanup(router.Close)
 	return &routerTester{
 		t:      t,
@@ -634,7 +635,8 @@ func TestConcurrency(t *testing.T) {
 		Interval: 10 * time.Millisecond,
 	}
 	fetcher := &mockBackendFetcher{}
-	router := NewScoreBasedRouter(logger.CreateLoggerForTest(t))
+	lg, _ := logger.CreateLoggerForTest(t)
+	router := NewScoreBasedRouter(lg)
 	err := router.Init(nil, fetcher, healthCheckConfig)
 	require.NoError(t, err)
 
@@ -735,7 +737,7 @@ func TestRefresh(t *testing.T) {
 		return backends, nil
 	})
 	// Create a router with a very long health check interval.
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
 	cfg := config.NewDefaultHealthCheckConfig()
 	cfg.Interval = time.Minute
@@ -774,7 +776,7 @@ func TestObserveError(t *testing.T) {
 		return backends, observeError
 	})
 	// Create a router with a very short health check interval.
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
 	observer, err := StartBackendObserver(lg, rt, nil, newHealthCheckConfigForTest(), fetcher)
 	require.NoError(t, err)
@@ -829,7 +831,7 @@ func TestDisableHealthCheck(t *testing.T) {
 		return backends, nil
 	})
 	// Create a router with a very short health check interval.
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
 	err := rt.Init(nil, fetcher, &config.HealthCheck{Enable: false})
 	require.NoError(t, err)
@@ -868,7 +870,8 @@ func TestSetBackendStatus(t *testing.T) {
 }
 
 func TestGetServerVersion(t *testing.T) {
-	rt := NewScoreBasedRouter(logger.CreateLoggerForTest(t))
+	lg, _ := logger.CreateLoggerForTest(t)
+	rt := NewScoreBasedRouter(lg)
 	t.Cleanup(rt.Close)
 	backends := map[string]*backendHealth{
 		"0": {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -36,7 +36,7 @@ func TestPushMetrics(t *testing.T) {
 		}),
 	)
 	defer pgwOK.Close()
-	log := logger.CreateLoggerForTest(t)
+	log, _ := logger.CreateLoggerForTest(t)
 
 	tests := []struct {
 		metricsAddr     string

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -92,10 +92,11 @@ func newBackendMgrTester(t *testing.T, cfg ...cfgOverrider) *backendMgrTester {
 		cfg.testSuiteConfig.enableRouteLogic = true
 	})
 	ts, clean := newTestSuite(t, tc, cfg...)
+	lg, _ := logger.CreateLoggerForTest(t)
 	tester := &backendMgrTester{
 		testSuite: ts,
 		t:         t,
-		lg:        logger.CreateLoggerForTest(t),
+		lg:        lg,
 	}
 	t.Cleanup(func() {
 		clean()
@@ -841,7 +842,8 @@ func TestGetBackendIO(t *testing.T) {
 			}
 		},
 	}
-	mgr := NewBackendConnManager(logger.CreateLoggerForTest(t), handler, 0, &BCConfig{})
+	lg, _ := logger.CreateLoggerForTest(t)
+	mgr := NewBackendConnManager(lg, handler, 0, &BCConfig{})
 	var wg waitgroup.WaitGroup
 	for i := 0; i <= len(listeners); i++ {
 		wg.Run(func() {

--- a/pkg/proxy/backend/common_test.go
+++ b/pkg/proxy/backend/common_test.go
@@ -46,7 +46,7 @@ func newTCPConnSuite(t *testing.T) *tcpConnSuite {
 }
 
 func (tc *tcpConnSuite) newConn(t *testing.T, enableRoute bool) func() {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	var wg waitgroup.WaitGroup
 	if !enableRoute {
 		wg.Run(func() {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -46,10 +46,11 @@ type mockProxy struct {
 }
 
 func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
+	lg, _ := logger.CreateLoggerForTest(t)
 	mp := &mockProxy{
 		proxyConfig: cfg,
-		logger:      logger.CreateLoggerForTest(t).Named("mockProxy"),
-		BackendConnManager: NewBackendConnManager(logger.CreateLoggerForTest(t), cfg.handler, 0, &BCConfig{
+		logger:      lg.Named("mockProxy"),
+		BackendConnManager: NewBackendConnManager(lg, cfg.handler, 0, &BCConfig{
 			CheckBackendInterval: cfg.checkBackendInterval,
 		}),
 	}

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func testPipeConn(t *testing.T, a func(*testing.T, *PacketIO), b func(*testing.T, *PacketIO), loop int) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	testkit.TestPipeConn(t,
 		func(t *testing.T, c net.Conn) {
 			a(t, NewPacketIO(c, lg))
@@ -29,7 +29,7 @@ func testPipeConn(t *testing.T, a func(*testing.T, *PacketIO), b func(*testing.T
 }
 
 func testTCPConn(t *testing.T, a func(*testing.T, *PacketIO), b func(*testing.T, *PacketIO), loop int) {
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	testkit.TestTCPConn(t,
 		func(t *testing.T, c net.Conn) {
 			cli := NewPacketIO(c, lg)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGracefulShutdown(t *testing.T) {
 	// Graceful shutdown finishes immediately if there's no connection.
-	lg := logger.CreateLoggerForTest(t)
+	lg, _ := logger.CreateLoggerForTest(t)
 	hsHandler := backend.NewDefaultHandshakeHandler(nil, "")
 	server, err := NewSQLServer(lg, config.ProxyServer{
 		ProxyServerOnline: config.ProxyServerOnline{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #321

Problem Summary:
- If the log file is in the same directory as the config file, TiProxy reloads the config file once the log outputs, and reloading itself causes log output, which is a dead loop.
- If the directory is removed and then both the directory and the file are created within 200ms, the ConfigManager doesn't receive an event.

What is changed and how it works:
- Check the file name for the watch event
- Reload events if watch list is empty before adding
- Support searching logger for test

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
