### PR TITLE
backend: fix stmt_execute hang

### DIFF
--- a/pkg/proxy/backend/cmd_processor_exec.go
+++ b/pkg/proxy/backend/cmd_processor_exec.go
@@ -193,8 +193,8 @@ func (cp *CmdProcessor) forwardQueryCmd(clientIO, backendIO *pnet.PacketIO, requ
 			var err error
 			switch first {
 			case pnet.OKHeader.Byte():
-				status := cp.handleOKPacket(request, response)
-				serverStatus, err = status, clientIO.Flush()
+				serverStatus = cp.handleOKPacket(request, response)
+				err = clientIO.Flush()
 			case pnet.ErrHeader.Byte():
 				if err = clientIO.Flush(); err != nil {
 					return err
@@ -267,7 +267,7 @@ func (cp *CmdProcessor) forwardResultSet(clientIO, backendIO *pnet.PacketIO, req
 			}
 			return nil
 		})
-		if err != nil {
+		if err != nil || serverStatus&pnet.ServerStatusCursorExists > 0 {
 			return serverStatus, err
 		}
 	}

--- a/pkg/proxy/backend/cmd_processor_test.go
+++ b/pkg/proxy/backend/cmd_processor_test.go
@@ -76,58 +76,61 @@ func TestForwardCommands(t *testing.T) {
 	for cmd, respondTypes := range cmdResponseTypes {
 		for _, respondType := range respondTypes {
 			for _, capability := range []pnet.Capability{defaultTestBackendCapability &^ pnet.ClientDeprecateEOF, defaultTestBackendCapability | pnet.ClientDeprecateEOF} {
-				cfgOvr := func(cfg *testConfig) {
-					cfg.clientConfig.cmd = cmd
-					cfg.backendConfig.respondType = respondType
-					cfg.backendConfig.capability = capability
-					cfg.clientConfig.capability = capability
-					cfg.proxyConfig.capability = capability
-				}
-				// Test more variables for some special response types.
-				switch respondType {
-				case responseTypeColumn:
-					for _, columns := range []int{1, 4096} {
-						extraCfgOvr := func(cfg *testConfig) {
-							cfg.backendConfig.columns = columns
-						}
-						runTest(cfgOvr, extraCfgOvr)
+				for _, status := range []uint16{0, pnet.ServerStatusCursorExists} {
+					cfgOvr := func(cfg *testConfig) {
+						cfg.clientConfig.cmd = cmd
+						cfg.backendConfig.respondType = respondType
+						cfg.backendConfig.capability = capability
+						cfg.backendConfig.status = status
+						cfg.clientConfig.capability = capability
+						cfg.proxyConfig.capability = capability
 					}
-				case responseTypeRow:
-					for _, rows := range []int{0, 1, 3} {
-						extraCfgOvr := func(cfg *testConfig) {
-							cfg.backendConfig.rows = rows
-						}
-						runTest(cfgOvr, extraCfgOvr)
-					}
-				case responseTypePrepareOK:
-					for _, columns := range []int{0, 1, 4096} {
-						for _, params := range []int{0, 1, 3} {
+					// Test more variables for some special response types.
+					switch respondType {
+					case responseTypeColumn:
+						for _, columns := range []int{1, 4096} {
 							extraCfgOvr := func(cfg *testConfig) {
 								cfg.backendConfig.columns = columns
-								cfg.backendConfig.params = params
 							}
 							runTest(cfgOvr, extraCfgOvr)
 						}
-					}
-				case responseTypeResultSet:
-					for _, columns := range []int{1, 4096} {
+					case responseTypeRow:
 						for _, rows := range []int{0, 1, 3} {
 							extraCfgOvr := func(cfg *testConfig) {
-								cfg.backendConfig.columns = columns
 								cfg.backendConfig.rows = rows
 							}
 							runTest(cfgOvr, extraCfgOvr)
 						}
-					}
-				case responseTypeLoadFile:
-					for _, filePkts := range []int{0, 1, 3} {
-						extraCfgOvr := func(cfg *testConfig) {
-							cfg.clientConfig.filePkts = filePkts
+					case responseTypePrepareOK:
+						for _, columns := range []int{0, 1, 4096} {
+							for _, params := range []int{0, 1, 3} {
+								extraCfgOvr := func(cfg *testConfig) {
+									cfg.backendConfig.columns = columns
+									cfg.backendConfig.params = params
+								}
+								runTest(cfgOvr, extraCfgOvr)
+							}
 						}
-						runTest(cfgOvr, extraCfgOvr)
+					case responseTypeResultSet:
+						for _, columns := range []int{1, 4096} {
+							for _, rows := range []int{0, 1, 3} {
+								extraCfgOvr := func(cfg *testConfig) {
+									cfg.backendConfig.columns = columns
+									cfg.backendConfig.rows = rows
+								}
+								runTest(cfgOvr, extraCfgOvr)
+							}
+						}
+					case responseTypeLoadFile:
+						for _, filePkts := range []int{0, 1, 3} {
+							extraCfgOvr := func(cfg *testConfig) {
+								cfg.clientConfig.filePkts = filePkts
+							}
+							runTest(cfgOvr, extraCfgOvr)
+						}
+					default:
+						runTest(cfgOvr, cfgOvr)
 					}
-				default:
-					runTest(cfgOvr, cfgOvr)
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #436

Problem Summary:
This bug was introduced by #394.

After the backend sends columns to the client, if `serverStatus&pnet.ServerStatusCursorExists > 0`, the packets are finished and the client should send `COM_STMT_FETCH`, but TiProxy still reads from the backend.

What is changed and how it works:
Stop reading from the backend when `serverStatus&pnet.ServerStatusCursorExists > 0 && capability&pnet.ClientDeprecateEOF == 0`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test the python program in #436:

```shell
$ python3.9 test.py
before get_rows
after get_rows
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
