### PR TITLE
backend, net: optimize read/write connection by forwarding packets

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -312,7 +312,7 @@ func (auth *Authenticator) readInitialHandshake(backendIO *pnet.PacketIO) (serve
 	if serverPkt, err = backendIO.ReadPacket(); err != nil {
 		return
 	}
-	if pnet.IsErrorPacket(serverPkt) {
+	if pnet.IsErrorPacket(serverPkt[0]) {
 		err = pnet.ParseErrorPacket(serverPkt)
 		return
 	}

--- a/pkg/proxy/backend/cmd_processor_query.go
+++ b/pkg/proxy/backend/cmd_processor_query.go
@@ -73,7 +73,7 @@ func (cp *CmdProcessor) readResultColumns(packetIO *pnet.PacketIO, result *gomys
 				if data, err = packetIO.ReadPacket(); err != nil {
 					return err
 				}
-				if !pnet.IsEOFPacket(data) {
+				if !pnet.IsEOFPacket(data[0], len(data)) {
 					return errors.WithStack(mysql.ErrMalformPacket)
 				}
 				result.Status = binary.LittleEndian.Uint16(data[3:])
@@ -103,19 +103,19 @@ func (cp *CmdProcessor) readResultRows(packetIO *pnet.PacketIO, result *gomysql.
 			return err
 		}
 		if cp.capability&pnet.ClientDeprecateEOF == 0 {
-			if pnet.IsEOFPacket(data) {
+			if pnet.IsEOFPacket(data[0], len(data)) {
 				result.Status = binary.LittleEndian.Uint16(data[3:])
 				break
 			}
 		} else {
-			if pnet.IsResultSetOKPacket(data) {
+			if pnet.IsResultSetOKPacket(data[0], len(data)) {
 				rs := pnet.ParseOKPacket(data)
 				result.Status = rs.Status
 				break
 			}
 		}
 		// An error may occur when the backend writes rows.
-		if pnet.IsErrorPacket(data) {
+		if pnet.IsErrorPacket(data[0]) {
 			return cp.handleErrorPacket(data)
 		}
 		result.RowDatas = append(result.RowDatas, data)

--- a/pkg/proxy/backend/mock_client_test.go
+++ b/pkg/proxy/backend/mock_client_test.go
@@ -279,11 +279,11 @@ func (mc *mockClient) readUntilResultEnd(packetIO *pnet.PacketIO) (pkt []byte, e
 			return
 		}
 		if mc.capability&pnet.ClientDeprecateEOF == 0 {
-			if pnet.IsEOFPacket(pkt) {
+			if pnet.IsEOFPacket(pkt[0], len(pkt)) {
 				break
 			}
 		} else {
-			if pnet.IsResultSetOKPacket(pkt) {
+			if pnet.IsResultSetOKPacket(pkt[0], len(pkt)) {
 				break
 			}
 		}

--- a/pkg/proxy/net/compress.go
+++ b/pkg/proxy/net/compress.go
@@ -227,9 +227,7 @@ func (crw *compressedReadWriter) Peek(n int) (data []byte, err error) {
 			return
 		}
 	}
-	data = make([]byte, 0, n)
-	copy(data, crw.readBuffer.Bytes())
-	return
+	return crw.readBuffer.Bytes()[:n], nil
 }
 
 // Discard won't be used.

--- a/pkg/proxy/net/error.go
+++ b/pkg/proxy/net/error.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	ErrExpectSSLRequest = errors.New("expect a SSLRequest packet")
-	ErrReadConn         = errors.New("failed to read the connection")
-	ErrWriteConn        = errors.New("failed to write the connection")
-	ErrFlushConn        = errors.New("failed to flush the connection")
-	ErrCloseConn        = errors.New("failed to close the connection")
-	ErrHandshakeTLS     = errors.New("failed to complete tls handshake")
+	ErrReadConn     = errors.New("failed to read the connection")
+	ErrWriteConn    = errors.New("failed to write the connection")
+	ErrRelayConn    = errors.New("failed to relay the connection")
+	ErrFlushConn    = errors.New("failed to flush the connection")
+	ErrCloseConn    = errors.New("failed to close the connection")
+	ErrHandshakeTLS = errors.New("failed to complete tls handshake")
 )
 
 // UserError is returned to the client.

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -412,24 +412,24 @@ func ParseErrorPacket(data []byte) error {
 }
 
 // IsOKPacket returns true if it's an OK packet (but not ResultSet OK).
-func IsOKPacket(data []byte) bool {
-	return data[0] == OKHeader.Byte()
+func IsOKPacket(firstByte byte) bool {
+	return firstByte == OKHeader.Byte()
 }
 
 // IsEOFPacket returns true if it's an EOF packet.
-func IsEOFPacket(data []byte) bool {
-	return data[0] == EOFHeader.Byte() && len(data) <= 5
+func IsEOFPacket(firstByte byte, length int) bool {
+	return firstByte == EOFHeader.Byte() && length <= 5
 }
 
 // IsResultSetOKPacket returns true if it's an OK packet after the result set when CLIENT_DEPRECATE_EOF is enabled.
 // A row packet may also begin with 0xfe, so we need to judge it with the packet length.
 // See https://mariadb.com/kb/en/result-set-packets/
-func IsResultSetOKPacket(data []byte) bool {
+func IsResultSetOKPacket(firstByte byte, length int) bool {
 	// With CLIENT_PROTOCOL_41 enabled, the least length is 7.
-	return data[0] == EOFHeader.Byte() && len(data) >= 7 && len(data) < 0xFFFFFF
+	return firstByte == EOFHeader.Byte() && length >= 7 && length < 0xFFFFFF
 }
 
 // IsErrorPacket returns true if it's an error packet.
-func IsErrorPacket(data []byte) bool {
-	return data[0] == ErrHeader.Byte()
+func IsErrorPacket(firstByte byte) bool {
+	return firstByte == ErrHeader.Byte()
 }

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -336,6 +336,7 @@ func (p *PacketIO) ForwardUntil(dest *PacketIO, isEnd func(firstByte byte, first
 		}
 		length := int(header[0]) | int(header[1])<<8 | int(header[2])<<16
 		if isEnd(header[4], length) {
+			// TODO: allocate a buffer from pool and return the buffer after `process`.
 			data, err := p.ReadPacket()
 			if err != nil {
 				return errors.Wrap(ErrReadConn, err)

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -329,9 +329,6 @@ func (p *PacketIO) ForwardUntil(dest *PacketIO, isEnd func(firstByte byte, first
 	p.readWriter.BeginRW(rwRead)
 	dest.readWriter.BeginRW(rwWrite)
 	p.limitReader.R = p.readWriter
-	defer func() {
-		p.limitReader.R = nil
-	}()
 	for {
 		header, err := p.readWriter.Peek(5)
 		if err != nil {

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -25,7 +25,6 @@
 package net
 
 import (
-	"bufio"
 	"crypto/tls"
 	"io"
 	"net"
@@ -37,6 +36,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/pkg/proxy/keepalive"
 	"github.com/pingcap/tiproxy/pkg/proxy/proxyprotocol"
+	"github.com/pingcap/tiproxy/pkg/util/bufio"
 	"go.uber.org/zap"
 )
 

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -416,6 +416,95 @@ func TestPacketSequence(t *testing.T) {
 	)
 }
 
+func TestForwardUntil(t *testing.T) {
+	stls, ctls, err := security.CreateTLSConfigForTest()
+	require.NoError(t, err)
+	_, p := mockProxy(t)
+	srvCh := make(chan *PacketIO)
+	exitCh := make(chan struct{})
+	prepareClient := func(enableProxy, enableTLS, enableCompress bool, cli *PacketIO) {
+		if enableProxy {
+			cli.EnableProxyClient(p)
+		}
+		if enableTLS {
+			require.NoError(t, cli.ClientTLSHandshake(ctls))
+			require.True(t, cli.TLSConnectionState().HandshakeComplete)
+		}
+		if enableCompress {
+			cli.ResetSequence()
+			require.NoError(t, cli.SetCompressionAlgorithm(CompressionZlib, 0))
+		}
+	}
+	prepareServer := func(enableProxy, enableTLS, enableCompress bool, srv *PacketIO) {
+		if enableProxy {
+			srv.EnableProxyServer()
+		}
+		if enableTLS {
+			state, err := srv.ServerTLSHandshake(stls)
+			require.NoError(t, err)
+			require.True(t, state.HandshakeComplete)
+			require.True(t, srv.TLSConnectionState().HandshakeComplete)
+		}
+		if enableCompress {
+			srv.ResetSequence()
+			require.NoError(t, srv.SetCompressionAlgorithm(CompressionZlib, 0))
+		}
+	}
+	for _, enableCompress := range []bool{true, false} {
+		for _, enableTLS := range []bool{true, false} {
+			for _, enableProxy := range []bool{true, false} {
+				var wg waitgroup.WaitGroup
+				loops := 100
+				// client1 writes to server1
+				// server1 forwards to server2
+				// server2 writes to client2
+				wg.Run(func() {
+					testTCPConn(t,
+						func(t *testing.T, cli *PacketIO) {
+							prepareClient(enableProxy, enableTLS, enableCompress, cli)
+							for i := 0; i <= loops; i++ {
+								require.NoError(t, cli.WritePacket([]byte{byte(i)}, true))
+							}
+						},
+						func(t *testing.T, srv1 *PacketIO) {
+							prepareServer(enableProxy, enableTLS, enableCompress, srv1)
+							srv2 := <-srvCh
+							err := srv1.ForwardUntil(srv2, func(firstByte byte, firstPktLen int) bool {
+								return firstByte == byte(loops) && firstPktLen == 1
+							}, func(response []byte) error {
+								require.Equal(t, []byte{byte(loops)}, response)
+								return srv2.Flush()
+							})
+							require.NoError(t, err)
+							exitCh <- struct{}{}
+						},
+						1,
+					)
+				})
+				wg.Run(func() {
+					testTCPConn(t,
+						func(t *testing.T, cli *PacketIO) {
+							prepareClient(enableProxy, enableTLS, enableCompress, cli)
+							for i := 0; i < loops; i++ {
+								data, err := cli.ReadPacket()
+								require.NoError(t, err)
+								require.Equal(t, []byte{byte(i)}, data)
+							}
+						},
+						func(t *testing.T, srv2 *PacketIO) {
+							prepareServer(enableProxy, enableTLS, enableCompress, srv2)
+							srvCh <- srv2
+							<-exitCh
+						},
+						1,
+					)
+				})
+				wg.Wait()
+			}
+		}
+	}
+}
+
 func BenchmarkWritePacket(b *testing.B) {
 	b.ReportAllocs()
 	cli, srv := net.Pipe()

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -6,6 +6,7 @@ package net
 import (
 	"bufio"
 	"crypto/tls"
+	"io"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 )
@@ -70,6 +71,10 @@ func newTLSReadWriter(rw packetReadWriter, tlsConn *tls.Conn) *tlsReadWriter {
 func (trw *tlsReadWriter) Read(b []byte) (n int, err error) {
 	// inBytes and outBytes are updated internally in trw.packetReadWriter.
 	return trw.buf.Read(b)
+}
+
+func (trw *tlsReadWriter) ReadFrom(r io.Reader) (int64, error) {
+	return trw.buf.ReadFrom(r)
 }
 
 func (trw *tlsReadWriter) Write(p []byte) (int, error) {

--- a/pkg/proxy/net/tls.go
+++ b/pkg/proxy/net/tls.go
@@ -4,11 +4,11 @@
 package net
 
 import (
-	"bufio"
 	"crypto/tls"
 	"io"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/util/bufio"
 )
 
 // tlsHandshakeConn is only used as the underlying connection in tls.Conn.

--- a/pkg/util/bufio/bufio.go
+++ b/pkg/util/bufio/bufio.go
@@ -1,10 +1,13 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package bufio implements buffered I/O. It wraps an io.Reader or io.Writer
-// object, creating another object (Reader or Writer) that also implements
-// the interface but provides buffering and some help for textual I/O.
+// Package bufio is a simplified Golang bufio.
+// It mainly avoids calling TCPConn.ReadFrom in Writer.ReadFrom because
+// TCPConn.ReadFrom calls sys calls.
 package bufio
 
 import (

--- a/pkg/util/bufio/bufio.go
+++ b/pkg/util/bufio/bufio.go
@@ -1,0 +1,498 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package bufio implements buffered I/O. It wraps an io.Reader or io.Writer
+// object, creating another object (Reader or Writer) that also implements
+// the interface but provides buffering and some help for textual I/O.
+package bufio
+
+import (
+	"errors"
+	"io"
+)
+
+const (
+	defaultBufSize = 4096
+)
+
+var (
+	ErrBufferFull    = errors.New("bufio: buffer full")
+	ErrNegativeCount = errors.New("bufio: negative count")
+)
+
+// Buffered input.
+
+// Reader implements buffering for an io.Reader object.
+type Reader struct {
+	buf          []byte
+	rd           io.Reader // reader provided by the client
+	r, w         int       // buf read and write positions
+	err          error
+	lastByte     int // last byte read for UnreadByte; -1 means invalid
+	lastRuneSize int // size of last rune read for UnreadRune; -1 means invalid
+}
+
+const minReadBufferSize = 16
+const maxConsecutiveEmptyReads = 100
+
+// NewReaderSize returns a new Reader whose buffer has at least the specified
+// size. If the argument io.Reader is already a Reader with large enough
+// size, it returns the underlying Reader.
+func NewReaderSize(rd io.Reader, size int) *Reader {
+	// Is it already a Reader?
+	b, ok := rd.(*Reader)
+	if ok && len(b.buf) >= size {
+		return b
+	}
+	if size < minReadBufferSize {
+		size = minReadBufferSize
+	}
+	r := new(Reader)
+	r.reset(make([]byte, size), rd)
+	return r
+}
+
+// NewReader returns a new Reader whose buffer has the default size.
+func NewReader(rd io.Reader) *Reader {
+	return NewReaderSize(rd, defaultBufSize)
+}
+
+// Size returns the size of the underlying buffer in bytes.
+func (b *Reader) Size() int { return len(b.buf) }
+
+// Reset discards any buffered data, resets all state, and switches
+// the buffered reader to read from r.
+// Calling Reset on the zero value of Reader initializes the internal buffer
+// to the default size.
+// Calling b.Reset(b) (that is, resetting a Reader to itself) does nothing.
+func (b *Reader) Reset(r io.Reader) {
+	// If a Reader r is passed to NewReader, NewReader will return r.
+	// Different layers of code may do that, and then later pass r
+	// to Reset. Avoid infinite recursion in that case.
+	if b == r {
+		return
+	}
+	if b.buf == nil {
+		b.buf = make([]byte, defaultBufSize)
+	}
+	b.reset(b.buf, r)
+}
+
+func (b *Reader) reset(buf []byte, r io.Reader) {
+	*b = Reader{
+		buf:          buf,
+		rd:           r,
+		lastByte:     -1,
+		lastRuneSize: -1,
+	}
+}
+
+var errNegativeRead = errors.New("bufio: reader returned negative count from Read")
+
+// fill reads a new chunk into the buffer.
+func (b *Reader) fill() {
+	// Slide existing data to beginning.
+	if b.r > 0 {
+		copy(b.buf, b.buf[b.r:b.w])
+		b.w -= b.r
+		b.r = 0
+	}
+
+	if b.w >= len(b.buf) {
+		panic("bufio: tried to fill full buffer")
+	}
+
+	// Read new data: try a limited number of times.
+	for i := maxConsecutiveEmptyReads; i > 0; i-- {
+		n, err := b.rd.Read(b.buf[b.w:])
+		if n < 0 {
+			panic(errNegativeRead)
+		}
+		b.w += n
+		if err != nil {
+			b.err = err
+			return
+		}
+		if n > 0 {
+			return
+		}
+	}
+	b.err = io.ErrNoProgress
+}
+
+func (b *Reader) readErr() error {
+	err := b.err
+	b.err = nil
+	return err
+}
+
+// Peek returns the next n bytes without advancing the reader. The bytes stop
+// being valid at the next read call. If Peek returns fewer than n bytes, it
+// also returns an error explaining why the read is short. The error is
+// ErrBufferFull if n is larger than b's buffer size.
+//
+// Calling Peek prevents a UnreadByte or UnreadRune call from succeeding
+// until the next read operation.
+func (b *Reader) Peek(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, ErrNegativeCount
+	}
+
+	b.lastByte = -1
+	b.lastRuneSize = -1
+
+	for b.w-b.r < n && b.w-b.r < len(b.buf) && b.err == nil {
+		b.fill() // b.w-b.r < len(b.buf) => buffer is not full
+	}
+
+	if n > len(b.buf) {
+		return b.buf[b.r:b.w], ErrBufferFull
+	}
+
+	// 0 <= n <= len(b.buf)
+	var err error
+	if avail := b.w - b.r; avail < n {
+		// not enough data in buffer
+		n = avail
+		err = b.readErr()
+		if err == nil {
+			err = ErrBufferFull
+		}
+	}
+	return b.buf[b.r : b.r+n], err
+}
+
+// Discard skips the next n bytes, returning the number of bytes discarded.
+//
+// If Discard skips fewer than n bytes, it also returns an error.
+// If 0 <= n <= b.Buffered(), Discard is guaranteed to succeed without
+// reading from the underlying io.Reader.
+func (b *Reader) Discard(n int) (discarded int, err error) {
+	if n < 0 {
+		return 0, ErrNegativeCount
+	}
+	if n == 0 {
+		return
+	}
+
+	b.lastByte = -1
+	b.lastRuneSize = -1
+
+	remain := n
+	for {
+		skip := b.Buffered()
+		if skip == 0 {
+			b.fill()
+			skip = b.Buffered()
+		}
+		if skip > remain {
+			skip = remain
+		}
+		b.r += skip
+		remain -= skip
+		if remain == 0 {
+			return n, nil
+		}
+		if b.err != nil {
+			return n - remain, b.readErr()
+		}
+	}
+}
+
+// Read reads data into p.
+// It returns the number of bytes read into p.
+// The bytes are taken from at most one Read on the underlying Reader,
+// hence n may be less than len(p).
+// To read exactly len(p) bytes, use io.ReadFull(b, p).
+// If the underlying Reader can return a non-zero count with io.EOF,
+// then this Read method can do so as well; see the [io.Reader] docs.
+func (b *Reader) Read(p []byte) (n int, err error) {
+	n = len(p)
+	if n == 0 {
+		if b.Buffered() > 0 {
+			return 0, nil
+		}
+		return 0, b.readErr()
+	}
+	if b.r == b.w {
+		if b.err != nil {
+			return 0, b.readErr()
+		}
+		if len(p) >= len(b.buf) {
+			// Large read, empty buffer.
+			// Read directly into p to avoid copy.
+			n, b.err = b.rd.Read(p)
+			if n < 0 {
+				panic(errNegativeRead)
+			}
+			if n > 0 {
+				b.lastByte = int(p[n-1])
+				b.lastRuneSize = -1
+			}
+			return n, b.readErr()
+		}
+		// One read.
+		// Do not use b.fill, which will loop.
+		b.r = 0
+		b.w = 0
+		n, b.err = b.rd.Read(b.buf)
+		if n < 0 {
+			panic(errNegativeRead)
+		}
+		if n == 0 {
+			return 0, b.readErr()
+		}
+		b.w += n
+	}
+
+	// copy as much as we can
+	// Note: if the slice panics here, it is probably because
+	// the underlying reader returned a bad count. See issue 49795.
+	n = copy(p, b.buf[b.r:b.w])
+	b.r += n
+	b.lastByte = int(b.buf[b.r-1])
+	b.lastRuneSize = -1
+	return n, nil
+}
+
+// Buffered returns the number of bytes that can be read from the current buffer.
+func (b *Reader) Buffered() int { return b.w - b.r }
+
+// WriteTo implements io.WriterTo.
+// This may make multiple calls to the Read method of the underlying Reader.
+// If the underlying reader supports the WriteTo method,
+// this calls the underlying WriteTo without buffering.
+func (b *Reader) WriteTo(w io.Writer) (n int64, err error) {
+	b.lastByte = -1
+	b.lastRuneSize = -1
+
+	n, err = b.writeBuf(w)
+	if err != nil {
+		return
+	}
+
+	if w, ok := w.(io.ReaderFrom); ok {
+		m, err := w.ReadFrom(b.rd)
+		n += m
+		return n, err
+	}
+
+	if b.w-b.r < len(b.buf) {
+		b.fill() // buffer not full
+	}
+
+	for b.r < b.w {
+		// b.r < b.w => buffer is not empty
+		m, err := b.writeBuf(w)
+		n += m
+		if err != nil {
+			return n, err
+		}
+		b.fill() // buffer is empty
+	}
+
+	if b.err == io.EOF {
+		b.err = nil
+	}
+
+	return n, b.readErr()
+}
+
+var errNegativeWrite = errors.New("bufio: writer returned negative count from Write")
+
+// writeBuf writes the Reader's buffer to the writer.
+func (b *Reader) writeBuf(w io.Writer) (int64, error) {
+	n, err := w.Write(b.buf[b.r:b.w])
+	if n < 0 {
+		panic(errNegativeWrite)
+	}
+	b.r += n
+	return int64(n), err
+}
+
+// buffered output
+
+// Writer implements buffering for an io.Writer object.
+// If an error occurs writing to a Writer, no more data will be
+// accepted and all subsequent writes, and Flush, will return the error.
+// After all data has been written, the client should call the
+// Flush method to guarantee all data has been forwarded to
+// the underlying io.Writer.
+type Writer struct {
+	err error
+	buf []byte
+	n   int
+	wr  io.Writer
+}
+
+// NewWriterSize returns a new Writer whose buffer has at least the specified
+// size. If the argument io.Writer is already a Writer with large enough
+// size, it returns the underlying Writer.
+func NewWriterSize(w io.Writer, size int) *Writer {
+	// Is it already a Writer?
+	b, ok := w.(*Writer)
+	if ok && len(b.buf) >= size {
+		return b
+	}
+	if size <= 0 {
+		size = defaultBufSize
+	}
+	return &Writer{
+		buf: make([]byte, size),
+		wr:  w,
+	}
+}
+
+// NewWriter returns a new Writer whose buffer has the default size.
+// If the argument io.Writer is already a Writer with large enough buffer size,
+// it returns the underlying Writer.
+func NewWriter(w io.Writer) *Writer {
+	return NewWriterSize(w, defaultBufSize)
+}
+
+// Size returns the size of the underlying buffer in bytes.
+func (b *Writer) Size() int { return len(b.buf) }
+
+// Reset discards any unflushed buffered data, clears any error, and
+// resets b to write its output to w.
+// Calling Reset on the zero value of Writer initializes the internal buffer
+// to the default size.
+// Calling w.Reset(w) (that is, resetting a Writer to itself) does nothing.
+func (b *Writer) Reset(w io.Writer) {
+	// If a Writer w is passed to NewWriter, NewWriter will return w.
+	// Different layers of code may do that, and then later pass w
+	// to Reset. Avoid infinite recursion in that case.
+	if b == w {
+		return
+	}
+	if b.buf == nil {
+		b.buf = make([]byte, defaultBufSize)
+	}
+	b.err = nil
+	b.n = 0
+	b.wr = w
+}
+
+// Flush writes any buffered data to the underlying io.Writer.
+func (b *Writer) Flush() error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.n == 0 {
+		return nil
+	}
+	n, err := b.wr.Write(b.buf[0:b.n])
+	if n < b.n && err == nil {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		if n > 0 && n < b.n {
+			copy(b.buf[0:b.n-n], b.buf[n:b.n])
+		}
+		b.n -= n
+		b.err = err
+		return err
+	}
+	b.n = 0
+	return nil
+}
+
+// Available returns how many bytes are unused in the buffer.
+func (b *Writer) Available() int { return len(b.buf) - b.n }
+
+// AvailableBuffer returns an empty buffer with b.Available() capacity.
+// This buffer is intended to be appended to and
+// passed to an immediately succeeding Write call.
+// The buffer is only valid until the next write operation on b.
+func (b *Writer) AvailableBuffer() []byte {
+	return b.buf[b.n:][:0]
+}
+
+// Buffered returns the number of bytes that have been written into the current buffer.
+func (b *Writer) Buffered() int { return b.n }
+
+// Write writes the contents of p into the buffer.
+// It returns the number of bytes written.
+// If nn < len(p), it also returns an error explaining
+// why the write is short.
+func (b *Writer) Write(p []byte) (nn int, err error) {
+	for len(p) > b.Available() && b.err == nil {
+		var n int
+		if b.Buffered() == 0 {
+			// Large write, empty buffer.
+			// Write directly from p to avoid copy.
+			n, b.err = b.wr.Write(p)
+		} else {
+			n = copy(b.buf[b.n:], p)
+			b.n += n
+			b.Flush()
+		}
+		nn += n
+		p = p[n:]
+	}
+	if b.err != nil {
+		return nn, b.err
+	}
+	n := copy(b.buf[b.n:], p)
+	b.n += n
+	nn += n
+	return nn, nil
+}
+
+// ReadFrom implements io.ReaderFrom. If the underlying writer
+// supports the ReadFrom method, this calls the underlying ReadFrom.
+// If there is buffered data and an underlying ReadFrom, this fills
+// the buffer and writes it before calling ReadFrom.
+func (b *Writer) ReadFrom(r io.Reader) (n int64, err error) {
+	if b.err != nil {
+		return 0, b.err
+	}
+	var m int
+	for {
+		if b.Available() == 0 {
+			if err1 := b.Flush(); err1 != nil {
+				return n, err1
+			}
+		}
+		nr := 0
+		for nr < maxConsecutiveEmptyReads {
+			m, err = r.Read(b.buf[b.n:])
+			if m != 0 || err != nil {
+				break
+			}
+			nr++
+		}
+		if nr == maxConsecutiveEmptyReads {
+			return n, io.ErrNoProgress
+		}
+		b.n += m
+		n += int64(m)
+		if err != nil {
+			break
+		}
+	}
+	if err == io.EOF {
+		// If we filled the buffer exactly, flush preemptively.
+		if b.Available() == 0 {
+			err = b.Flush()
+		} else {
+			err = nil
+		}
+	}
+	return n, err
+}
+
+// buffered input and output
+
+// ReadWriter stores pointers to a Reader and a Writer.
+// It implements io.ReadWriter.
+type ReadWriter struct {
+	*Reader
+	*Writer
+}
+
+// NewReadWriter allocates a new ReadWriter that dispatches to r and w.
+func NewReadWriter(r *Reader, w *Writer) *ReadWriter {
+	return &ReadWriter{r, w}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #381

Problem Summary:
The performance is still not good enough. We can just forward the packets between connections and avoid allocating memory and copying data.

What is changed and how it works:
- Add `PacketIO.ForwardUntil` and call it in `CmdProcessor.forwardUntilResultEnd`. `ForwardUntil` only allocates memory in the last packet. `ForwardUntil` mainly calls `Writer.ReadFrom` to copy data because reader and writer.
- Copy Golang `bufio.go` to TiProxy because `Writer.ReadFrom` always calls `TCPConn.ReadFrom`, which calls sys calls and skips the buffer. We always need the buffer and I can't find a replacement of `bufio`.
- Add `ReadFrom` for all the `packetReadWriter` implementations.
- Modify the parameters of `IsXXXPacket` because we only know the length and first byte if we do the optimization.
- Optimize `compressedReadWriter.Peek` to avoid allocating memory.
- Add `proxyReadWriter.Peek`. It was a bug not to add this function.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

#### Sysbench Result
Before this PR (with `conn-buffer-size=131072`):
| Range size | QPS   | TiProxy CPU | QPS per 100% CPU |
|------------|-------|-------------|------------------|
| 10         | 32818 | 150%        | 21878            |
| 100        | 22392 | 190%        | 11785            |
| 1000       | 4093  | 200%        | 2046             |
| 10000      | 449   | 200%        | 224              |

After this PR (with `conn-buffer-size=131072`):
| Range size | QPS   | TiProxy CPU | QPS per 100% CPU |
|------------|-------|-------------|------------------|
| 10         | 31430 | 130%        | 24176            |
| 100        | 23680 | 150%        | 15786            |
| 1000       | 6281  | 160%        | 3925             |
| 10000      | 707   | 140%        | 505              |

#### Flame Graph

![image](https://github.com/pingcap/tiproxy/assets/29590578/f6b252ae-7354-4545-a2fd-4a7146c234e9)


Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
