### PR TITLE
router, backend: check target health before redirection

### DIFF
--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -21,12 +21,12 @@ import (
 
 type BackendStatus int
 
-func (bs *BackendStatus) ToScore() int {
-	return statusScores[*bs]
+func (bs BackendStatus) ToScore() int {
+	return statusScores[bs]
 }
 
-func (bs *BackendStatus) String() string {
-	status, ok := statusNames[*bs]
+func (bs BackendStatus) String() string {
+	status, ok := statusNames[bs]
 	if !ok {
 		return "unknown"
 	}

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -5,6 +5,7 @@ package backend
 
 import (
 	"crypto/tls"
+	"fmt"
 	"testing"
 
 	gomysql "github.com/go-mysql-org/go-mysql/mysql"
@@ -42,14 +43,16 @@ type mockProxy struct {
 	// execution results
 	err         error
 	logger      *zap.Logger
+	text        fmt.Stringer
 	holdRequest bool
 }
 
 func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
-	lg, _ := logger.CreateLoggerForTest(t)
+	lg, text := logger.CreateLoggerForTest(t)
 	mp := &mockProxy{
 		proxyConfig:        cfg,
 		logger:             lg.Named("mockProxy"),
+		text:               text,
 		BackendConnManager: NewBackendConnManager(lg, cfg.handler, cfg.connectionID, cfg.bcConfig),
 	}
 	mp.cmdProcessor.capability = cfg.capability


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #408

Problem Summary:
- When the connection begins redirection, the target backend may become unhealthy. This will introduce unnecessary errors.
- In `ensureBackend`, the newly added backend may be removed by `adjustBackendList`.

What is changed and how it works:
- Pass `BackendInst` interface (instead of addr) to the `BackendConnMgr` in `Redirect()`
- Check the health by `BackendInst.Healthy()` before redirection. If it's unhealthy, abort redirection
- Add locks to `backendWrapper` because `status` may be read and written concurrently
- Add a parameter `removeEmpty` to `adjustBackendList` and pass `false` to it in `ensureBackend`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
