### PR TITLE
backend, infosync: optimize `TestHandlerReturnError` and `TestEtcdServerDown4Sync`

### DIFF
--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -54,20 +54,18 @@ func TestEtcdServerDown4Sync(t *testing.T) {
 	ts := newEtcdTestSuite(t)
 	t.Cleanup(ts.close)
 	var ttl string
-	for i := 0; i < 5; i++ {
-		// Make the server down for some time.
-		addr := ts.shutdownServer()
-		time.Sleep(time.Second)
-		ts.startServer(addr)
-		require.Eventually(t, func() bool {
-			newTTL, info := ts.getTTLAndInfo(tiproxyTopologyPath)
-			satisfied := newTTL != ttl && len(info) > 0
-			if satisfied {
-				ttl = newTTL
-			}
-			return satisfied
-		}, 5*time.Second, 100*time.Millisecond)
-	}
+	// Make the server down for some time.
+	addr := ts.shutdownServer()
+	time.Sleep(time.Second)
+	ts.startServer(addr)
+	require.Eventually(t, func() bool {
+		newTTL, info := ts.getTTLAndInfo(tiproxyTopologyPath)
+		satisfied := newTTL != ttl && len(info) > 0
+		if satisfied {
+			ttl = newTTL
+		}
+		return satisfied
+	}, 5*time.Second, 100*time.Millisecond)
 }
 
 // TTL and info are erased after the client shuts down normally.

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -8,15 +8,13 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
-	"net"
-	"time"
-
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/proxy/proxyprotocol"
 	"go.uber.org/zap"
+	"net"
 )
 
 var (
@@ -85,7 +83,7 @@ func (auth *Authenticator) verifyBackendCaps(logger *zap.Logger, backendCapabili
 	return nil
 }
 
-type backendIOGetter func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp, timeout time.Duration) (*pnet.PacketIO, error)
+type backendIOGetter func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error)
 
 func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnContext, clientIO *pnet.PacketIO, handshakeHandler HandshakeHandler,
 	getBackendIO backendIOGetter, frontendTLSConfig, backendTLSConfig *tls.Config) error {
@@ -162,7 +160,7 @@ func (auth *Authenticator) handshakeFirstTime(logger *zap.Logger, cctx ConnConte
 RECONNECT:
 
 	// In case of testing, backendIO is passed manually that we don't want to bother with the routing logic.
-	backendIO, err := getBackendIO(cctx, auth, clientResp, 15*time.Second)
+	backendIO, err := getBackendIO(cctx, auth, clientResp)
 	if err != nil {
 		return pnet.WrapUserError(err, connectErrMsg)
 	}

--- a/pkg/proxy/backend/authenticator.go
+++ b/pkg/proxy/backend/authenticator.go
@@ -8,13 +8,14 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
+	"net"
+
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/proxy/proxyprotocol"
 	"go.uber.org/zap"
-	"net"
 )
 
 var (

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -761,8 +761,8 @@ func TestHandlerReturnError(t *testing.T) {
 			quitSource: SrcProxyErr,
 		},
 		{
-			// TODO: make it fail faster.
 			cfg: func(config *testConfig) {
+				config.proxyConfig.bcConfig.ConnectTimeout = time.Second
 				config.proxyConfig.handler.getRouter = func(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error) {
 					return router.NewStaticRouter(nil), nil
 				}
@@ -857,7 +857,7 @@ func TestGetBackendIO(t *testing.T) {
 		},
 	}
 	lg, _ := logger.CreateLoggerForTest(t)
-	mgr := NewBackendConnManager(lg, handler, 0, &BCConfig{})
+	mgr := NewBackendConnManager(lg, handler, 0, &BCConfig{ConnectTimeout: time.Second})
 	var wg waitgroup.WaitGroup
 	for i := 0; i <= len(listeners); i++ {
 		wg.Run(func() {
@@ -867,7 +867,7 @@ func TestGetBackendIO(t *testing.T) {
 				require.NoError(t, cn.Close())
 			}
 		})
-		io, err := mgr.getBackendIO(mgr, mgr.authenticator, nil, time.Second)
+		io, err := mgr.getBackendIO(mgr, mgr.authenticator, nil)
 		if err == nil {
 			require.NoError(t, io.Close())
 		}

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -5,11 +5,12 @@ package backend
 
 import (
 	"crypto/tls"
+	"testing"
+
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"go.uber.org/zap"
-	"testing"
 )
 
 type proxyConfig struct {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -5,13 +5,11 @@ package backend
 
 import (
 	"crypto/tls"
-	"testing"
-	"time"
-
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"go.uber.org/zap"
+	"testing"
 )
 
 type proxyConfig struct {
@@ -58,7 +56,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 }
 
 func (mp *mockProxy) authenticateFirstTime(clientIO, backendIO *pnet.PacketIO) error {
-	if err := mp.authenticator.handshakeFirstTime(mp.logger, mp, clientIO, mp.handshakeHandler, func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp, timeout time.Duration) (*pnet.PacketIO, error) {
+	if err := mp.authenticator.handshakeFirstTime(mp.logger, mp, clientIO, mp.handshakeHandler, func(ctx ConnContext, auth *Authenticator, resp *pnet.HandshakeResp) (*pnet.PacketIO, error) {
 		return backendIO, nil
 	}, mp.frontendTLSConfig, mp.backendTLSConfig); err != nil {
 		return err


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #374

Problem Summary:
- `TestHandlerReturnError` takes 15s
- `TestEtcdServerDown4Sync` takes 17s

What is changed and how it works:
- Add `ConnectTime` to `BCConfig` so I can make the timeout shorter in `TestHandlerReturnError`. I prefer not to put it into configuration because connection timeout barely happens in self-hosted deployment.
- Reduce loops from 5 to 1 for `TestEtcdServerDown4Sync`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
