### PR TITLE
router: fix TestConcurrency

### DIFF
--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -320,7 +320,7 @@ func TestRotate(t *testing.T) {
 				return clientErr == nil && serverErr == nil
 			}
 			return true
-		}, time.Second, 100*time.Millisecond)
+		}, 5*time.Second, 100*time.Millisecond)
 		certMgr.Close()
 	}
 }

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -55,27 +55,27 @@ var statusScores = map[BackendStatus]int{
 
 type BackendHealth struct {
 	Status BackendStatus
-	// The error occurred when backends check fails. It's used to log why the backend becomes unhealthy.
+	// The error occurred when health check fails. It's used to log why the backend becomes unhealthy.
 	PingErr error
 	// The backend version that returned to the client during handshake.
 	ServerVersion string
 }
 
 func (bh *BackendHealth) String() string {
-	str := fmt.Sprintf("Status: %s", bh.Status.String())
+	str := fmt.Sprintf("status: %s", bh.Status.String())
 	if bh.PingErr != nil {
 		str += fmt.Sprintf(", err: %s", bh.PingErr.Error())
 	}
 	return str
 }
 
-// BackendEventReceiver receives the event of backend Status change.
+// BackendEventReceiver receives the event of backend status change.
 type BackendEventReceiver interface {
 	// OnBackendChanged is called when the backend list changes.
 	OnBackendChanged(backends map[string]*BackendHealth, err error)
 }
 
-// BackendInfo stores the Status info of each backend.
+// BackendInfo stores the status info of each backend.
 type BackendInfo struct {
 	IP         string
 	StatusPort uint
@@ -85,7 +85,7 @@ type BackendInfo struct {
 type BackendObserver struct {
 	logger            *zap.Logger
 	healthCheckConfig *config.HealthCheck
-	// The current backend Status synced to the receiver.
+	// The current backend status synced to the receiver.
 	curBackendInfo map[string]*BackendHealth
 	fetcher        BackendFetcher
 	hc             HealthCheck
@@ -204,7 +204,7 @@ func (bo *BackendObserver) notifyIfChanged(bhMap map[string]*BackendHealth) {
 				updatedBackends[addr] = newHealth
 				updateBackendStatusMetrics(addr, lastHealth.Status, newHealth.Status)
 			} else if lastHealth.ServerVersion != newHealth.ServerVersion {
-				// Not possible here: the backend finishes upgrading between two backends checks.
+				// Not possible here: the backend finishes upgrading between two health checks.
 				updatedBackends[addr] = newHealth
 			}
 		}

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -46,7 +46,7 @@ func newHealthCheckConfigForTest() *config.HealthCheck {
 	}
 }
 
-// Test that the notified backend Status is correct when the backend starts or shuts down.
+// Test that the notified backend status is correct when the backend starts or shuts down.
 func TestObserveBackends(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	t.Cleanup(ts.close)
@@ -68,7 +68,7 @@ func TestObserveBackends(t *testing.T) {
 	ts.checkStatus(backend1, StatusCannotConnect)
 }
 
-// Test that the backends check can exit when the context is cancelled.
+// Test that the health check can exit when the context is cancelled.
 func TestCancelObserver(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	t.Cleanup(ts.close)
@@ -188,7 +188,11 @@ func newMockBackendFetcher() *mockBackendFetcher {
 func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
 	mbf.Lock()
 	defer mbf.Unlock()
-	return mbf.backends, nil
+	backends := make(map[string]*BackendInfo, len(mbf.backends))
+	for addr, backend := range mbf.backends {
+		backends[addr] = backend
+	}
+	return backends, nil
 }
 
 func (mbf *mockBackendFetcher) setBackend(addr string, info *BackendInfo) {

--- a/pkg/manager/router/health_check_test.go
+++ b/pkg/manager/router/health_check_test.go
@@ -33,7 +33,7 @@ func TestReadServerVersion(t *testing.T) {
 	backend.close()
 }
 
-// Test that the backend Status is correct when the backend starts or shuts down.
+// Test that the backend status is correct when the backend starts or shuts down.
 func TestHealthCheck(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	cfg := newHealthCheckConfigForTest()

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -53,7 +53,7 @@ const (
 	// The threshold of ratio of the highest score and lowest score.
 	// If the ratio exceeds the threshold, the proxy will rebalance connections.
 	rebalanceMaxScoreRatio = 1.2
-	// After a connection fails to redirect, it may contain some unmigratable Status.
+	// After a connection fails to redirect, it may contain some unmigratable status.
 	// Limit its redirection interval to avoid unnecessary retrial to reduce latency jitter.
 	redirectFailMinInterval = 3 * time.Second
 )

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -97,7 +97,7 @@ func (router *ScoreBasedRouter) routeOnce(excluded []string) (string, error) {
 			return backend.addr, nil
 		}
 	}
-	// No available backends, maybe the backends check result is outdated during rolling restart.
+	// No available backends, maybe the health check result is outdated during rolling restart.
 	// Refresh the backends asynchronously in this case.
 	if router.observer != nil {
 		router.observer.Refresh()

--- a/pkg/proxy/backend/common_test.go
+++ b/pkg/proxy/backend/common_test.go
@@ -102,7 +102,7 @@ func (tc *tcpConnSuite) reconnectBackend(t *testing.T) {
 	wg.Wait()
 }
 
-func (tc *tcpConnSuite) run(clientRunner, backendRunner func(*pnet.PacketIO) error, proxyRunner func(*pnet.PacketIO, *pnet.PacketIO) error) (cerr, berr, perr error) {
+func (tc *tcpConnSuite) run(t *testing.T, clientRunner, backendRunner func(*pnet.PacketIO) error, proxyRunner func(*pnet.PacketIO, *pnet.PacketIO) error) (cerr, berr, perr error) {
 	var wg waitgroup.WaitGroup
 	if clientRunner != nil {
 		wg.Run(func() {
@@ -110,6 +110,7 @@ func (tc *tcpConnSuite) run(clientRunner, backendRunner func(*pnet.PacketIO) err
 			if cerr != nil {
 				_ = tc.clientIO.Close()
 			}
+			t.Logf("client quit, error: %v", cerr)
 		})
 	}
 	if backendRunner != nil {
@@ -118,6 +119,7 @@ func (tc *tcpConnSuite) run(clientRunner, backendRunner func(*pnet.PacketIO) err
 			if berr != nil {
 				_ = tc.backendIO.Close()
 			}
+			t.Logf("backend quit, error: %v", berr)
 		})
 	}
 	if proxyRunner != nil {
@@ -129,6 +131,7 @@ func (tc *tcpConnSuite) run(clientRunner, backendRunner func(*pnet.PacketIO) err
 					_ = tc.proxyBIO.Close()
 				}
 			}
+			t.Logf("proxy quit, error: %v", perr)
 		})
 	}
 	wg.Wait()

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -157,7 +157,7 @@ func (ts *testSuite) changeUser(username, db string) {
 
 func (ts *testSuite) runAndCheck(t *testing.T, c checker, clientRunner, backendRunner func(*pnet.PacketIO) error,
 	proxyRunner func(*pnet.PacketIO, *pnet.PacketIO) error) {
-	ts.mc.err, ts.mb.err, ts.mp.err = ts.tc.run(clientRunner, backendRunner, proxyRunner)
+	ts.mc.err, ts.mb.err, ts.mp.err = ts.tc.run(t, clientRunner, backendRunner, proxyRunner)
 	if c == nil {
 		require.NoError(t, ts.mc.err)
 		require.NoError(t, ts.mb.err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #432, #433, ref #434

Problem Summary:
- Some tests failed in CI
- A previous PR mistakenly updated comments when IDE refactored variable names

What is changed and how it works:
- Fix data race in `TestConcurrency`
- Fix `TestRotate`. I guess it's due to timeout but I can't guarantee. I'll reopen the issue if it happens again
- Add logs to `TestConnAttrs`. I don't know the reason yet.
- Revert the comments mistakenly updated by a previous PR

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
