### PR TITLE
config: move require-backend-tls from proxy to security

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -3,7 +3,6 @@
 [proxy]
 # addr = "0.0.0.0:6000"
 # tcp-keep-alive = true
-# require-backend-tls = true
 
 # possible values:
 #   "" => disable proxy protocol.
@@ -107,6 +106,8 @@ graceful-close-conn-timeout = 15
 	[security.server-http-tls]
 	# proxy HTTP port will use this
 	# auto-certs = true
+
+# require-backend-tls = false
 
 [metrics]
 

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -46,7 +46,6 @@ type KeepAlive struct {
 }
 
 type ProxyServerOnline struct {
-	RequireBackendTLS bool      `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
 	MaxConnections    uint64    `yaml:"max-connections,omitempty" toml:"max-connections,omitempty" json:"max-connections,omitempty"`
 	ConnBufferSize    int       `yaml:"conn-buffer-size,omitempty" toml:"conn-buffer-size,omitempty" json:"conn-buffer-size,omitempty"`
 	FrontendKeepalive KeepAlive `yaml:"frontend-keepalive" toml:"frontend-keepalive" json:"frontend-keepalive"`
@@ -113,10 +112,11 @@ func (c TLSConfig) HasCA() bool {
 }
 
 type Security struct {
-	ServerSQLTLS  TLSConfig `yaml:"server-tls,omitempty" toml:"server-tls,omitempty" json:"server-tls,omitempty"`
-	ServerHTTPTLS TLSConfig `yaml:"server-http-tls,omitempty" toml:"server-http-tls,omitempty" json:"server-http-tls,omitempty"`
-	ClusterTLS    TLSConfig `yaml:"cluster-tls,omitempty" toml:"cluster-tls,omitempty" json:"cluster-tls,omitempty"`
-	SQLTLS        TLSConfig `yaml:"sql-tls,omitempty" toml:"sql-tls,omitempty" json:"sql-tls,omitempty"`
+	ServerSQLTLS      TLSConfig `yaml:"server-tls,omitempty" toml:"server-tls,omitempty" json:"server-tls,omitempty"`
+	ServerHTTPTLS     TLSConfig `yaml:"server-http-tls,omitempty" toml:"server-http-tls,omitempty" json:"server-http-tls,omitempty"`
+	ClusterTLS        TLSConfig `yaml:"cluster-tls,omitempty" toml:"cluster-tls,omitempty" json:"cluster-tls,omitempty"`
+	SQLTLS            TLSConfig `yaml:"sql-tls,omitempty" toml:"sql-tls,omitempty" json:"sql-tls,omitempty"`
+	RequireBackendTLS bool      `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
 }
 
 func DefaultKeepAlive() (frontend, backendHealthy, backendUnhealthy KeepAlive) {
@@ -139,7 +139,6 @@ func NewConfig() *Config {
 
 	cfg.Proxy.Addr = "0.0.0.0:6000"
 	cfg.Proxy.FrontendKeepalive, cfg.Proxy.BackendHealthyKeepalive, cfg.Proxy.BackendUnhealthyKeepalive = DefaultKeepAlive()
-	cfg.Proxy.RequireBackendTLS = true
 	cfg.Proxy.PDAddrs = "127.0.0.1:2379"
 	cfg.Proxy.GracefulCloseConnTimeout = 15
 

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -21,7 +21,6 @@ var testProxyConfig = Config{
 		Addr:    "0.0.0.0:4000",
 		PDAddrs: "127.0.0.1:4089",
 		ProxyServerOnline: ProxyServerOnline{
-			RequireBackendTLS:          true,
 			MaxConnections:             1,
 			FrontendKeepalive:          KeepAlive{Enabled: true},
 			ProxyProtocol:              "v2",
@@ -75,6 +74,7 @@ var testProxyConfig = Config{
 			Cert:               "b",
 			Key:                "c",
 		},
+		RequireBackendTLS: true,
 	},
 }
 

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -23,7 +23,6 @@ func TestConfig(t *testing.T) {
 [proxy]
 addr = '0.0.0.0:6000'
 pd-addrs = '127.0.0.1:2379'
-require-backend-tls = true
 graceful-close-conn-timeout = 15
 
 [proxy.frontend-keepalive]
@@ -76,12 +75,12 @@ max-backups = 3
 	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","require-backend-tls":true,"frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.1"},"server-http-tls":{"min-tls-version":"1.1"},"cluster-tls":{"min-tls-version":"1.1"},"sql-tls":{"min-tls-version":"1.1"}},"metrics":{"metrics-addr":"","metrics-interval":0},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
+		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.1"},"server-http-tls":{"min-tls-version":"1.1"},"cluster-tls":{"min-tls-version":"1.1"},"sql-tls":{"min-tls-version":"1.1"}},"metrics":{"metrics-addr":"","metrics-interval":0},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
 			string(regexp.MustCompile(`"workdir":"[^"]+",`).ReplaceAll(all, nil)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("proxy.require-backend-tls = false"), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = true"), func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	sum := ""
@@ -102,7 +101,7 @@ max-backups = 3
 		require.Equal(t, sum, string(sumreg.Find(all)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("proxy.require-backend-tls = true"), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = false"), func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -133,7 +133,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		} else {
 			hsHandler = backend.NewDefaultHandshakeHandler(srv.NamespaceManager)
 		}
-		srv.Proxy, err = proxy.NewSQLServer(lg.Named("proxy"), cfg.Proxy, srv.CertManager, hsHandler)
+		srv.Proxy, err = proxy.NewSQLServer(lg.Named("proxy"), cfg, srv.CertManager, hsHandler)
 		if err != nil {
 			err = errors.WithStack(err)
 			return


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #411

Problem Summary:
- `require-backend-tls` is more like a security config
- `require-backend-tls` is true by default, which causes some compatible problems when updating it

What is changed and how it works:
- Move `require-backend-tls` from `proxy` section to `security`
- Change the default value of `require-backend-tls` to false

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```shell
tiup playground v7.5.0 --tiproxy 1 --tiproxy.binpath /Users/zhangming/gopath/src/github.com/pingcap/tiproxy/bin/tiproxy --tiproxy.config cfg --tiflash 0

cat cfg
[proxy]
  require-backend-tls = false
```

This proves that it's compatible with the previous config.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
