### PR TITLE
proxy, config: add config `graceful-close-conn-timeout`

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -10,10 +10,18 @@
 #   "v2" => accept proxy protocol if any, require backends to support proxy protocol.
 # proxy-protocol = ""
 
+# graceful-wait-before-shutdown is recommanded to be set to 0 when there's no other proxy(e.g. NLB) between the client and TiProxy.
 # possible values:
-# 	0 => disable graceful shutdown.
-# 	30 => graceful shutdown waiting time in 30 seconds.
+# 	0 => begin to drain clients immediately.
+# 	30 => HTTP status returns unhealthy and the SQL port accepts new connections for the last 30 seconds. After that, refuse new connections and drain clients.
 # graceful-wait-before-shutdown = 0
+
+# graceful-close-conn-timeout is recommanded to be set longer than the lifecycle of a transaction.
+# possible values:
+#   0 => force closing connections immediately.
+#   15 => close connections when they have finished current transactions (AKA drain clients). After 15s, force closing all the connections.
+
+graceful-close-conn-timeout = 15
 
 # possible values:
 #		"" => enable static routing.

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -58,6 +58,7 @@ type ProxyServerOnline struct {
 	BackendUnhealthyKeepalive  KeepAlive `yaml:"backend-unhealthy-keepalive" toml:"backend-unhealthy-keepalive" json:"backend-unhealthy-keepalive"`
 	ProxyProtocol              string    `yaml:"proxy-protocol,omitempty" toml:"proxy-protocol,omitempty" json:"proxy-protocol,omitempty"`
 	GracefulWaitBeforeShutdown int       `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty"`
+	GracefulCloseConnTimeout   int       `yaml:"graceful-close-conn-timeout,omitempty" toml:"graceful-close-conn-timeout,omitempty" json:"graceful-close-conn-timeout,omitempty"`
 }
 
 type ProxyServer struct {
@@ -140,6 +141,7 @@ func NewConfig() *Config {
 	cfg.Proxy.FrontendKeepalive, cfg.Proxy.BackendHealthyKeepalive, cfg.Proxy.BackendUnhealthyKeepalive = DefaultKeepAlive()
 	cfg.Proxy.RequireBackendTLS = true
 	cfg.Proxy.PDAddrs = "127.0.0.1:2379"
+	cfg.Proxy.GracefulCloseConnTimeout = 15
 
 	cfg.API.Addr = "0.0.0.0:3080"
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -72,6 +72,7 @@ func NewSQLServer(logger *zap.Logger, cfg config.ProxyServer, certMgr *cert.Cert
 		mu: serverState{
 			connID:  0,
 			clients: make(map[uint64]*client.ClientConnection),
+			status:  statusNormal,
 		},
 	}
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -118,15 +118,7 @@ func TestGracefulShutDown(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	wg.Run(func() {
 		// Wait until the server begins to shut down.
-		for i := 0; ; i++ {
-			if server.IsClosing() {
-				break
-			}
-			if i >= 50 {
-				t.Fatal("timeout")
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
+		require.Eventually(t, server.IsClosing, 500*time.Millisecond, 10*time.Millisecond)
 		// The listener should be open.
 		conn1, err := net.Dial("tcp", server.listeners[0].Addr().String())
 		require.NoError(t, err)
@@ -135,8 +127,6 @@ func TestGracefulShutDown(t *testing.T) {
 			conn, err := net.Dial("tcp", server.listeners[0].Addr().String())
 			if err == nil {
 				require.NoError(t, conn.Close())
-			} else {
-				require.ErrorContains(t, err, "connection refused")
 			}
 			return err != nil
 		}, 3*time.Second, 100*time.Millisecond)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -178,11 +178,11 @@ func TestWatchCfg(t *testing.T) {
 	cfg := &config.Config{
 		Proxy: config.ProxyServer{
 			ProxyServerOnline: config.ProxyServerOnline{
-				RequireBackendTLS:          true,
-				MaxConnections:             100,
-				ConnBufferSize:             1024 * 1024,
-				ProxyProtocol:              "v2",
-				GracefulWaitBeforeShutdown: 100,
+				RequireBackendTLS:        true,
+				MaxConnections:           100,
+				ConnBufferSize:           1024 * 1024,
+				ProxyProtocol:            "v2",
+				GracefulCloseConnTimeout: 100,
 			},
 		},
 	}

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -24,6 +24,7 @@ func TestConfig(t *testing.T) {
 addr = '0.0.0.0:6000'
 pd-addrs = '127.0.0.1:2379'
 require-backend-tls = true
+graceful-close-conn-timeout = 15
 
 [proxy.frontend-keepalive]
 enabled = true
@@ -75,7 +76,7 @@ max-backups = 3
 	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","require-backend-tls":true,"frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000}},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.1"},"peer-tls":{"min-tls-version":"1.1"},"cluster-tls":{"min-tls-version":"1.1"},"sql-tls":{"min-tls-version":"1.1"}},"metrics":{"metrics-addr":"","metrics-interval":0},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
+		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","require-backend-tls":true,"frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.1"},"peer-tls":{"min-tls-version":"1.1"},"cluster-tls":{"min-tls-version":"1.1"},"sql-tls":{"min-tls-version":"1.1"}},"metrics":{"metrics-addr":"","metrics-interval":0},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
 			string(regexp.MustCompile(`"workdir":"[^"]+",`).ReplaceAll(all, nil)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #399

Problem Summary:
On the cloud, NLB takes around 90s to mark TiProxy offline after TiProxy shuts down the HTTP port. During this process, new connections are denied.

What is changed and how it works:
- Only reject new connections after `graceful-wait-before-shutdown`, not before
- Add a configuration `graceful-close-conn-timeout`. After `graceful-wait-before-shutdown`, reject new connections and close connections that have finished transactions, until `graceful-close-conn-timeout` ends

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
