### PR TITLE
backend, net: support connection attrs in COM_CHANGE_USER

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -371,10 +371,10 @@ func (auth *Authenticator) handleSecondAuthResult(backendIO *pnet.PacketIO) erro
 }
 
 // changeUser is called once the client sends COM_CHANGE_USER.
-func (auth *Authenticator) changeUser(username, db string) {
-	auth.user = username
-	auth.dbname = db
-	// TODO: attrs
+func (auth *Authenticator) changeUser(req *pnet.ChangeUserReq) {
+	auth.user = req.User
+	auth.dbname = req.DB
+	auth.attrs = req.Attrs
 }
 
 // updateCurrentDB is called once the client sends COM_INIT_DB or `use db`.

--- a/pkg/proxy/backend/cmd_processor.go
+++ b/pkg/proxy/backend/cmd_processor.go
@@ -9,6 +9,7 @@ import (
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tidb/parser/mysql"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"go.uber.org/zap"
 )
 
 const (
@@ -25,12 +26,14 @@ type CmdProcessor struct {
 	capability         pnet.Capability
 	// Only includes in_trans or quit status.
 	serverStatus uint32
+	logger       *zap.Logger
 }
 
-func NewCmdProcessor() *CmdProcessor {
+func NewCmdProcessor(logger *zap.Logger) *CmdProcessor {
 	return &CmdProcessor{
 		serverStatus:       0,
 		preparedStmtStatus: make(map[int]uint32),
+		logger:             logger,
 	}
 }
 

--- a/pkg/proxy/backend/mock_client_test.go
+++ b/pkg/proxy/backend/mock_client_test.go
@@ -166,7 +166,15 @@ func (mc *mockClient) request(packetIO *pnet.PacketIO) error {
 }
 
 func (mc *mockClient) requestChangeUser(packetIO *pnet.PacketIO) error {
-	data := pnet.MakeChangeUser(mc.username, mc.dbName, mysql.AuthNativePassword, mc.authData)
+	req := &pnet.ChangeUserReq{
+		User:       mc.username,
+		DB:         mc.dbName,
+		AuthPlugin: mysql.AuthNativePassword,
+		AuthData:   mc.authData,
+		Charset:    []byte{0x11, 0x22},
+		Attrs:      mc.attrs,
+	}
+	data := pnet.MakeChangeUser(req, mc.capability)
 	if err := packetIO.WritePacket(data, true); err != nil {
 		return err
 	}

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -148,7 +148,11 @@ func (ts *testSuite) changeDB(db string) {
 func (ts *testSuite) changeUser(username, db string) {
 	ts.mc.username = username
 	ts.mc.dbName = db
-	ts.mp.authenticator.changeUser(username, db)
+	req := &pnet.ChangeUserReq{
+		User: username,
+		DB:   db,
+	}
+	ts.mp.authenticator.changeUser(req)
 }
 
 func (ts *testSuite) runAndCheck(t *testing.T, c checker, clientRunner, backendRunner func(*pnet.PacketIO) error,

--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -24,3 +24,25 @@ func TestHandshakeResp(t *testing.T) {
 	require.Equal(t, resp1, resp2)
 	require.NoError(t, err)
 }
+
+func TestChangeUserReq(t *testing.T) {
+	req1 := &ChangeUserReq{
+		Attrs:      map[string]string{"key": "value"},
+		User:       "user",
+		DB:         "db",
+		AuthPlugin: "plugin",
+		AuthData:   []byte("1234567890"),
+		Charset:    []byte{0x11, 0x22},
+	}
+	capability := ClientConnectAttrs | ClientSecureConnection | ClientPluginAuth
+	b := MakeChangeUser(req1, capability)
+	req2, err := ParseChangeUser(b, capability)
+	require.NoError(t, err)
+	require.Equal(t, req1, req2)
+
+	capability = 0
+	req1.Attrs = nil
+	b = MakeChangeUser(req1, capability)
+	req2, err = ParseChangeUser(b, capability)
+	require.NoError(t, err)
+}

--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -43,6 +43,6 @@ func TestChangeUserReq(t *testing.T) {
 	capability = 0
 	req1.Attrs = nil
 	b = MakeChangeUser(req1, capability)
-	req2, err = ParseChangeUser(b, capability)
+	_, err = ParseChangeUser(b, capability)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #355 

Problem Summary:
- Connection attributes in COM_CHANGE_USER are not saved, so the connection attrs may be wrong after session migration.

What is changed and how it works:
- Parse connection attrs in COM_CHANGE_USER, passes it to TiDB (previously not), and sends it to TiDB in the second handshake.
- After COM_CHANGE_USER, migrate the session if needed. Previously it didn't check the redirection signal after COM_CHANGE_USER.
- Add comments for why we need another switch-auth request for COM_CHANGE_USER. The reason is here: https://github.com/pingcap/tiproxy/issues/127#issuecomment-1715308573

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Integration test: testBug19354014 in JDBC test.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
