### PR TITLE
backend, net: log client versions

### DIFF
--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -411,6 +411,12 @@ func (auth *Authenticator) updateCurrentDB(db string) {
 	auth.dbname = db
 }
 
+func (auth *Authenticator) ConnInfo() []zap.Field {
+	fields := pnet.Attr2ZapFields(auth.attrs)
+	fields = append(fields, zap.Stringer("capability", auth.capability), zap.Bool("proxy-protocol", auth.proxyProtocol))
+	return fields
+}
+
 func setCompress(packetIO *pnet.PacketIO, capability pnet.Capability, zstdLevel int) error {
 	algorithm := pnet.CompressionNone
 	if capability&pnet.ClientCompress > 0 {

--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -49,6 +49,7 @@ func (cc *ClientConnection) Run(ctx context.Context) {
 		msg = "new connection failed"
 		goto clean
 	}
+	cc.logger.Info("connected to backend", cc.connMgr.ConnInfo()...)
 	if err = cc.processMsg(ctx); err != nil {
 		msg = "fails to relay the connection"
 		goto clean
@@ -59,7 +60,9 @@ clean:
 	switch src {
 	case backend.SrcClientQuit, backend.SrcClientErr, backend.SrcProxyQuit:
 	default:
-		cc.logger.Warn(msg, zap.String("backend_addr", cc.connMgr.ServerAddr()), zap.Stringer("quit source", src), zap.Error(err))
+		fields := cc.connMgr.ConnInfo()
+		fields = append(fields, zap.Stringer("quit source", src), zap.Error(err))
+		cc.logger.Warn(msg, fields...)
 	}
 }
 

--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -6,6 +6,7 @@ package net
 import (
 	"testing"
 
+	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +46,18 @@ func TestChangeUserReq(t *testing.T) {
 	b = MakeChangeUser(req1, capability)
 	_, err = ParseChangeUser(b, capability)
 	require.NoError(t, err)
+}
+
+func TestLogAttrs(t *testing.T) {
+	attrs := map[string]string{
+		AttrNameClientVersion: "8.1.0",
+		AttrNameClientName1:   "libmysql",
+		AttrNameProgramName:   "mysql",
+	}
+	lg, text := logger.CreateLoggerForTest(t)
+	lg.Info("connection info", Attr2ZapFields(attrs)...)
+	str := text.String()
+	require.Contains(t, str, `"client_version": "8.1.0"`)
+	require.Contains(t, str, `"client_name": "libmysql"`)
+	require.Contains(t, str, `"program_name": "mysql"`)
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -158,7 +158,7 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
 	connID := s.mu.connID
 	s.mu.connID++
 	logger := s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()),
-		zap.Bool("proxy-protocol", s.mu.proxyProtocol), zap.String("addr", addr))
+		zap.String("addr", addr))
 	clientConn := client.NewClientConnection(logger.Named("conn"), conn, s.certMgr.ServerTLS(), s.certMgr.SQLTLS(),
 		s.hsHandler, connID, addr, &backend.BCConfig{
 			ProxyProtocol:      s.mu.proxyProtocol,
@@ -168,9 +168,9 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
 			ConnBufferSize:     s.mu.connBufferSize,
 		})
 	s.mu.clients[connID] = clientConn
+	logger.Info("new connection", zap.Bool("proxy-protocol", s.mu.proxyProtocol))
 	s.mu.Unlock()
 
-	logger.Info("new connection")
 	metrics.ConnGauge.Inc()
 
 	defer func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #369

Problem Summary:
Some client versions are in the connection attributes. If we can log them once the connection is created, it might be helpful for troubleshooting.

What is changed and how it works:
- Move the log `connected to backend` after the connection is established.
- Add client names and versions in the log.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
[2023/11/08 16:25:28.157 +08:00] [INFO] [main.proxy.conn] [client/client_conn.go:52] [connected to backend] [connID=5] [client_addr=127.0.0.1:65006] [addr=0.0.0.0:6000] [client_version=8.1.0] [client_name=libmysql] [capability=CLIENT_LONG_PASSWORD|CLIENT_LONG_FLAG|CLIENT_CONNECT_WITH_DB|CLIENT_LOCAL_FILES|CLIENT_PROTOCOL_41|CLIENT_SSL|CLIENT_TRANSACTIONS|CLIENT_SECURE_CONNECTION|CLIENT_MULTI_STATEMENTS|CLIENT_MULTI_RESULTS|CLIENT_PLUGIN_AUTH|CLIENT_CONNECT_ATTS|CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA|CLIENT_DEPRECATE_EOF] [proxy-protocol=false] [backend_addr=127.0.0.1:4000]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
