### PR TITLE
backend, net: Remind the user when TiDB sets wrong proxy-protocol

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -210,12 +210,17 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 
 	// forward other packets
 	pluginName := ""
+	pktIdx := 0
 loop:
 	for {
 		serverPkt, err := forwardMsg(backendIO, clientIO)
 		if err != nil {
+			if pktIdx == 0 && errors.Is(err, pnet.ErrInvalidSequence) {
+				return pnet.WrapUserError(err, checkPPV2ErrMsg)
+			}
 			return err
 		}
+		pktIdx++
 		switch serverPkt[0] {
 		case pnet.OKHeader.Byte():
 			return nil
@@ -334,7 +339,9 @@ func (auth *Authenticator) writeAuthHandshake(
 			tcfg.ServerName = host
 		}
 		if err := backendIO.ClientTLSHandshake(tcfg); err != nil {
-			return err
+			// tiproxy pp enabled, tidb pp disabled, tls enabled => tls handshake encounters unrecognized packet
+			// tiproxy pp disabled, tidb pp enabled, tls enabled => tls handshake encounters unrecognized packet
+			return pnet.WrapUserError(err, checkPPV2ErrMsg)
 		}
 	} else {
 		resp.Capability &= ^pnet.ClientSSL

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -215,6 +215,8 @@ loop:
 	for {
 		serverPkt, err := forwardMsg(backendIO, clientIO)
 		if err != nil {
+			// tiproxy pp enabled, tidb pp disabled, tls disabled => invalid sequence
+			// tiproxy pp disabled, tidb pp enabled, tls disabled => invalid sequence
 			if pktIdx == 0 && errors.Is(err, pnet.ErrInvalidSequence) {
 				return pnet.WrapUserError(err, checkPPV2ErrMsg)
 			}

--- a/pkg/proxy/backend/error.go
+++ b/pkg/proxy/backend/error.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	connectErrMsg         = "No available TiDB instances, please check TiDB cluster"
+	connectErrMsg         = "No available TiDB instances, please make sure TiDB is available"
 	parsePktErrMsg        = "TiProxy fails to parse the packet, please contact PingCAP"
-	handshakeErrMsg       = "TiProxy fails to connect to TiDB, please check network"
+	handshakeErrMsg       = "TiProxy fails to connect to TiDB, please make sure TiDB is available"
 	capabilityErrMsg      = "Verify TiDB capability failed, please upgrade TiDB"
-	requireProxyTLSErrMsg = "Require TLS config on TiProxy when require-backend-tls=true"
-	requireTiDBTLSErrMsg  = "Require TLS config on TiDB when require-backend-tls=true"
+	requireProxyTLSErrMsg = "Require TLS enabled on TiProxy when require-backend-tls=true"
+	requireTiDBTLSErrMsg  = "Require TLS enabled on TiDB when require-backend-tls=true"
+	checkPPV2ErrMsg       = "TiProxy fails to connect to TiDB, please make sure TiDB proxy-protocol is set correctly"
 )
 
 var (

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -32,7 +32,7 @@ func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *t
 	}
 	pkt := pnet.NewPacketIO(conn, logger, opts...)
 	return &ClientConnection{
-		logger:            logger.With(zap.Bool("proxy-protocol", bcConfig.ProxyProtocol)),
+		logger:            logger,
 		frontendTLSConfig: frontendTLSConfig,
 		backendTLSConfig:  backendTLSConfig,
 		pkt:               pkt,
@@ -58,7 +58,7 @@ clean:
 	switch src {
 	case backend.SrcClientQuit, backend.SrcClientErr, backend.SrcProxyQuit:
 	default:
-		cc.logger.Info(msg, zap.String("backend_addr", cc.connMgr.ServerAddr()), zap.Stringer("quit source", src), zap.Error(err))
+		cc.logger.Warn(msg, zap.String("backend_addr", cc.connMgr.ServerAddr()), zap.Stringer("quit source", src), zap.Error(err))
 	}
 }
 

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	errInvalidSequence = dbterror.ClassServer.NewStd(errno.ErrInvalidSequence)
+	ErrInvalidSequence = dbterror.ClassServer.NewStd(errno.ErrInvalidSequence)
 )
 
 const (
@@ -169,7 +169,7 @@ func (p *PacketIO) readOnePacket() ([]byte, bool, error) {
 
 	sequence := header[3]
 	if sequence != p.sequence {
-		return nil, false, errInvalidSequence.GenWithStack("invalid sequence %d != %d", sequence, p.sequence)
+		return nil, false, ErrInvalidSequence.GenWithStack("invalid sequence %d != %d", sequence, p.sequence)
 	}
 	p.sequence++
 	length := int(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -145,7 +145,8 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn) {
 
 	connID := s.mu.connID
 	s.mu.connID++
-	logger := s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()))
+	logger := s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()),
+		zap.Bool("proxy-protocol", s.mu.proxyProtocol))
 	clientConn := client.NewClientConnection(logger.Named("conn"), conn, s.certMgr.ServerTLS(), s.certMgr.SQLTLS(),
 		s.hsHandler, connID, &backend.BCConfig{
 			ProxyProtocol:      s.mu.proxyProtocol,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #360 

Problem Summary:
Users are very likely to misconfigure proxy-protocol. And they do, they are hard to find the reason according to the error message.

What is changed and how it works:
- Remind the user when TiDB and TiProxy proxy-protocol mismatch.
- Move zap field `proxy-protocol` to the place where the connection is created.
- Refine other error messages.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

- Enable TiProxy PPV2, disable TiDB PPV2, enable TLS
- Enable TiProxy PPV2, disable TiDB PPV2, disable TLS
- Disable TiProxy PPV2, enable TiDB PPV2, enable TLS
- Disable TiProxy PPV2, enable TiDB PPV2, disable TLS

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
