### PR TITLE
net, config: optimize read and write packets

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -25,6 +25,12 @@
 #		100 => accept as many as 100 connections.
 # max-connections = 0
 
+# It's a tradeoff between memory and performance.
+# possible values:
+#       0 => default value
+#		1K to 16M
+# conn-buffer-size = 0
+
 [api]
 # addr = "0.0.0.0:3080"
 

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	ErrUnsupportedProxyProtocolVersion = errors.New("unsupported proxy protocol version")
+	ErrInvalidConfigValue              = errors.New("invalid config value")
 )
 
 type Config struct {
@@ -46,6 +47,7 @@ type KeepAlive struct {
 
 type ProxyServerOnline struct {
 	MaxConnections    uint64    `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
+	ConnBufferSize    int       `yaml:"conn-buffer-size,omitempty" toml:"conn-buffer-size,omitempty" json:"conn-buffer-size,omitempty"`
 	FrontendKeepalive KeepAlive `yaml:"frontend-keepalive" toml:"frontend-keepalive" json:"frontend-keepalive"`
 	// BackendHealthyKeepalive applies when the observer treats the backend as healthy.
 	// The config values should be conservative to save CPU and tolerate network fluctuation.
@@ -182,6 +184,9 @@ func (cfg *Config) Check() error {
 		return errors.Wrapf(ErrUnsupportedProxyProtocolVersion, "%s", cfg.Proxy.ProxyProtocol)
 	}
 
+	if cfg.Proxy.ConnBufferSize > 0 && (cfg.Proxy.ConnBufferSize > 16*1024*1024 || cfg.Proxy.ConnBufferSize < 1024) {
+		return errors.Wrapf(ErrInvalidConfigValue, "conn-buffer-size must be between 1K and 16M")
+	}
 	return nil
 }
 

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -26,6 +26,7 @@ var testProxyConfig = Config{
 			FrontendKeepalive:          KeepAlive{Enabled: true},
 			ProxyProtocol:              "v2",
 			GracefulWaitBeforeShutdown: 10,
+			ConnBufferSize:             32 * 1024,
 		},
 	},
 	API: API{
@@ -112,6 +113,12 @@ func TestProxyCheck(t *testing.T) {
 				c.Proxy.ProxyProtocol = "v1"
 			},
 			err: ErrUnsupportedProxyProtocolVersion,
+		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.ConnBufferSize = 100 * 1024 * 1024
+			},
+			err: ErrInvalidConfigValue,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -125,7 +125,7 @@ func (ts *backendMgrTester) firstHandshake4Proxy(clientIO, backendIO *pnet.Packe
 func (ts *backendMgrTester) handshake4Backend(packetIO *pnet.PacketIO) error {
 	conn, err := ts.tc.backendListener.Accept()
 	require.NoError(ts.t, err)
-	ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg)
+	ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg, pnet.DefaultConnBufferSize)
 	return ts.mb.authenticate(ts.tc.backendIO)
 }
 
@@ -404,7 +404,7 @@ func TestConnectFail(t *testing.T) {
 			backend: func(_ *pnet.PacketIO) error {
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(ts.t, err)
-				ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg)
+				ts.tc.backendIO = pnet.NewPacketIO(conn, ts.lg, pnet.DefaultConnBufferSize)
 				ts.mb.authSucceed = false
 				return ts.mb.authenticate(ts.tc.backendIO)
 			},
@@ -448,7 +448,7 @@ func TestRedirectFail(t *testing.T) {
 				require.NoError(t, err)
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(t, err)
-				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg)
+				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg, pnet.DefaultConnBufferSize)
 				// auth fails
 				ts.mb.authSucceed = false
 				err = ts.mb.authenticate(tmpBackendIO)
@@ -469,7 +469,7 @@ func TestRedirectFail(t *testing.T) {
 				require.NoError(ts.t, err)
 				conn, err := ts.tc.backendListener.Accept()
 				require.NoError(ts.t, err)
-				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg)
+				tmpBackendIO := pnet.NewPacketIO(conn, ts.lg, pnet.DefaultConnBufferSize)
 				ts.mb.authSucceed = true
 				err = ts.mb.authenticate(tmpBackendIO)
 				require.NoError(t, err)

--- a/pkg/proxy/backend/common_test.go
+++ b/pkg/proxy/backend/common_test.go
@@ -52,23 +52,23 @@ func (tc *tcpConnSuite) newConn(t *testing.T, enableRoute bool) func() {
 		wg.Run(func() {
 			conn, err := tc.backendListener.Accept()
 			require.NoError(t, err)
-			tc.backendIO = pnet.NewPacketIO(conn, lg)
+			tc.backendIO = pnet.NewPacketIO(conn, lg, pnet.DefaultConnBufferSize)
 		})
 	}
 	wg.Run(func() {
 		if !enableRoute {
 			backendConn, err := net.Dial("tcp", tc.backendListener.Addr().String())
 			require.NoError(t, err)
-			tc.proxyBIO = pnet.NewPacketIO(backendConn, lg)
+			tc.proxyBIO = pnet.NewPacketIO(backendConn, lg, pnet.DefaultConnBufferSize)
 		}
 		clientConn, err := tc.proxyListener.Accept()
 		require.NoError(t, err)
-		tc.proxyCIO = pnet.NewPacketIO(clientConn, lg)
+		tc.proxyCIO = pnet.NewPacketIO(clientConn, lg, pnet.DefaultConnBufferSize)
 	})
 	wg.Run(func() {
 		conn, err := net.Dial("tcp", tc.proxyListener.Addr().String())
 		require.NoError(t, err)
-		tc.clientIO = pnet.NewPacketIO(conn, lg)
+		tc.clientIO = pnet.NewPacketIO(conn, lg, pnet.DefaultConnBufferSize)
 	})
 	wg.Wait()
 	return func() {
@@ -91,13 +91,13 @@ func (tc *tcpConnSuite) reconnectBackend(t *testing.T) {
 		_ = tc.backendIO.Close()
 		conn, err := tc.backendListener.Accept()
 		require.NoError(t, err)
-		tc.backendIO = pnet.NewPacketIO(conn, lg)
+		tc.backendIO = pnet.NewPacketIO(conn, lg, pnet.DefaultConnBufferSize)
 	})
 	wg.Run(func() {
 		_ = tc.proxyBIO.Close()
 		backendConn, err := net.Dial("tcp", tc.backendListener.Addr().String())
 		require.NoError(t, err)
-		tc.proxyBIO = pnet.NewPacketIO(backendConn, lg)
+		tc.proxyBIO = pnet.NewPacketIO(backendConn, lg, pnet.DefaultConnBufferSize)
 	})
 	wg.Wait()
 }

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -30,7 +30,7 @@ func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *t
 	if bcConfig.ProxyProtocol {
 		opts = append(opts, pnet.WithProxy)
 	}
-	pkt := pnet.NewPacketIO(conn, logger, opts...)
+	pkt := pnet.NewPacketIO(conn, logger, bcConfig.ConnBufferSize, opts...)
 	return &ClientConnection{
 		logger:            logger,
 		frontendTLSConfig: frontendTLSConfig,

--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -41,14 +41,14 @@ func TestProxyReadWrite(t *testing.T) {
 	message := []byte("hello world")
 	testkit.TestTCPConn(t,
 		func(t *testing.T, c net.Conn) {
-			prw := newProxyClient(newBasicReadWriter(c), p)
+			prw := newProxyClient(newBasicReadWriter(c, DefaultConnBufferSize), p)
 			n, err := prw.Write(message)
 			require.NoError(t, err)
 			require.Equal(t, len(message), n)
 			require.NoError(t, prw.Flush())
 		},
 		func(t *testing.T, c net.Conn) {
-			prw := newProxyServer(newBasicReadWriter(c))
+			prw := newProxyServer(newBasicReadWriter(c, DefaultConnBufferSize))
 			data := make([]byte, len(message))
 			n, err := prw.Read(data)
 			require.NoError(t, err)

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -59,7 +59,7 @@ type tlsReadWriter struct {
 func newTLSReadWriter(rw packetReadWriter, tlsConn *tls.Conn) *tlsReadWriter {
 	// Can not modify rw and reuse it because tlsConn is using rw internally.
 	// We must create another buffer.
-	buf := bufio.NewReadWriter(bufio.NewReaderSize(tlsConn, defaultReaderSize), bufio.NewWriterSize(tlsConn, defaultWriterSize))
+	buf := bufio.NewReadWriter(bufio.NewReaderSize(tlsConn, DefaultConnBufferSize), bufio.NewWriterSize(tlsConn, DefaultConnBufferSize))
 	return &tlsReadWriter{
 		packetReadWriter: rw,
 		buf:              buf,

--- a/pkg/proxy/net/tls_test.go
+++ b/pkg/proxy/net/tls_test.go
@@ -21,7 +21,7 @@ func TestTLSReadWrite(t *testing.T) {
 	ch := make(chan []byte)
 	testkit.TestTCPConn(t,
 		func(t *testing.T, c net.Conn) {
-			brw := newBasicReadWriter(c)
+			brw := newBasicReadWriter(c, DefaultConnBufferSize)
 			conn := &tlsInternalConn{brw}
 			tlsConn := tls.Client(conn, ctls)
 			require.NoError(t, tlsConn.Handshake())
@@ -45,7 +45,7 @@ func TestTLSReadWrite(t *testing.T) {
 			}
 		},
 		func(t *testing.T, c net.Conn) {
-			brw := newBasicReadWriter(c)
+			brw := newBasicReadWriter(c, DefaultConnBufferSize)
 			conn := &tlsInternalConn{brw}
 			tlsConn := tls.Server(conn, stls)
 			require.NoError(t, tlsConn.Handshake())

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -29,6 +29,7 @@ type serverState struct {
 	clients            map[uint64]*client.ClientConnection
 	connID             uint64
 	maxConnections     uint64
+	connBufferSize     int
 	tcpKeepAlive       bool
 	proxyProtocol      bool
 	gracefulWait       int
@@ -80,6 +81,7 @@ func (s *SQLServer) reset(cfg *config.ProxyServerOnline) {
 	s.mu.gracefulWait = cfg.GracefulWaitBeforeShutdown
 	s.mu.healthyKeepAlive = cfg.BackendHealthyKeepalive
 	s.mu.unhealthyKeepAlive = cfg.BackendUnhealthyKeepalive
+	s.mu.connBufferSize = cfg.ConnBufferSize
 	s.mu.Unlock()
 }
 
@@ -154,6 +156,7 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn) {
 			RequireBackendTLS:  s.requireBackendTLS,
 			HealthyKeepAlive:   s.mu.healthyKeepAlive,
 			UnhealthyKeepAlive: s.mu.unhealthyKeepAlive,
+			ConnBufferSize:     s.mu.connBufferSize,
 		})
 	s.mu.clients[connID] = clientConn
 	s.mu.Unlock()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #381 

Problem Summary:
`WritePacket` and `ReadPacket` become the hot path when there are many rows returned, so this code should be optimized:
- `WriteOnePacket` calls 2 `NewReader` and that allocates memory twice.
- `ReadPacket` grows slice in `data = append(data, buf)`, which is unncessary.
- `var header [4]byte` escapes to the heap because `header` is passed as a parameter to other functions.
- The read/write buffer size is 16K, which means for 1000 rows, it calls syscall `read`/`write` 8 times.
- `io.ReadFull` contains unnecessary boundary checks, function calls, and interface conversion.

What is changed and how it works:
Optimization:
- Replace `io.Copy` with `readWriter.Write` to remove `NewReader`.
- Do not call `data = append(data, buf)` for the first packet.
- Move `header` into `PacketIO`/`compressedReadWriter` as a member.
- Make `conn-buffer-size` configurable and set to 32K by default.
- Replace `io.ReadFull` with customized `ReadFull`.

Others:
- Add `DirectWrite` to `compressedReadWriter` because it was missed, but it doesn't matter actually.
- Also add benchmarks of compression.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


Sysbench result:
Before this PR:
| Range size | QPS   | TiProxy CPU | QPS per 100% CPU |
|------------|-------|-------------|------------------|
| 10         | 30955 | 180%        | 17200            |
| 100        | 14655 | 190%        | 7710             |
| 1000       | 2112  | 200%        | 1060             |
| 10000      | 221   | 200%        | 110              |

After this PR:
| Range size | QPS   | TiProxy CPU | QPS per 100% CPU |
|------------|-------|-------------|------------------|
| 10         | 32818 | 150%        | 21878            |
| 100        | 22392 | 190%        | 11785            |
| 1000       | 4093  | 200%        | 2046             |
| 10000      | 449   | 200%        | 224              |

The flame graph when range size is 1000:

![image](https://github.com/pingcap/tiproxy/assets/29590578/a4f87e2f-7704-4f3b-9766-08490bd8953a)


Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
