### PR TITLE
[WIP] handle prefix mismatch 

### DIFF
--- a/pkg/proxy/backend/cmd_processor.go
+++ b/pkg/proxy/backend/cmd_processor.go
@@ -17,6 +17,11 @@ const (
 	StatusQuit
 	StatusPrepareWaitExecute
 	StatusPrepareWaitFetch
+
+	// errUserPrefixMismatch is a special error that indicates the request is
+	// directed to unexpected tidb-server and has been rejected by tidb.
+	// Therefore, it should be treated as a proxy error instead of a MySQL error.
+	errUserPrefixMismatch = uint16(20003)
 )
 
 // CmdProcessor maintains the transaction and prepared statement status and decides whether the session can be redirected.
@@ -122,6 +127,6 @@ func IsMySQLError(err error) bool {
 	if err == nil {
 		return false
 	}
-	_, ok := err.(*gomysql.MyError)
-	return ok
+	myError, ok := err.(*gomysql.MyError)
+	return ok && myError.Code != errUserPrefixMismatch
 }


### PR DESCRIPTION
### What problem does this PR solve?

Sometimes, due to router cache out of date, an authentication request will be directed to a unexpected tidb that belongs to another keyspace and rejected. A special error code (20003) is added in this case to differentiate this from regular authentication error. 

This error should then be treated not as MySQL error but as proxy error