### PR TITLE
auth: reconnect backend

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -226,18 +226,21 @@ loop:
 			}
 			return err
 		}
+		var packetErr error
 		if serverPkt[0] == pnet.ErrHeader.Byte() {
-			err = pnet.ParseErrorPacket(serverPkt)
-			if handshakeHandler.HandleHandshakeErr(cctx, err.(*gomysql.MyError)) {
+			packetErr = pnet.ParseErrorPacket(serverPkt)
+			if handshakeHandler.HandleHandshakeErr(cctx, packetErr.(*gomysql.MyError)) {
 				logger.Warn("handle handshake error, start reconnect", zap.Error(err))
 				backendIO.Close()
 				goto RECONNECT
 			}
-			return err
 		}
 		err = clientIO.WritePacket(serverPkt, true)
 		if err != nil {
 			return err
+		}
+		if packetErr != nil {
+			return packetErr
 		}
 
 		pktIdx++

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
+	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
@@ -159,6 +160,8 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	auth.attrs = clientResp.Attrs
 	auth.zstdLevel = clientResp.ZstdLevel
 
+RECONNECT:
+
 	// In case of testing, backendIO is passed manually that we don't want to bother with the routing logic.
 	backendIO, err := getBackendIO(cctx, auth, clientResp, 15*time.Second)
 	if err != nil {
@@ -214,7 +217,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 	pktIdx := 0
 loop:
 	for {
-		serverPkt, err := forwardMsg(backendIO, clientIO)
+		serverPkt, err := backendIO.ReadPacket()
 		if err != nil {
 			// tiproxy pp enabled, tidb pp disabled, tls disabled => invalid sequence
 			// tiproxy pp disabled, tidb pp enabled, tls disabled => invalid sequence
@@ -223,6 +226,20 @@ loop:
 			}
 			return err
 		}
+		if serverPkt[0] == pnet.ErrHeader.Byte() {
+			err = pnet.ParseErrorPacket(serverPkt)
+			if handshakeHandler.HandleHandshakeErr(cctx, err.(*gomysql.MyError)) {
+				logger.Warn("handle handshake error, start reconnect", zap.Error(err))
+				backendIO.Close()
+				goto RECONNECT
+			}
+			return err
+		}
+		err = clientIO.WritePacket(serverPkt, true)
+		if err != nil {
+			return err
+		}
+
 		pktIdx++
 		switch serverPkt[0] {
 		case pnet.OKHeader.Byte():
@@ -233,8 +250,6 @@ loop:
 				return err
 			}
 			return nil
-		case pnet.ErrHeader.Byte():
-			return pnet.ParseErrorPacket(serverPkt)
 		default: // mysql.AuthSwitchRequest, ShaCommand
 			if serverPkt[0] == pnet.AuthSwitchHeader.Byte() {
 				pluginName = string(serverPkt[1 : bytes.IndexByte(serverPkt[1:], 0)+1])


### PR DESCRIPTION
### What problem does this PR solve?
In our severless use case, sometimes tiproxy may connect to the wrong tidb (other user's instance). In this case, we hope that tiproxy can automatically reconnect for certain specific error types, instead of returning the errors to the client.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
