### PR TITLE
security: report warning when TLS version is below 1.2

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -5,10 +5,8 @@ package config
 
 import (
 	"bytes"
-	"crypto/tls"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -109,21 +107,6 @@ type TLSConfig struct {
 
 func (c TLSConfig) HasCert() bool {
 	return !(c.Cert == "" && c.Key == "")
-}
-
-func (c TLSConfig) MinTLSVer() uint16 {
-	switch {
-	case strings.HasSuffix(c.MinTLSVersion, "1.0"):
-		return tls.VersionTLS10
-	case strings.HasSuffix(c.MinTLSVersion, "1.1"):
-		return tls.VersionTLS11
-	case strings.HasSuffix(c.MinTLSVersion, "1.2"):
-		return tls.VersionTLS12
-	case strings.HasSuffix(c.MinTLSVersion, "1.3"):
-		return tls.VersionTLS13
-	default:
-		return tls.VersionTLS12
-	}
 }
 
 func (c TLSConfig) HasCA() bool {

--- a/lib/util/security/cert.go
+++ b/lib/util/security/cert.go
@@ -144,7 +144,7 @@ func (ci *CertInfo) buildServerConfig(lg *zap.Logger) (*tls.Config, error) {
 	}
 
 	tcfg := &tls.Config{
-		MinVersion:            cfg.MinTLSVer(),
+		MinVersion:            GetMinTLSVer(cfg.MinTLSVersion, lg),
 		GetCertificate:        ci.getCert,
 		GetClientCertificate:  ci.getClientCert,
 		VerifyPeerCertificate: ci.verifyPeerCertificate,
@@ -221,7 +221,7 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 			// still enable TLS without verify server certs
 			return &tls.Config{
 				InsecureSkipVerify: true,
-				MinVersion:         cfg.MinTLSVer(),
+				MinVersion:         GetMinTLSVer(cfg.MinTLSVersion, lg),
 			}, nil
 		}
 		lg.Info("no CA to verify server connections, disable TLS")
@@ -229,7 +229,7 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 	}
 
 	tcfg := &tls.Config{
-		MinVersion:            cfg.MinTLSVer(),
+		MinVersion:            GetMinTLSVer(cfg.MinTLSVersion, lg),
 		GetCertificate:        ci.getCert,
 		GetClientCertificate:  ci.getClientCert,
 		InsecureSkipVerify:    true,

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -250,9 +250,9 @@ func GetMinTLSVer(tlsVerStr string, logger *zap.Logger) uint16 {
 		minTLSVersion = tls.VersionTLS12
 	case strings.HasSuffix(tlsVerStr, "1.3"):
 		minTLSVersion = tls.VersionTLS13
+	case len(tlsVerStr) == 0:
 	default:
 		logger.Warn("Invalid TLS version, using default instead", zap.String("tls-version", tlsVerStr))
-		minTLSVersion = tls.VersionTLS12
 	}
 	if minTLSVersion < tls.VersionTLS12 {
 		logger.Warn("Minimum TLS version allows pre-TLSv1.2 protocols, this is not recommended")

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pingcap/TiProxy/lib/config"
@@ -235,4 +236,26 @@ func BuildClientTLSConfig(logger *zap.Logger, cfg config.TLSConfig) (*tls.Config
 	tcfg.Certificates = append(tcfg.Certificates, cert)
 
 	return tcfg, nil
+}
+
+// GetMinTLSVer parses the min tls version from config and reports warning if necessary.
+func GetMinTLSVer(tlsVerStr string, logger *zap.Logger) uint16 {
+	var minTLSVersion uint16 = tls.VersionTLS12
+	switch {
+	case strings.HasSuffix(tlsVerStr, "1.0"):
+		minTLSVersion = tls.VersionTLS10
+	case strings.HasSuffix(tlsVerStr, "1.1"):
+		minTLSVersion = tls.VersionTLS11
+	case strings.HasSuffix(tlsVerStr, "1.2"):
+		minTLSVersion = tls.VersionTLS12
+	case strings.HasSuffix(tlsVerStr, "1.3"):
+		minTLSVersion = tls.VersionTLS13
+	default:
+		logger.Warn("Invalid TLS version, using default instead", zap.String("tls-version", tlsVerStr))
+		minTLSVersion = tls.VersionTLS12
+	}
+	if minTLSVersion < tls.VersionTLS12 {
+		logger.Warn("Minimum TLS version allows pre-TLSv1.2 protocols, this is not recommended")
+	}
+	return minTLSVersion
 }

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -49,7 +49,6 @@ func TestGetMinTLSVer(t *testing.T) {
 		},
 		{
 			verInt: tls.VersionTLS12,
-			warn:   "Invalid TLS version",
 		},
 	}
 

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -4,8 +4,10 @@
 package security
 
 import (
+	"crypto/tls"
 	"testing"
 
+	"github.com/pingcap/TiProxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,5 +15,52 @@ func BenchmarkCreateTLS(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, _, _, err := createTempTLS(0, DefaultCertExpiration)
 		require.Nil(b, err)
+	}
+}
+
+func TestGetMinTLSVer(t *testing.T) {
+	tests := []struct {
+		verStr string
+		verInt uint16
+		warn   string
+	}{
+		{
+			verStr: "v1.0",
+			verInt: tls.VersionTLS10,
+			warn:   "not recommended",
+		},
+		{
+			verStr: "v1.1",
+			verInt: tls.VersionTLS11,
+			warn:   "not recommended",
+		},
+		{
+			verStr: "v1.2",
+			verInt: tls.VersionTLS12,
+		},
+		{
+			verStr: "v1.3",
+			verInt: tls.VersionTLS13,
+		},
+		{
+			verStr: "unknown",
+			verInt: tls.VersionTLS12,
+			warn:   "Invalid TLS version",
+		},
+		{
+			verInt: tls.VersionTLS12,
+			warn:   "Invalid TLS version",
+		},
+	}
+
+	for _, test := range tests {
+		lg, text := logger.CreateLoggerForTest(t)
+		res := GetMinTLSVer(test.verStr, lg)
+		require.Equal(t, test.verInt, res)
+		if len(test.warn) > 0 {
+			require.Contains(t, text.String(), test.warn)
+		} else {
+			require.Empty(t, text.String())
+		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #337

Problem Summary:
TiDB reports warnings when TLS version is below 1.2: https://github.com/pingcap/tidb/blob/master/util/misc.go#L499
But TiProxy doesn't: https://github.com/pingcap/TiProxy/blob/main/lib/config/proxy.go#L114

TiProxy can add the warning to keep consistency.

What is changed and how it works:
- Move parsing TLS version from `config` to `security` because it can import logger.
- Report warning if necessary.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
