### PR TITLE
net: fix packet sequence when sequence overflows

### DIFF
--- a/pkg/proxy/net/compress_test.go
+++ b/pkg/proxy/net/compress_test.go
@@ -235,6 +235,7 @@ func TestReadWriteError(t *testing.T) {
 }
 
 func fillAndWrite(t *testing.T, crw *compressedReadWriter, b byte, length int) {
+	crw.BeginRW(rwWrite)
 	data := fillData(b, length)
 	_, err := crw.Write(data)
 	require.NoError(t, err)
@@ -250,6 +251,7 @@ func fillData(b byte, length int) []byte {
 }
 
 func readAndCheck(t *testing.T, crw *compressedReadWriter, b byte, length int) {
+	crw.BeginRW(rwRead)
 	data := make([]byte, length)
 	_, err := io.ReadFull(crw, data)
 	require.NoError(t, err)

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -380,9 +380,14 @@ func TestPacketSequence(t *testing.T) {
 			// uncompressed sequence = compressed sequence
 			write(cli, false)
 			write(cli, true)
-			// sequence wraps around
+			// uncompressed sequence wraps around (1000 writes + 1 flush)
 			for i := 0; i < loops; i++ {
-				read(cli)
+				write(cli, false)
+			}
+			require.NoError(t, cli.Flush())
+			// compressed sequence wraps around (1000 writes + 1000 flushes)
+			for i := 0; i < loops; i++ {
+				write(cli, true)
 			}
 			// reset sequence
 			cli.ResetSequence()
@@ -394,11 +399,14 @@ func TestPacketSequence(t *testing.T) {
 			// uncompressed sequence = compressed sequence
 			read(srv)
 			read(srv)
-			// sequence wraps around
+			// uncompressed sequence wraps around
 			for i := 0; i < loops; i++ {
-				write(srv, false)
+				read(srv)
 			}
-			require.NoError(t, srv.Flush())
+			// compressed sequence wraps around
+			for i := 0; i < loops; i++ {
+				read(srv)
+			}
 			// reset sequence
 			srv.ResetSequence()
 			read(srv)

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -362,3 +362,47 @@ func TestProxyTLSCompress(t *testing.T) {
 		}
 	}
 }
+
+// Test the sequence is correct with the compression protocol.
+func TestPacketSequence(t *testing.T) {
+	write := func(p *PacketIO, flush bool) {
+		require.NoError(t, p.WritePacket([]byte{0}, flush))
+	}
+	read := func(p *PacketIO) {
+		_, err := p.ReadPacket()
+		require.NoError(t, err)
+	}
+	loops := 1024
+	testTCPConn(t,
+		func(t *testing.T, cli *PacketIO) {
+			require.NoError(t, cli.SetCompressionAlgorithm(CompressionZlib, 0))
+			read(cli)
+			// uncompressed sequence = compressed sequence
+			write(cli, false)
+			write(cli, true)
+			// sequence wraps around
+			for i := 0; i < loops; i++ {
+				read(cli)
+			}
+			// reset sequence
+			cli.ResetSequence()
+			write(cli, true)
+		},
+		func(t *testing.T, srv *PacketIO) {
+			require.NoError(t, srv.SetCompressionAlgorithm(CompressionZlib, 0))
+			write(srv, true)
+			// uncompressed sequence = compressed sequence
+			read(srv)
+			read(srv)
+			// sequence wraps around
+			for i := 0; i < loops; i++ {
+				write(srv, false)
+			}
+			require.NoError(t, srv.Flush())
+			// reset sequence
+			srv.ResetSequence()
+			read(srv)
+		},
+		1,
+	)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #377

Problem Summary:
- The uncompressed sequence is incorrectly set before writing: it should be set before writing the uncompressed packet, rather than writing the compressed packet.
- The compressed sequence is set to 0 when the uncompressed sequence overflows. `SetSequence()` mistakenly set both the compressed and uncompressed sequences to 0.

What is changed and how it works:
- Move `BeginRW` from `compressedReadWriter` to `PacketIO` so that the uncompressed sequence can be set before writing the uncompressed packet.
- Add a `ResetSequence()` and only set the compressed sequence to 0 when a new command begins.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Tested with jdbc-test:
- `ConnectionRegressionTest#testBug11237`
- `ConnectionTest#testCompression`
- `ConnectionTest#testUseCompress`

Test with sysbench (`--range_size=1000`):
```
sysbench --table_size=10000 --mysql-user=root --threads=1 --time=60 --report-interval=10 --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=test --mysql-compression=on oltp_read_only --point_selects=0 --sum_ranges=0 --order_ranges=0 --distinct_ranges=0 --simple_ranges=1 --range_size=1000 run
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
