### PR TITLE
router: fix connection score becomes wrong when a connection closes during redirecting

### DIFF
--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -139,7 +139,9 @@ func (b *backendWrapper) String() string {
 // connWrapper wraps RedirectableConn.
 type connWrapper struct {
 	RedirectableConn
-	phase connPhase
+	// Reference to the target backend if it's redirecting, otherwise nil.
+	redirectingBackend *backendWrapper
 	// Last redirect start time of this connection.
 	lastRedirect time.Time
+	phase        connPhase
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #448

Problem Summary:
There were 2 ways to update the connection score correctly when a connection closes after receiving a redirection signal:
- The connection passes the target backend to the router when it closes
- The router requests for the target backend when the connection closes

However, both these 2 ways are removed, and the connection score is incorrectly maintained.

What is changed and how it works:
Maintain the target backend in the router itself. When a connection is closed during redirecting, get the target backend from the router itself.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
