### PR TITLE
Change MinTLSVersion to TLSv1.2

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -145,10 +145,10 @@ func NewConfig() *Config {
 	cfg.Log.LogFile.MaxBackups = 3
 
 	cfg.Advance.IgnoreWrongNamespace = true
-	cfg.Security.SQLTLS.MinTLSVersion = "1.1"
-	cfg.Security.ServerSQLTLS.MinTLSVersion = "1.1"
-	cfg.Security.ServerHTTPTLS.MinTLSVersion = "1.1"
-	cfg.Security.ClusterTLS.MinTLSVersion = "1.1"
+	cfg.Security.SQLTLS.MinTLSVersion = "1.2"
+	cfg.Security.ServerSQLTLS.MinTLSVersion = "1.2"
+	cfg.Security.ServerHTTPTLS.MinTLSVersion = "1.2"
+	cfg.Security.ClusterTLS.MinTLSVersion = "1.2"
 
 	return &cfg
 }

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -50,16 +50,16 @@ ignore-wrong-namespace = true
 
 [security]
 [security.server-tls]
-min-tls-version = '1.1'
+min-tls-version = '1.2'
 
 [security.server-http-tls]
-min-tls-version = '1.1'
+min-tls-version = '1.2'
 
 [security.cluster-tls]
-min-tls-version = '1.1'
+min-tls-version = '1.2'
 
 [security.sql-tls]
-min-tls-version = '1.1'
+min-tls-version = '1.2'
 
 [log]
 encoder = 'tidb'

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -75,7 +75,7 @@ max-backups = 3
 	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.1"},"server-http-tls":{"min-tls-version":"1.1"},"cluster-tls":{"min-tls-version":"1.1"},"sql-tls":{"min-tls-version":"1.1"}},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
+		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.2"},"server-http-tls":{"min-tls-version":"1.2"},"cluster-tls":{"min-tls-version":"1.2"},"sql-tls":{"min-tls-version":"1.2"}},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
 			string(regexp.MustCompile(`"workdir":"[^"]+",`).ReplaceAll(all, nil)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/36036

Problem Summary:

[IETF RFC 8996](https://www.rfc-editor.org/rfc/rfc8996.html#name-do-not-use-tls-11) says TLSv1.1 and older should not be used by default. 

What is changed and how it works:

This changes the minimum TLS version to TLSv1.2.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The minimum TLS version was changed to TLSv1.2. This can be changed in the configuration file.
```

> [!WARNING]
> This change should be clearly listed in release notes etc as depending on the MySQL driver and connection configuration this might lead to problems.