### PR TITLE
server: print more info about build and runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,19 @@
 # limitations under the License.
 
 GOBIN := $(shell pwd)/bin
-VERSION ?= $(shell git rev-parse --abbrev-ref HEAD)
+VERSION ?= $(shell git describe --tags --dirty --always)
+BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT ?= $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty)
 DEBUG ?=
 DOCKERPREFIX ?=
 BUILD_TAGS ?=
 LDFLAGS ?=
-BUILDFLAGS ?= -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS) -X github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyVersion=$(VERSION) -X github.com/pingcap/TiProxy/pkg/util/versioninfo.TiProxyGitHash=$(COMMIT)' -tags '$(BUILD_TAGS)'
+LDFLAGS += -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyVersion=$(VERSION)"
+LDFLAGS += -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitBranch=$(BRANCH)"
+LDFLAGS += -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitHash=$(COMMIT)"
+LDFLAGS += -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyBuildTS=$(shell date -u '+%Y-%m-%d %H:%M:%S')"
+
+BUILDFLAGS ?= -gcflags '$(GCFLAGS)' -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)'
 ifneq ("$(DEBUG)", "")
 	BUILDFLAGS += -race
 endif

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -158,7 +158,7 @@ func printInfo(lg *zap.Logger) {
 		zap.String("Git Commit Hash", versioninfo.TiProxyGitHash),
 		zap.String("Git Branch", versioninfo.TiProxyGitBranch),
 		zap.String("UTC Build Time", versioninfo.TiProxyBuildTS),
-		zap.String("GoVersion", versioninfo.BuildVersion),
+		zap.String("GoVersion", runtime.Version()),
 		zap.String("OS", runtime.GOOS),
 		zap.String("Arch", runtime.GOARCH),
 	}

--- a/pkg/util/versioninfo/versioninfo.go
+++ b/pkg/util/versioninfo/versioninfo.go
@@ -3,11 +3,6 @@
 
 package versioninfo
 
-import (
-	_ "runtime" // import link package
-	_ "unsafe"  // required by go:linkname
-)
-
 // These variables will be overwritten by Makefile.
 var (
 	TiProxyVersion   = "None"
@@ -15,6 +10,3 @@ var (
 	TiProxyGitHash   = "None"
 	TiProxyBuildTS   = "None"
 )
-
-//go:linkname BuildVersion runtime.buildVersion
-var BuildVersion string

--- a/pkg/util/versioninfo/versioninfo.go
+++ b/pkg/util/versioninfo/versioninfo.go
@@ -3,8 +3,18 @@
 
 package versioninfo
 
+import (
+	_ "runtime" // import link package
+	_ "unsafe"  // required by go:linkname
+)
+
 // These variables will be overwritten by Makefile.
 var (
-	TiProxyGitHash = "None"
-	TiProxyVersion = "None"
+	TiProxyVersion   = "None"
+	TiProxyGitBranch = "None"
+	TiProxyGitHash   = "None"
+	TiProxyBuildTS   = "None"
 )
+
+//go:linkname BuildVersion runtime.buildVersion
+var BuildVersion string


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #286

Problem Summary:
Print more info about build and runtime so that we can reproduce the bugs locally with the same environment.

What is changed and how it works:
- Change `VERSION` from git branch to git tag, and add `BRANCH` to keep the same with TiDB.
- Add more fields such as build time, go version, os, and arch.
- Print `Welcome to TiProxy` so that we can search the restart event by log.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
zhangmingdeMacBook-Pro:tiproxy zhangming$ make
go build -gcflags '' -ldflags ' -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyVersion=v0.1.1-14-g6194ad1" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitBranch=print_info" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitHash=6194ad15119645595ce5ee56e09b3a78c3170610" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyBuildTS=2023-09-02 02:25:04"' -tags '' -o ./bin/tiproxy ./cmd/tiproxy
go build -gcflags '' -ldflags ' -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyVersion=v0.1.1-14-g6194ad1" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitBranch=print_info" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyGitHash=6194ad15119645595ce5ee56e09b3a78c3170610" -X "github.com/pingcap/tiproxy/pkg/util/versioninfo.TiProxyBuildTS=2023-09-02 02:25:15"' -tags '' -o ./bin/tiproxyctl ./cmd/tiproxyctl
zhangmingdeMacBook-Pro:tiproxy zhangming$ ./bin/tiproxy -v
./bin/tiproxy version v0.1.1-14-g6194ad1, commit 6194ad15119645595ce5ee56e09b3a78c3170610
zhangmingdeMacBook-Pro:tiproxy zhangming$ ./bin/tiproxy
[2023/09/02 10:25:27.000 +08:00] [INFO] [main] [server/server.go:165] [Welcome to TiProxy.]  ["Release Version"=v0.1.1-14-g6194ad1] ["Git Commit Hash"=6194ad15119645595ce5ee56e09b3a78c3170610] ["Git Branch"=print_info] ["UTC Build Time"="2023-09-02 02:25:04"] [GoVersion=go1.21.0] [OS=darwin] [Arch=amd64]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
