### PR TITLE
router: fix status path of TiDB

### DIFF
--- a/pkg/manager/router/health_check.go
+++ b/pkg/manager/router/health_check.go
@@ -24,7 +24,7 @@ type HealthCheck interface {
 }
 
 const (
-	statusPathSuffix = "/Status"
+	statusPathSuffix = "/status"
 )
 
 type DefaultHealthCheck struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #428

Problem Summary:
The status path is wrong. Maybe it's modified by IDE by mistake.

What is changed and how it works:
Fix the status path.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Start a TiDB cluster
2. Start the TiProxy
3. Connect to TiProxy and query

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
