### PR TITLE
manager: get unicast ip only when the config one is not

### DIFF
--- a/lib/util/sys/sys.go
+++ b/lib/util/sys/sys.go
@@ -5,7 +5,7 @@ package sys
 
 import "net"
 
-func GetLocalIP() string {
+func GetGlobalUnicastIP() string {
 	addrs, err := net.InterfaceAddrs()
 	if err == nil {
 		for _, address := range addrs {

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -168,9 +168,9 @@ func (is *InfoSyncer) getTopologyInfo(cfg *config.Config) (*TopologyInfo, error)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	// reporting a non unicast IP makes no sense
-	// try to find one
-	if !net.ParseIP(ip).IsGlobalUnicast() {
+	// reporting a non unicast IP makes no sense, try to find one
+	// loopback/linklocal-unicast are not global unicast IP, but are valid local unicast IP
+	if pip := net.ParseIP(ip); !pip.IsGlobalUnicast() && !pip.IsLoopback() && !pip.IsLinkLocalUnicast() {
 		if v := sys.GetGlobalUnicastIP(); v != "" {
 			ip = v
 		}

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -170,7 +170,7 @@ func (is *InfoSyncer) getTopologyInfo(cfg *config.Config) (*TopologyInfo, error)
 	}
 	// reporting a non unicast IP makes no sense, try to find one
 	// loopback/linklocal-unicast are not global unicast IP, but are valid local unicast IP
-	if pip := net.ParseIP(ip); pip.Equal(net.IPv4bcast) || pip.IsUnspecified() || pip.IsMulticast() {
+	if pip := net.ParseIP(ip); ip == "" || pip.Equal(net.IPv4bcast) || pip.IsUnspecified() || pip.IsMulticast() {
 		if v := sys.GetGlobalUnicastIP(); v != "" {
 			ip = v
 		}

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -160,14 +160,20 @@ func (is *InfoSyncer) getTopologyInfo(cfg *config.Config) (*TopologyInfo, error)
 		s = ""
 	}
 	dir := path.Dir(s)
-	ip := sys.GetLocalIP()
-	_, port, err := net.SplitHostPort(cfg.Proxy.Addr)
+	ip, port, err := net.SplitHostPort(cfg.Proxy.Addr)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	_, statusPort, err := net.SplitHostPort(cfg.API.Addr)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	// reporting a non unicast IP makes no sense
+	// try to find one
+	if !net.ParseIP(ip).IsGlobalUnicast() {
+		if v := sys.GetGlobalUnicastIP(); v != "" {
+			ip = v
+		}
 	}
 	return &TopologyInfo{
 		Version:        versioninfo.TiProxyVersion,

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -170,7 +170,7 @@ func (is *InfoSyncer) getTopologyInfo(cfg *config.Config) (*TopologyInfo, error)
 	}
 	// reporting a non unicast IP makes no sense, try to find one
 	// loopback/linklocal-unicast are not global unicast IP, but are valid local unicast IP
-	if pip := net.ParseIP(ip); !pip.IsGlobalUnicast() && !pip.IsLoopback() && !pip.IsLinkLocalUnicast() {
+	if pip := net.ParseIP(ip); pip.Equal(net.IPv4bcast) || pip.IsUnspecified() || pip.IsMulticast() {
 		if v := sys.GetGlobalUnicastIP(); v != "" {
 			ip = v
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #383

Problem Summary: when tiproxy listens on `127.0.0.1:2379`, it also tries to report another unicast IP, e.g. `192.168.4.43`. This does not make sense.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
