### PR TITLE
router: add customized health check function

### DIFF
--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -40,7 +40,9 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
 	rt := router.NewScoreBasedRouter(logger.Named("router"))
-	if err := rt.Init(mgr.httpCli, fetcher, config.NewDefaultHealthCheckConfig()); err != nil {
+	healthCheckCfg := config.NewDefaultHealthCheckConfig()
+	hc := router.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
+	if err := rt.Init(fetcher, hc, healthCheckCfg); err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}
 	return &Namespace{

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -6,17 +6,16 @@ package router
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/http"
-	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+<<<<<<< Updated upstream
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+=======
+>>>>>>> Stashed changes
 	"go.uber.org/zap"
 )
 
@@ -58,31 +57,29 @@ var statusScores = map[BackendStatus]int{
 	StatusSchemaOutdated: 10000000,
 }
 
-type backendHealth struct {
-	status        BackendStatus
-	pingErr       error
-	serverVersion string
+type BackendHealth struct {
+	Status BackendStatus
+	// The error occurred when backends check fails. It's used to log why the backend becomes unhealthy.
+	PingErr error
+	// The backend version that returned to the client during handshake.
+	ServerVersion string
 }
 
-func (bh *backendHealth) String() string {
-	str := fmt.Sprintf("status: %s", bh.status.String())
-	if bh.pingErr != nil {
-		str += fmt.Sprintf(", err: %s", bh.pingErr.Error())
+func (bh *BackendHealth) String() string {
+	str := fmt.Sprintf("Status: %s", bh.Status.String())
+	if bh.PingErr != nil {
+		str += fmt.Sprintf(", err: %s", bh.PingErr.Error())
 	}
 	return str
 }
 
-const (
-	statusPathSuffix = "/status"
-)
-
-// BackendEventReceiver receives the event of backend status change.
+// BackendEventReceiver receives the event of backend Status change.
 type BackendEventReceiver interface {
 	// OnBackendChanged is called when the backend list changes.
-	OnBackendChanged(backends map[string]*backendHealth, err error)
+	OnBackendChanged(backends map[string]*BackendHealth, err error)
 }
 
-// BackendInfo stores the status info of each backend.
+// BackendInfo stores the Status info of each backend.
 type BackendInfo struct {
 	IP         string
 	StatusPort uint
@@ -92,11 +89,10 @@ type BackendInfo struct {
 type BackendObserver struct {
 	logger            *zap.Logger
 	healthCheckConfig *config.HealthCheck
-	// The current backend status synced to the receiver.
-	curBackendInfo map[string]*backendHealth
+	// The current backend Status synced to the receiver.
+	curBackendInfo map[string]*BackendHealth
 	fetcher        BackendFetcher
-	httpCli        *http.Client
-	httpTLS        bool
+	hc             HealthCheck
 	eventReceiver  BackendEventReceiver
 	wg             waitgroup.WaitGroup
 	cancelFunc     context.CancelFunc
@@ -104,37 +100,26 @@ type BackendObserver struct {
 }
 
 // StartBackendObserver creates a BackendObserver and starts watching.
-func StartBackendObserver(logger *zap.Logger, eventReceiver BackendEventReceiver, httpCli *http.Client,
-	config *config.HealthCheck, backendFetcher BackendFetcher) (*BackendObserver, error) {
-	bo, err := NewBackendObserver(logger, eventReceiver, httpCli, config, backendFetcher)
-	if err != nil {
-		return nil, err
-	}
+func StartBackendObserver(logger *zap.Logger, eventReceiver BackendEventReceiver, config *config.HealthCheck,
+	backendFetcher BackendFetcher, hc HealthCheck) *BackendObserver {
+	bo := NewBackendObserver(logger, eventReceiver, config, backendFetcher, hc)
 	bo.Start()
-	return bo, nil
+	return bo
 }
 
 // NewBackendObserver creates a BackendObserver.
-func NewBackendObserver(logger *zap.Logger, eventReceiver BackendEventReceiver, httpCli *http.Client,
-	config *config.HealthCheck, backendFetcher BackendFetcher) (*BackendObserver, error) {
-	if httpCli == nil {
-		httpCli = http.DefaultClient
-	}
-	httpTLS := false
-	if v, ok := httpCli.Transport.(*http.Transport); ok && v != nil && v.TLSClientConfig != nil {
-		httpTLS = true
-	}
+func NewBackendObserver(logger *zap.Logger, eventReceiver BackendEventReceiver, config *config.HealthCheck,
+	backendFetcher BackendFetcher, hc HealthCheck) *BackendObserver {
 	bo := &BackendObserver{
 		logger:            logger,
 		healthCheckConfig: config,
-		curBackendInfo:    make(map[string]*backendHealth),
-		httpCli:           httpCli,
-		httpTLS:           httpTLS,
+		curBackendInfo:    make(map[string]*BackendHealth),
+		hc:                hc,
 		eventReceiver:     eventReceiver,
 		refreshChan:       make(chan struct{}),
+		fetcher:           backendFetcher,
 	}
-	bo.fetcher = backendFetcher
-	return bo, nil
+	return bo
 }
 
 // Start starts watching.
@@ -184,117 +169,46 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 	}
 }
 
-func (bo *BackendObserver) connectWithRetry(ctx context.Context, connect func() error) error {
-	err := backoff.Retry(func() error {
-		err := connect()
-		if !isRetryableError(err) {
-			return backoff.Permanent(err)
-		}
-		return err
-	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(bo.healthCheckConfig.RetryInterval), uint64(bo.healthCheckConfig.MaxRetries)), ctx))
-	return err
-}
-
-func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]*BackendInfo) map[string]*backendHealth {
-	curBackendHealth := make(map[string]*backendHealth, len(backends))
+func (bo *BackendObserver) checkHealth(ctx context.Context, backends map[string]*BackendInfo) map[string]*BackendHealth {
+	curBackendHealth := make(map[string]*BackendHealth, len(backends))
 	for addr, info := range backends {
-		bh := &backendHealth{
-			status: StatusHealthy,
-		}
-		curBackendHealth[addr] = bh
-		if !bo.healthCheckConfig.Enable {
-			continue
-		}
 		if ctx.Err() != nil {
 			return nil
 		}
-
-		// Skip checking the status port if it's not fetched.
-		if info != nil && len(info.IP) > 0 {
-			// When a backend gracefully shut down, the status port returns 500 but the SQL port still accepts
-			// new connections, so we must check the status port first.
-			schema := "http"
-			if bo.httpTLS {
-				schema = "https"
-			}
-			httpCli := *bo.httpCli
-			httpCli.Timeout = bo.healthCheckConfig.DialTimeout
-			url := fmt.Sprintf("%s://%s:%d%s", schema, info.IP, info.StatusPort, statusPathSuffix)
-			err := bo.connectWithRetry(ctx, func() error {
-				resp, err := httpCli.Get(url)
-				if err == nil {
-					if resp.StatusCode != http.StatusOK {
-						err = backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
-					}
-					if ignoredErr := resp.Body.Close(); ignoredErr != nil {
-						bo.logger.Warn("close http response in health check failed", zap.Error(ignoredErr))
-					}
-				}
-				return err
-			})
-			if err != nil {
-				bh.status = StatusCannotConnect
-				bh.pingErr = errors.Wrapf(err, "connect status port failed")
-				continue
-			}
-		}
-
-		// Also dial the SQL port just in case that the SQL port hangs.
-		var serverVersion string
-		err := bo.connectWithRetry(ctx, func() error {
-			startTime := time.Now()
-			conn, err := net.DialTimeout("tcp", addr, bo.healthCheckConfig.DialTimeout)
-			setPingBackendMetrics(addr, err == nil, startTime)
-			if err != nil {
-				return err
-			}
-			if err = conn.SetReadDeadline(time.Now().Add(bo.healthCheckConfig.DialTimeout)); err != nil {
-				return err
-			}
-			serverVersion, err = pnet.ReadServerVersion(conn)
-			if ignoredErr := conn.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
-				bo.logger.Warn("close connection in health check failed", zap.Error(ignoredErr))
-			}
-			bh.serverVersion = serverVersion
-			return err
-		})
-		if err != nil {
-			bh.status = StatusCannotConnect
-			bh.pingErr = errors.Wrapf(err, "connect sql port failed")
-		}
+		curBackendHealth[addr] = bo.hc.Check(ctx, addr, info)
 	}
 	return curBackendHealth
 }
 
-func (bo *BackendObserver) notifyIfChanged(bhMap map[string]*backendHealth) {
-	updatedBackends := make(map[string]*backendHealth)
+func (bo *BackendObserver) notifyIfChanged(bhMap map[string]*BackendHealth) {
+	updatedBackends := make(map[string]*BackendHealth)
 	for addr, lastHealth := range bo.curBackendInfo {
-		if lastHealth.status == StatusHealthy {
+		if lastHealth.Status == StatusHealthy {
 			if newHealth, ok := bhMap[addr]; !ok {
-				updatedBackends[addr] = &backendHealth{
-					status:  StatusCannotConnect,
-					pingErr: errors.New("removed from backend list"),
+				updatedBackends[addr] = &BackendHealth{
+					Status:  StatusCannotConnect,
+					PingErr: errors.New("removed from backend list"),
 				}
-				updateBackendStatusMetrics(addr, lastHealth.status, StatusCannotConnect)
-			} else if newHealth.status != StatusHealthy {
+				updateBackendStatusMetrics(addr, lastHealth.Status, StatusCannotConnect)
+			} else if newHealth.Status != StatusHealthy {
 				updatedBackends[addr] = newHealth
-				updateBackendStatusMetrics(addr, lastHealth.status, newHealth.status)
+				updateBackendStatusMetrics(addr, lastHealth.Status, newHealth.Status)
 			}
 		}
 	}
 	for addr, newHealth := range bhMap {
-		if newHealth.status == StatusHealthy {
+		if newHealth.Status == StatusHealthy {
 			lastHealth, ok := bo.curBackendInfo[addr]
 			if !ok {
-				lastHealth = &backendHealth{
-					status: StatusCannotConnect,
+				lastHealth = &BackendHealth{
+					Status: StatusCannotConnect,
 				}
 			}
-			if lastHealth.status != StatusHealthy {
+			if lastHealth.Status != StatusHealthy {
 				updatedBackends[addr] = newHealth
-				updateBackendStatusMetrics(addr, lastHealth.status, newHealth.status)
-			} else if lastHealth.serverVersion != newHealth.serverVersion {
-				// Not possible here: the backend finishes upgrading between two health checks.
+				updateBackendStatusMetrics(addr, lastHealth.Status, newHealth.Status)
+			} else if lastHealth.ServerVersion != newHealth.ServerVersion {
+				// Not possible here: the backend finishes upgrading between two backends checks.
 				updatedBackends[addr] = newHealth
 			}
 		}
@@ -310,22 +224,4 @@ func (bo *BackendObserver) Close() {
 		bo.cancelFunc()
 	}
 	bo.wg.Wait()
-}
-
-// When the server refused to connect, the port is shut down, so no need to retry.
-var notRetryableError = []string{
-	"connection refused",
-}
-
-func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	for _, errStr := range notRetryableError {
-		if strings.Contains(msg, errStr) {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -11,11 +11,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
-<<<<<<< Updated upstream
 	"github.com/pingcap/tiproxy/pkg/metrics"
-	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
-=======
->>>>>>> Stashed changes
 	"go.uber.org/zap"
 )
 

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -5,26 +5,23 @@ package router
 
 import (
 	"context"
-	"net"
-	"net/http"
-	"strconv"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
-	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
 
 type mockEventReceiver struct {
-	backendChan chan map[string]*backendHealth
+	backendChan chan map[string]*BackendHealth
 	errChan     chan error
 }
 
-func (mer *mockEventReceiver) OnBackendChanged(backends map[string]*backendHealth, err error) {
+func (mer *mockEventReceiver) OnBackendChanged(backends map[string]*BackendHealth, err error) {
 	if err != nil {
 		mer.errChan <- err
 	} else if len(backends) > 0 {
@@ -32,7 +29,7 @@ func (mer *mockEventReceiver) OnBackendChanged(backends map[string]*backendHealt
 	}
 }
 
-func newMockEventReceiver(backendChan chan map[string]*backendHealth, errChan chan error) *mockEventReceiver {
+func newMockEventReceiver(backendChan chan map[string]*BackendHealth, errChan chan error) *mockEventReceiver {
 	return &mockEventReceiver{
 		backendChan: backendChan,
 		errChan:     errChan,
@@ -49,7 +46,7 @@ func newHealthCheckConfigForTest() *config.HealthCheck {
 	}
 }
 
-// Test that the notified backend status is correct when the backend starts or shuts down.
+// Test that the notified backend Status is correct when the backend starts or shuts down.
 func TestObserveBackends(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	t.Cleanup(ts.close)
@@ -57,21 +54,9 @@ func TestObserveBackends(t *testing.T) {
 
 	backend1 := ts.addBackend()
 	ts.checkStatus(backend1, StatusHealthy)
-	backend1.stopSQLServer()
+	ts.setHealth(backend1, StatusCannotConnect)
 	ts.checkStatus(backend1, StatusCannotConnect)
-	backend1.startSQLServer()
-	ts.checkStatus(backend1, StatusHealthy)
-	backend1.setHTTPResp(false)
-	ts.checkStatus(backend1, StatusCannotConnect)
-	backend1.setHTTPResp(true)
-	ts.checkStatus(backend1, StatusHealthy)
-	backend1.setHTTPWait(ts.bo.healthCheckConfig.DialTimeout + time.Second)
-	ts.checkStatus(backend1, StatusCannotConnect)
-	backend1.setHTTPWait(time.Duration(0))
-	ts.checkStatus(backend1, StatusHealthy)
-	backend1.stopHTTPServer()
-	ts.checkStatus(backend1, StatusCannotConnect)
-	backend1.startHTTPServer()
+	ts.setHealth(backend1, StatusHealthy)
 	ts.checkStatus(backend1, StatusHealthy)
 
 	backend2 := ts.addBackend()
@@ -79,23 +64,21 @@ func TestObserveBackends(t *testing.T) {
 	ts.removeBackend(backend2)
 	ts.checkStatus(backend2, StatusCannotConnect)
 
-	backend1.close()
+	ts.setHealth(backend1, StatusCannotConnect)
 	ts.checkStatus(backend1, StatusCannotConnect)
-	backend2.close()
 }
 
-// Test that the health check can exit when the context is cancelled.
+// Test that the backends check can exit when the context is cancelled.
 func TestCancelObserver(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	t.Cleanup(ts.close)
 
-	backends := make([]*backendServer, 0, 3)
-	for i := 0; i < 3; i++ {
-		backends = append(backends, ts.addBackend())
+	for i := 0; i < 10; i++ {
+		ts.addBackend()
 	}
 	info, err := ts.fetcher.GetBackendList(context.Background())
 	require.NoError(t, err)
-	require.Len(t, info, 3)
+	require.Len(t, info, 10)
 
 	// Try 10 times.
 	for i := 0; i < 10; i++ {
@@ -110,50 +93,29 @@ func TestCancelObserver(t *testing.T) {
 		cancelFunc()
 		wg.Wait()
 	}
-
-	for _, backend := range backends {
-		backend.close()
-	}
-}
-
-func TestReadServerVersion(t *testing.T) {
-	ts := newObserverTestSuite(t)
-	t.Cleanup(ts.close)
-
-	backend1 := ts.addBackend()
-	backend1.serverVersion.Store("1.0")
-	ts.bo.Start()
-	backends := ts.getBackendsFromCh()
-	require.Equal(t, "1.0", backends[backend1.sqlAddr].serverVersion)
-	backend1.stopSQLServer()
-	ts.checkStatus(backend1, StatusCannotConnect)
-	backend1.serverVersion.Store("2.0")
-	backend1.startSQLServer()
-	backends = ts.getBackendsFromCh()
-	require.Equal(t, "2.0", backends[backend1.sqlAddr].serverVersion)
-	backend1.close()
 }
 
 type observerTestSuite struct {
 	t           *testing.T
 	bo          *BackendObserver
+	hc          *mockHealthCheck
 	fetcher     *mockBackendFetcher
-	backendChan chan map[string]*backendHealth
+	backendIdx  int
+	backendChan chan map[string]*BackendHealth
 }
 
 func newObserverTestSuite(t *testing.T) *observerTestSuite {
-	backendChan := make(chan map[string]*backendHealth, 1)
+	backendChan := make(chan map[string]*BackendHealth, 1)
 	mer := newMockEventReceiver(backendChan, make(chan error, 1))
-	fetcher := &mockBackendFetcher{
-		backends: make(map[string]*BackendInfo),
-	}
+	fetcher := newMockBackendFetcher()
+	hc := newMockHealthCheck()
 	lg, _ := logger.CreateLoggerForTest(t)
-	bo, err := NewBackendObserver(lg, mer, nil, newHealthCheckConfigForTest(), fetcher)
-	require.NoError(t, err)
+	bo := NewBackendObserver(lg, mer, newHealthCheckConfigForTest(), fetcher, hc)
 	return &observerTestSuite{
 		t:           t,
 		bo:          bo,
 		fetcher:     fetcher,
+		hc:          hc,
 		backendChan: backendChan,
 	}
 }
@@ -165,21 +127,26 @@ func (ts *observerTestSuite) close() {
 	}
 }
 
-func (ts *observerTestSuite) checkStatus(backend *backendServer, expectedStatus BackendStatus) {
+func (ts *observerTestSuite) checkStatus(addr string, expectedStatus BackendStatus) {
 	backends := ts.getBackendsFromCh()
 	require.Equal(ts.t, 1, len(backends))
-	health, ok := backends[backend.sqlAddr]
+	health, ok := backends[addr]
 	require.True(ts.t, ok)
+<<<<<<< Updated upstream
 	require.Equal(ts.t, expectedStatus, health.status)
 	require.True(ts.t, checkBackendStatusMetrics(backend.sqlAddr, health.status))
 	cycle, err := readHealthCheckCycle()
 	require.NoError(ts.t, err)
 	require.Greater(ts.t, cycle.Nanoseconds(), int64(0))
 	require.Less(ts.t, cycle.Nanoseconds(), 3*time.Second)
+=======
+	require.Equal(ts.t, expectedStatus, health.Status)
+	require.True(ts.t, checkBackendStatusMetrics(addr, health.Status))
+>>>>>>> Stashed changes
 }
 
-func (ts *observerTestSuite) getBackendsFromCh() map[string]*backendHealth {
-	var backends map[string]*backendHealth
+func (ts *observerTestSuite) getBackendsFromCh() map[string]*BackendHealth {
+	var backends map[string]*BackendHealth
 	select {
 	case backends = <-ts.backendChan:
 	case <-time.After(3 * time.Second):
@@ -188,139 +155,57 @@ func (ts *observerTestSuite) getBackendsFromCh() map[string]*backendHealth {
 	return backends
 }
 
-func (ts *observerTestSuite) addBackend() *backendServer {
-	backend := newBackendServer(ts.t)
-	ts.fetcher.backends[backend.sqlAddr] = &BackendInfo{
-		IP:         backend.ip,
-		StatusPort: backend.statusPort,
-	}
-	return backend
+func (ts *observerTestSuite) addBackend() string {
+	ts.backendIdx++
+	addr := fmt.Sprintf("%d", ts.backendIdx)
+	ts.fetcher.setBackend(addr, &BackendInfo{
+		IP:         "127.0.0.1",
+		StatusPort: uint(ts.backendIdx),
+	})
+	ts.hc.setBackend(addr, &BackendHealth{
+		Status: StatusHealthy,
+	})
+	return addr
 }
 
-func (ts *observerTestSuite) removeBackend(backend *backendServer) {
-	delete(ts.fetcher.backends, backend.sqlAddr)
-}
-
-type backendServer struct {
-	t             *testing.T
-	sqlListener   net.Listener
-	sqlAddr       string
-	statusServer  *http.Server
-	statusAddr    string
-	serverVersion atomic.String
-	*mockHttpHandler
-	wg         waitgroup.WaitGroup
-	ip         string
-	statusPort uint
-}
-
-func newBackendServer(t *testing.T) *backendServer {
-	backend := &backendServer{
-		t: t,
-	}
-	backend.startHTTPServer()
-	backend.setHTTPResp(true)
-	backend.startSQLServer()
-	return backend
-}
-
-type mockHttpHandler struct {
-	t      *testing.T
-	httpOK atomic.Bool
-	wait   atomic.Int64
-}
-
-func (handler *mockHttpHandler) setHTTPResp(succeed bool) {
-	handler.httpOK.Store(succeed)
-}
-
-func (handler *mockHttpHandler) setHTTPWait(wait time.Duration) {
-	handler.wait.Store(int64(wait))
-}
-
-func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	wait := handler.wait.Load()
-	if wait > 0 {
-		time.Sleep(time.Duration(wait))
-	}
-	if handler.httpOK.Load() {
-		w.WriteHeader(http.StatusOK)
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
-}
-
-func (srv *backendServer) startHTTPServer() {
-	if srv.mockHttpHandler == nil {
-		srv.mockHttpHandler = &mockHttpHandler{
-			t: srv.t,
-		}
-	}
-	var statusListener net.Listener
-	statusListener, srv.statusAddr = startListener(srv.t, srv.statusAddr)
-	srv.ip, srv.statusPort = parseHostPort(srv.t, srv.statusAddr)
-	srv.statusServer = &http.Server{Addr: srv.statusAddr, Handler: srv.mockHttpHandler}
-	srv.wg.Run(func() {
-		_ = srv.statusServer.Serve(statusListener)
+func (ts *observerTestSuite) setHealth(addr string, health BackendStatus) {
+	ts.hc.setBackend(addr, &BackendHealth{
+		Status: health,
 	})
 }
 
-func (srv *backendServer) stopHTTPServer() {
-	err := srv.statusServer.Close()
-	require.NoError(srv.t, err)
-}
-
-func (srv *backendServer) startSQLServer() {
-	srv.sqlListener, srv.sqlAddr = startListener(srv.t, srv.sqlAddr)
-	srv.wg.Run(func() {
-		for {
-			conn, err := srv.sqlListener.Accept()
-			if err != nil {
-				// listener is closed
-				break
-			}
-			if err = pnet.WriteServerVersion(conn, srv.serverVersion.Load()); err != nil {
-				break
-			}
-			_ = conn.Close()
-		}
-	})
-}
-
-func (srv *backendServer) stopSQLServer() {
-	err := srv.sqlListener.Close()
-	require.NoError(srv.t, err)
-}
-
-func (srv *backendServer) close() {
-	srv.stopHTTPServer()
-	srv.stopSQLServer()
-	srv.wg.Wait()
-}
-
-func startListener(t *testing.T, addr string) (net.Listener, string) {
-	if len(addr) == 0 {
-		addr = "127.0.0.1:0"
-	}
-	listener, err := net.Listen("tcp", addr)
-	require.NoError(t, err)
-	return listener, listener.Addr().String()
-}
-
-func parseHostPort(t *testing.T, addr string) (string, uint) {
-	host, port, err := net.SplitHostPort(addr)
-	require.NoError(t, err)
-	p, err := strconv.ParseUint(port, 10, 32)
-	require.NoError(t, err)
-	return host, uint(p)
+func (ts *observerTestSuite) removeBackend(addr string) {
+	ts.fetcher.removeBackend(addr)
+	ts.hc.removeBackend(addr)
 }
 
 type mockBackendFetcher struct {
+	sync.Mutex
 	backends map[string]*BackendInfo
 }
 
+func newMockBackendFetcher() *mockBackendFetcher {
+	return &mockBackendFetcher{
+		backends: make(map[string]*BackendInfo),
+	}
+}
+
 func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+	mbf.Lock()
+	defer mbf.Unlock()
 	return mbf.backends, nil
+}
+
+func (mbf *mockBackendFetcher) setBackend(addr string, info *BackendInfo) {
+	mbf.Lock()
+	defer mbf.Unlock()
+	mbf.backends[addr] = info
+}
+
+func (mbf *mockBackendFetcher) removeBackend(addr string) {
+	mbf.Lock()
+	defer mbf.Unlock()
+	delete(mbf.backends, addr)
 }
 
 // ExternalFetcher fetches backend list from a given callback.
@@ -337,4 +222,33 @@ func NewExternalFetcher(backendGetter func() ([]string, error)) *ExternalFetcher
 func (ef *ExternalFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
 	addrs, err := ef.backendGetter()
 	return backendListToMap(addrs), err
+}
+
+type mockHealthCheck struct {
+	sync.Mutex
+	backends map[string]*BackendHealth
+}
+
+func newMockHealthCheck() *mockHealthCheck {
+	return &mockHealthCheck{
+		backends: make(map[string]*BackendHealth),
+	}
+}
+
+func (mhc *mockHealthCheck) Check(_ context.Context, addr string, _ *BackendInfo) *BackendHealth {
+	mhc.Lock()
+	defer mhc.Unlock()
+	return mhc.backends[addr]
+}
+
+func (mhc *mockHealthCheck) setBackend(addr string, health *BackendHealth) {
+	mhc.Lock()
+	defer mhc.Unlock()
+	mhc.backends[addr] = health
+}
+
+func (mhc *mockHealthCheck) removeBackend(addr string) {
+	mhc.Lock()
+	defer mhc.Unlock()
+	delete(mhc.backends, addr)
 }

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -132,17 +132,12 @@ func (ts *observerTestSuite) checkStatus(addr string, expectedStatus BackendStat
 	require.Equal(ts.t, 1, len(backends))
 	health, ok := backends[addr]
 	require.True(ts.t, ok)
-<<<<<<< Updated upstream
-	require.Equal(ts.t, expectedStatus, health.status)
-	require.True(ts.t, checkBackendStatusMetrics(backend.sqlAddr, health.status))
+	require.Equal(ts.t, expectedStatus, health.Status)
+	require.True(ts.t, checkBackendStatusMetrics(addr, health.Status))
 	cycle, err := readHealthCheckCycle()
 	require.NoError(ts.t, err)
 	require.Greater(ts.t, cycle.Nanoseconds(), int64(0))
 	require.Less(ts.t, cycle.Nanoseconds(), 3*time.Second)
-=======
-	require.Equal(ts.t, expectedStatus, health.Status)
-	require.True(ts.t, checkBackendStatusMetrics(addr, health.Status))
->>>>>>> Stashed changes
 }
 
 func (ts *observerTestSuite) getBackendsFromCh() map[string]*BackendHealth {

--- a/pkg/manager/router/health_check.go
+++ b/pkg/manager/router/health_check.go
@@ -1,0 +1,143 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"go.uber.org/zap"
+)
+
+// HealthCheck is used to check the backends of one backend. One can pass a customized backends check function to the observer.
+type HealthCheck interface {
+	Check(ctx context.Context, addr string, info *BackendInfo) *BackendHealth
+}
+
+const (
+	statusPathSuffix = "/Status"
+)
+
+type DefaultHealthCheck struct {
+	cfg     *config.HealthCheck
+	logger  *zap.Logger
+	httpCli *http.Client
+	httpTLS bool
+}
+
+func NewDefaultHealthCheck(httpCli *http.Client, cfg *config.HealthCheck, logger *zap.Logger) *DefaultHealthCheck {
+	if httpCli == nil {
+		httpCli = http.DefaultClient
+	}
+	httpTLS := false
+	if v, ok := httpCli.Transport.(*http.Transport); ok && v != nil && v.TLSClientConfig != nil {
+		httpTLS = true
+	}
+	return &DefaultHealthCheck{
+		httpCli: httpCli,
+		httpTLS: httpTLS,
+		cfg:     cfg,
+		logger:  logger,
+	}
+}
+
+func (dhc *DefaultHealthCheck) Check(ctx context.Context, addr string, info *BackendInfo) *BackendHealth {
+	bh := &BackendHealth{
+		Status: StatusHealthy,
+	}
+	if !dhc.cfg.Enable {
+		return bh
+	}
+	// Skip checking the Status port if it's not fetched.
+	if info != nil && len(info.IP) > 0 {
+		// When a backend gracefully shut down, the Status port returns 500 but the SQL port still accepts
+		// new connections, so we must check the Status port first.
+		schema := "http"
+		if dhc.httpTLS {
+			schema = "https"
+		}
+		httpCli := *dhc.httpCli
+		httpCli.Timeout = dhc.cfg.DialTimeout
+		url := fmt.Sprintf("%s://%s:%d%s", schema, info.IP, info.StatusPort, statusPathSuffix)
+		err := dhc.connectWithRetry(ctx, func() error {
+			resp, err := httpCli.Get(url)
+			if err == nil {
+				if resp.StatusCode != http.StatusOK {
+					err = backoff.Permanent(errors.Errorf("http Status %d", resp.StatusCode))
+				}
+				if ignoredErr := resp.Body.Close(); ignoredErr != nil {
+					dhc.logger.Warn("close http response in backends check failed", zap.Error(ignoredErr))
+				}
+			}
+			return err
+		})
+		if err != nil {
+			bh.Status = StatusCannotConnect
+			bh.PingErr = errors.Wrapf(err, "connect Status port failed")
+			return bh
+		}
+	}
+
+	// Also dial the SQL port just in case that the SQL port hangs.
+	var serverVersion string
+	err := dhc.connectWithRetry(ctx, func() error {
+		startTime := time.Now()
+		conn, err := net.DialTimeout("tcp", addr, dhc.cfg.DialTimeout)
+		setPingBackendMetrics(addr, err == nil, startTime)
+		if err != nil {
+			return err
+		}
+		if err = conn.SetReadDeadline(time.Now().Add(dhc.cfg.DialTimeout)); err != nil {
+			return err
+		}
+		serverVersion, err = pnet.ReadServerVersion(conn)
+		if ignoredErr := conn.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
+			dhc.logger.Warn("close connection in backends check failed", zap.Error(ignoredErr))
+		}
+		bh.ServerVersion = serverVersion
+		return err
+	})
+	if err != nil {
+		bh.Status = StatusCannotConnect
+		bh.PingErr = errors.Wrapf(err, "connect sql port failed")
+	}
+	return bh
+}
+
+func (dhc *DefaultHealthCheck) connectWithRetry(ctx context.Context, connect func() error) error {
+	err := backoff.Retry(func() error {
+		err := connect()
+		if !isRetryableError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(dhc.cfg.RetryInterval), uint64(dhc.cfg.MaxRetries)), ctx))
+	return err
+}
+
+// When the server refused to connect, the port is shut down, so no need to retry.
+var notRetryableError = []string{
+	"connection refused",
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, errStr := range notRetryableError {
+		if strings.Contains(msg, errStr) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/manager/router/health_check_test.go
+++ b/pkg/manager/router/health_check_test.go
@@ -1,0 +1,184 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestReadServerVersion(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	hc := NewDefaultHealthCheck(nil, newHealthCheckConfigForTest(), lg)
+	backend, info := newBackendServer(t)
+	backend.serverVersion.Store("1.0")
+	health := hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, "1.0", health.ServerVersion)
+	backend.stopSQLServer()
+	backend.serverVersion.Store("2.0")
+	backend.startSQLServer()
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, "2.0", health.ServerVersion)
+	backend.close()
+}
+
+// Test that the backend Status is correct when the backend starts or shuts down.
+func TestHealthCheck(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := newHealthCheckConfigForTest()
+	hc := NewDefaultHealthCheck(nil, cfg, lg)
+	backend, info := newBackendServer(t)
+	health := hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusHealthy, health.Status)
+
+	backend.stopSQLServer()
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusCannotConnect, health.Status)
+	backend.startSQLServer()
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusHealthy, health.Status)
+
+	backend.setHTTPResp(false)
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusCannotConnect, health.Status)
+	backend.setHTTPResp(true)
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusHealthy, health.Status)
+
+	backend.setHTTPWait(time.Second + cfg.DialTimeout)
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusCannotConnect, health.Status)
+	backend.setHTTPWait(time.Duration(0))
+	health = hc.Check(context.Background(), backend.sqlAddr, info)
+	require.Equal(t, StatusHealthy, health.Status)
+
+	backend.close()
+}
+
+type backendServer struct {
+	t             *testing.T
+	sqlListener   net.Listener
+	sqlAddr       string
+	statusServer  *http.Server
+	statusAddr    string
+	serverVersion atomic.String
+	*mockHttpHandler
+	wg         waitgroup.WaitGroup
+	ip         string
+	statusPort uint
+}
+
+func newBackendServer(t *testing.T) (*backendServer, *BackendInfo) {
+	backend := &backendServer{
+		t: t,
+	}
+	backend.startHTTPServer()
+	backend.setHTTPResp(true)
+	backend.startSQLServer()
+	return backend, &BackendInfo{
+		IP:         backend.ip,
+		StatusPort: backend.statusPort,
+	}
+}
+
+type mockHttpHandler struct {
+	t      *testing.T
+	httpOK atomic.Bool
+	wait   atomic.Int64
+}
+
+func (handler *mockHttpHandler) setHTTPResp(succeed bool) {
+	handler.httpOK.Store(succeed)
+}
+
+func (handler *mockHttpHandler) setHTTPWait(wait time.Duration) {
+	handler.wait.Store(int64(wait))
+}
+
+func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	wait := handler.wait.Load()
+	if wait > 0 {
+		time.Sleep(time.Duration(wait))
+	}
+	if handler.httpOK.Load() {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func (srv *backendServer) startHTTPServer() {
+	if srv.mockHttpHandler == nil {
+		srv.mockHttpHandler = &mockHttpHandler{
+			t: srv.t,
+		}
+	}
+	var statusListener net.Listener
+	statusListener, srv.statusAddr = startListener(srv.t, srv.statusAddr)
+	srv.ip, srv.statusPort = parseHostPort(srv.t, srv.statusAddr)
+	srv.statusServer = &http.Server{Addr: srv.statusAddr, Handler: srv.mockHttpHandler}
+	srv.wg.Run(func() {
+		_ = srv.statusServer.Serve(statusListener)
+	})
+}
+
+func (srv *backendServer) stopHTTPServer() {
+	err := srv.statusServer.Close()
+	require.NoError(srv.t, err)
+}
+
+func (srv *backendServer) startSQLServer() {
+	srv.sqlListener, srv.sqlAddr = startListener(srv.t, srv.sqlAddr)
+	srv.wg.Run(func() {
+		for {
+			conn, err := srv.sqlListener.Accept()
+			if err != nil {
+				// listener is closed
+				break
+			}
+			if err = pnet.WriteServerVersion(conn, srv.serverVersion.Load()); err != nil {
+				break
+			}
+			_ = conn.Close()
+		}
+	})
+}
+
+func (srv *backendServer) stopSQLServer() {
+	err := srv.sqlListener.Close()
+	require.NoError(srv.t, err)
+}
+
+func (srv *backendServer) close() {
+	srv.stopHTTPServer()
+	srv.stopSQLServer()
+	srv.wg.Wait()
+}
+
+func startListener(t *testing.T, addr string) (net.Listener, string) {
+	if len(addr) == 0 {
+		addr = "127.0.0.1:0"
+	}
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	return listener, listener.Addr().String()
+}
+
+func parseHostPort(t *testing.T, addr string) (string, uint) {
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 32)
+	require.NoError(t, err)
+	return host, uint(p)
+}

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -77,14 +77,10 @@ type BackendInst interface {
 
 // backendWrapper contains the connections on the backend.
 type backendWrapper struct {
-<<<<<<< Updated upstream
 	mu struct {
 		sync.RWMutex
-		backendHealth
+		BackendHealth
 	}
-=======
-	*BackendHealth
->>>>>>> Stashed changes
 	addr string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
 	// connScore = connList.Len() + incoming connections - outgoing connections.
@@ -94,17 +90,16 @@ type backendWrapper struct {
 	connList *glist.List[*connWrapper]
 }
 
-func (b *backendWrapper) setHealth(health backendHealth) {
+func (b *backendWrapper) setHealth(health BackendHealth) {
 	b.mu.Lock()
-	b.mu.backendHealth = health
+	b.mu.BackendHealth = health
 	b.mu.Unlock()
 }
 
 // score calculates the score of the backend. Larger score indicates higher load.
 func (b *backendWrapper) score() int {
-<<<<<<< Updated upstream
 	b.mu.RLock()
-	score := b.mu.status.ToScore() + b.connScore
+	score := b.mu.Status.ToScore() + b.connScore
 	b.mu.RUnlock()
 	return score
 }
@@ -115,21 +110,21 @@ func (b *backendWrapper) Addr() string {
 
 func (b *backendWrapper) Status() BackendStatus {
 	b.mu.RLock()
-	status := b.mu.status
+	status := b.mu.Status
 	b.mu.RUnlock()
 	return status
 }
 
 func (b *backendWrapper) Healthy() bool {
 	b.mu.RLock()
-	healthy := b.mu.status == StatusHealthy
+	healthy := b.mu.Status == StatusHealthy
 	b.mu.RUnlock()
 	return healthy
 }
 
 func (b *backendWrapper) ServerVersion() string {
 	b.mu.RLock()
-	version := b.mu.serverVersion
+	version := b.mu.ServerVersion
 	b.mu.RUnlock()
 	return version
 }
@@ -139,9 +134,6 @@ func (b *backendWrapper) String() string {
 	str := b.mu.String()
 	b.mu.RUnlock()
 	return str
-=======
-	return b.Status.ToScore() + b.connScore
->>>>>>> Stashed changes
 }
 
 // connWrapper wraps RedirectableConn.

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -53,7 +53,7 @@ const (
 	// The threshold of ratio of the highest score and lowest score.
 	// If the ratio exceeds the threshold, the proxy will rebalance connections.
 	rebalanceMaxScoreRatio = 1.2
-	// After a connection fails to redirect, it may contain some unmigratable status.
+	// After a connection fails to redirect, it may contain some unmigratable Status.
 	// Limit its redirection interval to avoid unnecessary retrial to reduce latency jitter.
 	redirectFailMinInterval = 3 * time.Second
 )
@@ -77,10 +77,14 @@ type BackendInst interface {
 
 // backendWrapper contains the connections on the backend.
 type backendWrapper struct {
+<<<<<<< Updated upstream
 	mu struct {
 		sync.RWMutex
 		backendHealth
 	}
+=======
+	*BackendHealth
+>>>>>>> Stashed changes
 	addr string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
 	// connScore = connList.Len() + incoming connections - outgoing connections.
@@ -98,6 +102,7 @@ func (b *backendWrapper) setHealth(health backendHealth) {
 
 // score calculates the score of the backend. Larger score indicates higher load.
 func (b *backendWrapper) score() int {
+<<<<<<< Updated upstream
 	b.mu.RLock()
 	score := b.mu.status.ToScore() + b.connScore
 	b.mu.RUnlock()
@@ -134,6 +139,9 @@ func (b *backendWrapper) String() string {
 	str := b.mu.String()
 	b.mu.RUnlock()
 	return str
+=======
+	return b.Status.ToScore() + b.connScore
+>>>>>>> Stashed changes
 }
 
 // connWrapper wraps RedirectableConn.

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -80,11 +80,7 @@ func (router *ScoreBasedRouter) routeOnce(excluded []string) (string, error) {
 	for be := router.backends.Back(); be != nil; be = be.Prev() {
 		backend := be.Value
 		// These backends may be recycled, so we should not connect to them again.
-<<<<<<< Updated upstream
 		switch backend.Status() {
-=======
-		switch backend.Status {
->>>>>>> Stashed changes
 		case StatusCannotConnect, StatusSchemaOutdated:
 			continue
 		}
@@ -139,13 +135,8 @@ func (router *ScoreBasedRouter) addConn(be *glist.Element[*backendWrapper], conn
 	ce := backend.connList.PushBack(conn)
 	setBackendConnMetrics(backend.addr, backend.connList.Len())
 	router.setConnWrapper(conn, ce)
-<<<<<<< Updated upstream
 	conn.NotifyBackendStatus(backend.Status())
 	router.adjustBackendList(be, false)
-=======
-	conn.NotifyBackendStatus(backend.Status)
-	router.adjustBackendList(be)
->>>>>>> Stashed changes
 }
 
 // adjustBackendList moves `be` after the score of `be` changes to keep the list ordered.
@@ -230,19 +221,12 @@ func (router *ScoreBasedRouter) ensureBackend(addr string, forward bool) *glist.
 	if be == nil {
 		// The backend should always exist if it will be needed. Add a warning and add it back.
 		router.logger.Warn("backend is not found in the router", zap.String("backend_addr", addr), zap.Stack("stack"))
-<<<<<<< Updated upstream
 		backend := &backendWrapper{
-=======
-		be = router.backends.PushFront(&backendWrapper{
-			BackendHealth: &BackendHealth{
-				Status: StatusCannotConnect,
-			},
->>>>>>> Stashed changes
 			addr:     addr,
 			connList: glist.New[*connWrapper](),
 		}
-		backend.setHealth(backendHealth{
-			status: StatusCannotConnect,
+		backend.setHealth(BackendHealth{
+			Status: StatusCannotConnect,
 		})
 		be = router.backends.PushFront(backend)
 		router.adjustBackendList(be, false)
@@ -304,7 +288,6 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 		if be == nil && health.Status != StatusCannotConnect {
 			router.logger.Info("update backend", zap.String("backend_addr", addr),
 				zap.String("prev", "none"), zap.String("cur", health.String()))
-<<<<<<< Updated upstream
 			backend := &backendWrapper{
 				addr:     addr,
 				connList: glist.New[*connWrapper](),
@@ -318,20 +301,6 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 				zap.String("prev", backend.mu.String()), zap.String("cur", health.String()))
 			backend.setHealth(*health)
 			router.adjustBackendList(be, true)
-=======
-			be = router.backends.PushBack(&backendWrapper{
-				BackendHealth: health,
-				addr:          addr,
-				connList:      glist.New[*connWrapper](),
-			})
-			router.adjustBackendList(be)
-		} else if be != nil {
-			backend := be.Value
-			router.logger.Info("update backend", zap.String("backend_addr", addr),
-				zap.String("prev", backend.String()), zap.String("cur", health.String()))
-			backend.BackendHealth = health
-			router.adjustBackendList(be)
->>>>>>> Stashed changes
 			for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
 				conn := ele.Value
 				conn.NotifyBackendStatus(health.Status)
@@ -413,11 +382,7 @@ func (router *ScoreBasedRouter) removeBackendIfEmpty(be *glist.Element[*backendW
 	backend := be.Value
 	// If connList.Len() == 0, there won't be any outgoing connections.
 	// And if also connScore == 0, there won't be any incoming connections.
-<<<<<<< Updated upstream
 	if backend.Status() == StatusCannotConnect && backend.connList.Len() == 0 && backend.connScore <= 0 {
-=======
-	if backend.Status == StatusCannotConnect && backend.connList.Len() == 0 && backend.connScore <= 0 {
->>>>>>> Stashed changes
 		router.backends.Remove(be)
 		return true
 	}
@@ -439,18 +404,12 @@ func (router *ScoreBasedRouter) ConnCount() int {
 func (router *ScoreBasedRouter) updateServerVersion() {
 	for be := router.backends.Front(); be != nil; be = be.Next() {
 		backend := be.Value
-<<<<<<< Updated upstream
 		if backend.Status() != StatusCannotConnect {
 			serverVersion := backend.ServerVersion()
 			if len(serverVersion) > 0 {
 				router.serverVersion = serverVersion
 				return
 			}
-=======
-		if backend.BackendHealth.Status != StatusCannotConnect && len(backend.ServerVersion) > 0 {
-			router.serverVersion = backend.ServerVersion
-			return
->>>>>>> Stashed changes
 		}
 	}
 }

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -158,11 +158,7 @@ func (tester *routerTester) killBackends(num int) {
 		}
 		// set the ith backend as unhealthy
 		backend := tester.getBackendByIndex(index)
-<<<<<<< Updated upstream
 		if backend.Status() == StatusCannotConnect {
-=======
-		if backend.Status == StatusCannotConnect {
->>>>>>> Stashed changes
 			continue
 		}
 		backends[backend.addr] = &BackendHealth{
@@ -196,11 +192,7 @@ func (tester *routerTester) checkBackendOrder() {
 	for be := tester.router.backends.Front(); be != nil; be = be.Next() {
 		backend := be.Value
 		// Empty unhealthy backends should be removed.
-<<<<<<< Updated upstream
 		if backend.Status() == StatusCannotConnect {
-=======
-		if backend.Status == StatusCannotConnect {
->>>>>>> Stashed changes
 			require.True(tester.t, backend.connList.Len() > 0 || backend.connScore > 0)
 		}
 		curScore := backend.score()
@@ -296,11 +288,7 @@ func (tester *routerTester) checkBalanced() {
 	for be := tester.router.backends.Front(); be != nil; be = be.Next() {
 		backend := be.Value
 		// Empty unhealthy backends should be removed.
-<<<<<<< Updated upstream
 		require.Equal(tester.t, StatusHealthy, backend.Status())
-=======
-		require.Equal(tester.t, StatusHealthy, backend.Status)
->>>>>>> Stashed changes
 		curScore := backend.score()
 		if curScore > maxNum {
 			maxNum = curScore


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #422

Problem Summary:
The serverless tier needs a customized health check function to check K8S pod health.

What is changed and how it works:
- Add an interface `HealthCheck` and its implementation `DefaultHealthCheck`.
- Pass a `HealthCheck` to `ScoreBasedRouter` and `BackendObserver`.
- Decouple the tests of `BackendObserver` and `HealthCheck`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
