### PR TITLE
backend: fix `using password` in the error message is wrong

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -203,8 +203,9 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	// forward client handshake resp
 	if err := auth.writeAuthHandshake(
 		backendIO, backendTLSConfig, backendCapability,
-		// send an unknown auth plugin so that the backend will request the auth data again.
-		unknownAuthPlugin, nil, 0,
+		// Send an unknown auth plugin so that the backend will request the auth data again.
+		// Copy the auth data so that the backend can set correct `using password` in the error message.
+		unknownAuthPlugin, clientResp.AuthData, 0,
 	); err != nil {
 		return pnet.WrapUserError(err, handshakeErrMsg)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #332

Problem Summary:
When TiProxy handshakes with TiDB, it sends `auth_plugin=unknown_auth_plugin` and `auth_data=nil`. TiDB sees that `auth_data=nil` and then sets `using password` to `NO`.

What is changed and how it works:
Pass `authData` to TiDB for the first handshake.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
mysql -h127.1 -udummy -P6001 -pdummy
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 1045 (28000): Access denied for user 'dummy'@'127.0.0.1' (using password: YES)

mysql -h127.1 -udummy -P6001
ERROR 1045 (28000): Access denied for user 'dummy'@'127.0.0.1' (using password: NO)
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
