### PR TITLE
backend, net: replace tidb/parser/mysql

### DIFF
--- a/pkg/proxy/backend/authenticator_test.go
+++ b/pkg/proxy/backend/authenticator_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pingcap/tidb/parser/mysql"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/stretchr/testify/require"
 )
@@ -107,18 +106,18 @@ func TestAuthPlugin(t *testing.T) {
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.clientConfig.authPlugin = mysql.AuthNativePassword
+				cfg.clientConfig.authPlugin = pnet.AuthNativePassword
 			},
 			func(cfg *testConfig) {
-				cfg.clientConfig.authPlugin = mysql.AuthCachingSha2Password
+				cfg.clientConfig.authPlugin = pnet.AuthCachingSha2Password
 			},
 		},
 		{
 			func(cfg *testConfig) {
-				cfg.backendConfig.authPlugin = mysql.AuthNativePassword
+				cfg.backendConfig.authPlugin = pnet.AuthNativePassword
 			},
 			func(cfg *testConfig) {
-				cfg.backendConfig.authPlugin = mysql.AuthCachingSha2Password
+				cfg.backendConfig.authPlugin = pnet.AuthCachingSha2Password
 			},
 		},
 		{

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -18,7 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/cenkalti/backoff/v4"
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -264,7 +264,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 		mgr.handshakeHandler.OnTraffic(mgr)
 	}()
 	if len(request) < 1 {
-		err = gomysql.ErrMalformPacket
+		err = mysql.ErrMalformPacket
 		return
 	}
 	cmd := pnet.Command(request[0])
@@ -304,7 +304,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 				mgr.authenticator.capability &^= pnet.ClientMultiStatements
 				mgr.cmdProcessor.capability &^= pnet.ClientMultiStatements
 			default:
-				err = errors.Wrapf(gomysql.ErrMalformPacket, "unrecognized set_option value:%d", val)
+				err = errors.Wrapf(mysql.ErrMalformPacket, "unrecognized set_option value:%d", val)
 				return
 			}
 		case pnet.ComChangeUser:
@@ -359,7 +359,7 @@ func (mgr *BackendConnManager) initSessionStates(backendIO *pnet.PacketIO, sessi
 
 func (mgr *BackendConnManager) querySessionStates(backendIO *pnet.PacketIO) (sessionStates, sessionToken string, err error) {
 	// Do not lock here because the caller already locks.
-	var result *gomysql.Resultset
+	var result *mysql.Resultset
 	if result, _, err = mgr.cmdProcessor.query(backendIO, sqlQueryState); err != nil {
 		return
 	}

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -202,7 +201,7 @@ func (ts *backendMgrTester) respondWithNoTxn4Backend(packetIO *pnet.PacketIO) er
 
 func (ts *backendMgrTester) startTxn4Backend(packetIO *pnet.PacketIO) error {
 	ts.mb.respondType = responseTypeOK
-	ts.mb.status = mysql.ServerStatusInTrans
+	ts.mb.status = pnet.ServerStatusInTrans
 	return ts.mb.respond(packetIO)
 }
 

--- a/pkg/proxy/backend/cmd_processor.go
+++ b/pkg/proxy/backend/cmd_processor.go
@@ -6,7 +6,6 @@ package backend
 import (
 	"encoding/binary"
 
-	"github.com/pingcap/tidb/parser/mysql"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"go.uber.org/zap"
 )
@@ -58,7 +57,7 @@ func (cp *CmdProcessor) updateServerStatus(request []byte, serverStatus uint16) 
 }
 
 func (cp *CmdProcessor) updateTxnStatus(serverStatus uint16) {
-	if serverStatus&mysql.ServerStatusInTrans > 0 {
+	if serverStatus&pnet.ServerStatusInTrans > 0 {
 		cp.serverStatus |= StatusInTrans
 	} else {
 		cp.serverStatus &^= StatusInTrans
@@ -84,11 +83,11 @@ func (cp *CmdProcessor) updatePrepStmtStatus(request []byte, serverStatus uint16
 	case pnet.ComStmtSendLongData:
 		prepStmtStatus = StatusPrepareWaitExecute
 	case pnet.ComStmtExecute:
-		if serverStatus&mysql.ServerStatusCursorExists > 0 {
+		if serverStatus&pnet.ServerStatusCursorExists > 0 {
 			prepStmtStatus = StatusPrepareWaitFetch
 		}
 	case pnet.ComStmtFetch:
-		if serverStatus&mysql.ServerStatusLastRowSend == 0 {
+		if serverStatus&pnet.ServerStatusLastRowSend == 0 {
 			prepStmtStatus = StatusPrepareWaitFetch
 		}
 	}

--- a/pkg/proxy/backend/cmd_processor_test.go
+++ b/pkg/proxy/backend/cmd_processor_test.go
@@ -6,7 +6,6 @@ package backend
 import (
 	"testing"
 
-	"github.com/pingcap/tidb/parser/mysql"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/stretchr/testify/require"
 )
@@ -303,7 +302,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 			},
 			canRedirect: false,
@@ -316,7 +315,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 			},
 			canRedirect: false,
@@ -328,13 +327,13 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 			},
 			canRedirect: false,
@@ -346,13 +345,13 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusLastRowSend
+					cfg.backendConfig.status = pnet.ServerStatusLastRowSend
 				},
 			},
 			canRedirect: true,
@@ -364,7 +363,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
@@ -381,20 +380,20 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtExecute
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusLastRowSend
+					cfg.backendConfig.status = pnet.ServerStatusLastRowSend
 				},
 			},
 			canRedirect: false,
@@ -411,13 +410,13 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusLastRowSend
+					cfg.backendConfig.status = pnet.ServerStatusLastRowSend
 				},
 			},
 			canRedirect: false,
@@ -491,7 +490,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtClose
@@ -508,7 +507,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtReset
@@ -525,7 +524,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtClose
@@ -542,7 +541,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtReset
@@ -565,7 +564,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComResetConnection
@@ -586,7 +585,7 @@ func TestPreparedStmts(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 2
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComChangeUser
@@ -619,7 +618,7 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 			},
 			canRedirect: false,
@@ -629,7 +628,7 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 			},
 			canRedirect: false,
@@ -639,7 +638,7 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
@@ -654,12 +653,12 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			canRedirect: true,
@@ -669,12 +668,12 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComChangeUser
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			canRedirect: true,
@@ -684,12 +683,12 @@ func TestTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComResetConnection
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			canRedirect: true,
@@ -718,13 +717,13 @@ func TestMixPrepAndTxnStatus(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtExecute
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusInTrans
 				},
 			},
 			canRedirect: false,
@@ -736,13 +735,13 @@ func TestMixPrepAndTxnStatus(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusLastRowSend
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusLastRowSend
 				},
 			},
 			canRedirect: false,
@@ -754,7 +753,7 @@ func TestMixPrepAndTxnStatus(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
@@ -772,12 +771,12 @@ func TestMixPrepAndTxnStatus(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComResetConnection
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			canRedirect: true,
@@ -789,13 +788,13 @@ func TestMixPrepAndTxnStatus(t *testing.T) {
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtFetch
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.respondType = responseTypeRow
-					cfg.backendConfig.status = mysql.ServerStatusInTrans | mysql.ServerStatusLastRowSend
+					cfg.backendConfig.status = pnet.ServerStatusInTrans | pnet.ServerStatusLastRowSend
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtExecute
@@ -830,14 +829,14 @@ func TestHoldRequest(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.clientConfig.sql = "begin"
 					cfg.proxyConfig.waitRedirect = true
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 					cfg.backendConfig.loops = 2
 				},
 			},
@@ -849,14 +848,14 @@ func TestHoldRequest(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.clientConfig.sql = "commit"
 					cfg.proxyConfig.waitRedirect = true
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			holdRequest: false,
@@ -867,14 +866,14 @@ func TestHoldRequest(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtExecute
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit
 				},
 			},
 			holdRequest: false,
@@ -885,21 +884,21 @@ func TestHoldRequest(t *testing.T) {
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComStmtExecute
 					cfg.clientConfig.prepStmtID = 1
 					cfg.backendConfig.columns = 1
 					cfg.backendConfig.respondType = responseTypeResultSet
-					cfg.backendConfig.status = mysql.ServerStatusCursorExists
+					cfg.backendConfig.status = pnet.ServerStatusCursorExists
 				},
 				func(cfg *testConfig) {
 					cfg.clientConfig.cmd = pnet.ComQuery
 					cfg.clientConfig.sql = "begin"
 					cfg.proxyConfig.waitRedirect = true
 					cfg.backendConfig.respondType = responseTypeOK
-					cfg.backendConfig.status = mysql.ServerStatusAutocommit | mysql.ServerStatusInTrans
+					cfg.backendConfig.status = pnet.ServerStatusAutocommit | pnet.ServerStatusInTrans
 				},
 			},
 			holdRequest: false,

--- a/pkg/proxy/backend/error.go
+++ b/pkg/proxy/backend/error.go
@@ -4,7 +4,7 @@
 package backend
 
 import (
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 )
@@ -107,7 +107,7 @@ func Error2Source(err error) ErrorSource {
 	}
 	switch {
 	// ErrInvalidSequence and ErrMalformPacket may be wrapped with other errors such as ErrBackendHandshake.
-	case errors.Is(err, pnet.ErrInvalidSequence), errors.Is(err, gomysql.ErrMalformPacket):
+	case errors.Is(err, pnet.ErrInvalidSequence), errors.Is(err, mysql.ErrMalformPacket):
 		// We assume the clients and TiDB are right and treat it as TiProxy bugs.
 		return SrcProxyMalformed
 	case errors.Is(err, ErrClientHandshake), errors.Is(err, ErrClientCap):

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -4,7 +4,7 @@
 package backend
 
 import (
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/pkg/manager/namespace"
 	"github.com/pingcap/tiproxy/pkg/manager/router"
@@ -38,7 +38,7 @@ type ConnContext interface {
 
 type HandshakeHandler interface {
 	HandleHandshakeResp(ctx ConnContext, resp *pnet.HandshakeResp) error
-	HandleHandshakeErr(ctx ConnContext, err *gomysql.MyError) bool // return true means retry connect
+	HandleHandshakeErr(ctx ConnContext, err *mysql.MyError) bool // return true means retry connect
 	GetRouter(ctx ConnContext, resp *pnet.HandshakeResp) (router.Router, error)
 	OnHandshake(ctx ConnContext, to string, err error, src ErrorSource)
 	OnConnClose(ctx ConnContext, src ErrorSource) error
@@ -61,7 +61,7 @@ func (handler *DefaultHandshakeHandler) HandleHandshakeResp(ConnContext, *pnet.H
 	return nil
 }
 
-func (handler *DefaultHandshakeHandler) HandleHandshakeErr(ctx ConnContext, err *gomysql.MyError) bool {
+func (handler *DefaultHandshakeHandler) HandleHandshakeErr(ctx ConnContext, err *mysql.MyError) bool {
 	return false
 }
 
@@ -110,7 +110,7 @@ type CustomHandshakeHandler struct {
 	onTraffic           func(ConnContext)
 	onConnClose         func(ConnContext, ErrorSource) error
 	handleHandshakeResp func(ctx ConnContext, resp *pnet.HandshakeResp) error
-	handleHandshakeErr  func(ctx ConnContext, err *gomysql.MyError) bool
+	handleHandshakeErr  func(ctx ConnContext, err *mysql.MyError) bool
 	getCapability       func() pnet.Capability
 	getServerVersion    func() string
 }
@@ -148,7 +148,7 @@ func (h *CustomHandshakeHandler) HandleHandshakeResp(ctx ConnContext, resp *pnet
 	return nil
 }
 
-func (h *CustomHandshakeHandler) HandleHandshakeErr(ctx ConnContext, err *gomysql.MyError) bool {
+func (h *CustomHandshakeHandler) HandleHandshakeErr(ctx ConnContext, err *mysql.MyError) bool {
 	if h.handleHandshakeErr != nil {
 		return h.handleHandshakeErr(ctx, err)
 	}

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"go.uber.org/zap"
@@ -39,7 +39,7 @@ type mockProxy struct {
 
 	*proxyConfig
 	// outputs that received from the server.
-	rs *gomysql.Resultset
+	rs *mysql.Resultset
 	// execution results
 	err         error
 	logger      *zap.Logger

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -24,7 +24,7 @@ const (
 var (
 	ServerVersion = mysql.ServerVersion
 	Collation     = uint8(mysql.DefaultCollationID)
-	Status        = mysql.ServerStatusAutocommit
+	Status        = ServerStatusAutocommit
 )
 
 // ParseInitialHandshake parses the initial handshake received from the server.
@@ -365,7 +365,7 @@ func ReadServerVersion(conn net.Conn) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if data[0] == gomysql.ERR_HEADER {
+	if data[0] == ErrHeader.Byte() {
 		return "", errors.New("read initial handshake error")
 	}
 	pos := 1

--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -6,7 +6,7 @@ package net
 import (
 	"testing"
 
-	gomysql "github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestLogAttrs(t *testing.T) {
 }
 
 func TestMySQLError(t *testing.T) {
-	myerr := &gomysql.MyError{}
+	myerr := &mysql.MyError{}
 	require.True(t, IsMySQLError(errors.Wrap(ErrHandshakeTLS, myerr)))
 	require.False(t, IsMySQLError(errors.Wrap(myerr, ErrHandshakeTLS)))
 	require.False(t, IsMySQLError(ErrHandshakeTLS))

--- a/pkg/proxy/net/server_status.go
+++ b/pkg/proxy/net/server_status.go
@@ -1,0 +1,20 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package net
+
+// Server information.
+const (
+	ServerStatusInTrans            uint16 = 0x0001
+	ServerStatusAutocommit         uint16 = 0x0002
+	ServerMoreResultsExists        uint16 = 0x0008
+	ServerStatusNoGoodIndexUsed    uint16 = 0x0010
+	ServerStatusNoIndexUsed        uint16 = 0x0020
+	ServerStatusCursorExists       uint16 = 0x0040
+	ServerStatusLastRowSend        uint16 = 0x0080
+	ServerStatusDBDropped          uint16 = 0x0100
+	ServerStatusNoBackslashEscaped uint16 = 0x0200
+	ServerStatusMetadataChanged    uint16 = 0x0400
+	ServerStatusWasSlow            uint16 = 0x0800
+	ServerPSOutParams              uint16 = 0x1000
+)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #358

Problem Summary:
Using `tidb/parser/mysql`, `go-mysql-org/go-mysql/mysql`, and `pnet` at the same time may cause problems, such as `errors.Is(err, mysql.ErrMalformPacket)` may unexpectedly return false.

What is changed and how it works:
- Add `server_status.go`
- Replace most of the usage of `tidb/parser/mysql` with `go-mysql-org/go-mysql/mysql` and `pnet`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Code refactor, no tests.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
