### PR TITLE
config: check mod time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ go-header:
 	GOBIN=$(GOBIN) go install github.com/denis-tingaikin/go-header/cmd/go-header@latest
 
 header: go-header
-	$(GOBIN)/go-header $(shell find . -name "*.go" -not -path "./pkg/proxy/keepalive*")
+	NEW_GO_FILES=$(git diff --cached --diff-filter=A --name-only | grep -E '.*\.go')
+	[ ! $(NEW_GO_FILES) ] || $(GOBIN)/go-header $(NEW_GO_FILES)
 
 lint: golangci-lint tidy header
 	cd lib && $(GOBIN)/golangci-lint run -c ../.golangci.yaml

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-contrib/pprof v1.4.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-mysql-org/go-mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1041,7 +1039,6 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -162,7 +162,7 @@ func (cfg *Config) Check() error {
 	if cfg.Workdir == "" {
 		d, err := os.Getwd()
 		if err != nil {
-			return err
+			return errors.WithStack(err)
 		}
 		cfg.Workdir = filepath.Clean(filepath.Join(d, "work"))
 	}
@@ -184,5 +184,5 @@ func (cfg *Config) Check() error {
 func (cfg *Config) ToBytes() ([]byte, error) {
 	b := new(bytes.Buffer)
 	err := toml.NewEncoder(b).Encode(cfg)
-	return b.Bytes(), err
+	return b.Bytes(), errors.WithStack(err)
 }

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
 	"go.uber.org/zap"
 )
 
 func (e *ConfigManager) reloadConfigFile(file string) error {
 	proxyConfigData, err := os.ReadFile(file)
 	if err != nil {
-		return err
+		return errors.WithStack(err)
 	}
 
 	return e.SetTOMLConfig(proxyConfigData)
@@ -44,11 +45,11 @@ func (e *ConfigManager) SetTOMLConfig(data []byte) (err error) {
 	}
 
 	if err = toml.Unmarshal(data, base); err != nil {
-		return
+		return errors.WithStack(err)
 	}
 
 	if err = toml.Unmarshal(e.overlay, base); err != nil {
-		return
+		return errors.WithStack(err)
 	}
 
 	if err = base.Check(); err != nil {
@@ -58,7 +59,7 @@ func (e *ConfigManager) SetTOMLConfig(data []byte) (err error) {
 	e.sts.current = base
 	var buf bytes.Buffer
 	if err = toml.NewEncoder(&buf).Encode(base); err != nil {
-		return
+		return errors.WithStack(err)
 	}
 	e.sts.checksum = crc32.ChecksumIEEE(buf.Bytes())
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -7,10 +7,8 @@ import (
 	"bytes"
 	"hash/crc32"
 	"os"
-	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/fsnotify/fsnotify"
 	"github.com/pingcap/tiproxy/lib/config"
 	"go.uber.org/zap"
 )
@@ -22,33 +20,6 @@ func (e *ConfigManager) reloadConfigFile(file string) error {
 	}
 
 	return e.SetTOMLConfig(proxyConfigData)
-}
-
-func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
-	switch {
-	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
-		// The file may be the log file, triggering reload will cause more logs and thus cause reload again,
-		// so we need to filter the wrong files.
-		// The filesystem differs from OS to OS, so don't use string comparison.
-		f1, err := os.Stat(ev.Name)
-		if err != nil {
-			break
-		}
-		f2, err := os.Stat(f)
-		if err != nil {
-			break
-		}
-		if !os.SameFile(f1, f2) {
-			break
-		}
-		if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
-			// in case of remove/rename the file, files are not present at filesystem for a while
-			// it may be too fast to read the config file now, sleep for a while
-			time.Sleep(50 * time.Millisecond)
-		}
-		// try to reload it
-		e.logger.Info("config file reloaded", zap.Stringer("event", ev), zap.Error(e.reloadConfigFile(f)))
-	}
 }
 
 // SetTOMLConfig will do partial config update. Usually, user will expect config changes

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -123,7 +123,7 @@ func TestConfigReload(t *testing.T) {
 
 		require.NoError(t, os.WriteFile(tmpcfg, []byte(tc.postcfg), 0644), msg)
 		if tc.postcheck != nil {
-			require.Eventually(t, func() bool { return tc.postcheck(cfgmgr1.GetConfig()) }, time.Second, 100*time.Millisecond, msg)
+			require.Eventually(t, func() bool { return tc.postcheck(cfgmgr1.GetConfig()) }, 3*time.Second, 100*time.Millisecond, msg)
 		}
 	}
 }
@@ -143,7 +143,7 @@ func TestConfigRemove(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpcfg, []byte(`proxy.addr = "gg"`), 0644))
 
 	// check that reload still works
-	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "gg" }, time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "gg" }, 3*time.Second, 100*time.Millisecond)
 
 	// remove again but with a long sleep
 	require.NoError(t, os.Remove(tmpcfg))
@@ -151,7 +151,7 @@ func TestConfigRemove(t *testing.T) {
 
 	// but eventually re-watched the file again
 	require.NoError(t, os.WriteFile(tmpcfg, []byte(`proxy.addr = "vv"`), 0644))
-	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "vv" }, time.Second, 100*time.Millisecond)
+	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "vv" }, 3*time.Second, 100*time.Millisecond)
 }
 
 func TestFilePath(t *testing.T) {
@@ -163,12 +163,18 @@ func TestFilePath(t *testing.T) {
 
 	tmpdir := t.TempDir()
 	checkLog := func(increased bool) {
-		// On linux, writing once will trigger 2 WRITE events. But on macOS, it only triggers once.
-		// So we always sleep 100ms to avoid missing any logs on the way.
-		time.Sleep(100 * time.Millisecond)
-		newCount := strings.Count(text.String(), "config file reloaded")
-		require.Equal(t, increased, newCount > count, fmt.Sprintf("now: %d, was: %d", newCount, count))
-		count = newCount
+		if increased {
+			var newCount int
+			require.Eventually(t, func() bool {
+				newCount = strings.Count(text.String(), "config file reloaded")
+				return newCount > count
+			}, 3*time.Second, 10*time.Millisecond, "count=%d, newCount=%d", count, newCount)
+			count = newCount
+		} else {
+			time.Sleep(100 * time.Millisecond)
+			newCount := strings.Count(text.String(), "config file reloaded")
+			require.Equal(t, count, newCount)
+		}
 	}
 
 	tests := []struct {
@@ -271,7 +277,7 @@ func TestFilePath(t *testing.T) {
 
 		count = 0
 		cfgmgr, text, _ = testConfigManager(t, test.filename)
-		checkLog(false)
+		checkLog(true)
 
 		// Test write.
 		require.NoError(t, os.WriteFile(test.filename, []byte("proxy.pd-addrs = \"127.0.0.1:2379\""), 0644))

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -149,7 +149,7 @@ func TestConfigRemove(t *testing.T) {
 	require.NoError(t, os.Remove(tmpcfg))
 	time.Sleep(200 * time.Millisecond)
 
-	// but eventually re-watched the file again
+	// but eventually reload the file again
 	require.NoError(t, os.WriteFile(tmpcfg, []byte(`proxy.addr = "vv"`), 0644))
 	require.Eventually(t, func() bool { return cfgmgr.GetConfig().Proxy.Addr == "vv" }, 3*time.Second, 100*time.Millisecond)
 }

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -82,7 +82,7 @@ func (e *ConfigManager) Init(ctx context.Context, logger *zap.Logger, configFile
 			return errors.WithStack(err)
 		}
 		e.wg.Run(func() {
-			ticker := time.NewTicker(100 * time.Millisecond)
+			ticker := time.NewTicker(checkFileInterval)
 			for {
 				select {
 				case <-nctx.Done():

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -44,7 +43,6 @@ type ConfigManager struct {
 
 	kv *btree.BTreeG[KVValue]
 
-	wch         *fsnotify.Watcher
 	lastModTime time.Time
 	overlay     []byte
 	sts         struct {

--- a/pkg/manager/config/manager_test.go
+++ b/pkg/manager/config/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
@@ -15,6 +16,7 @@ import (
 
 func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, fmt.Stringer, context.Context) {
 	logger, text := logger.CreateLoggerForTest(t)
+	checkFileInterval = 20 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	if ddl, ok := t.Deadline(); ok {

--- a/pkg/manager/config/manager_test.go
+++ b/pkg/manager/config/manager_test.go
@@ -16,7 +16,6 @@ import (
 
 func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, fmt.Stringer, context.Context) {
 	logger, text := logger.CreateLoggerForTest(t)
-	checkFileInterval = 20 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.Background())
 	if ddl, ok := t.Deadline(); ok {
@@ -24,6 +23,7 @@ func testConfigManager(t *testing.T, configFile string, overlays ...*config.Conf
 	}
 
 	cfgmgr := NewConfigManager()
+	cfgmgr.checkFileInterval = 20 * time.Millisecond
 	require.NoError(t, cfgmgr.Init(ctx, logger, configFile, nil))
 
 	t.Cleanup(func() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #444

Problem Summary:
Currently `TestFilePath` frequently fails in CI because of the concurrency issue, which was commented in the code.

What is changed and how it works:
- Deprecate the watcher way and simply check the file modify time periodically. If the modify time changes, reload the file.
- Only check headers for new files in Makefile

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
