### PR TITLE
log: print welcom after config init

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -61,7 +61,6 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		return
 	}
 	srv.LoggerManager.Init(srv.ConfigManager.WatchConfig())
-	printInfo(lg)
 
 	// setup config manager
 	if err = srv.ConfigManager.Init(ctx, lg.Named("config"), sctx.ConfigFile, &sctx.Overlay); err != nil {
@@ -69,6 +68,8 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		return
 	}
 	cfg := srv.ConfigManager.GetConfig()
+
+	printInfo(lg)
 
 	// setup metrics
 	srv.MetricsManager.Init(ctx, lg.Named("metrics"))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	}
 	cfg := srv.ConfigManager.GetConfig()
 
+	// welcome messages must be printed after initialization of configmager, because
+	// logfile backended zaplogger is enabled after cfgmgr.Init(..).
+	// otherwise, printInfo will output to stdout, which can not be redirected to the log file on tiup-cluster.
 	printInfo(lg)
 
 	// setup metrics

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,6 +72,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	// welcome messages must be printed after initialization of configmager, because
 	// logfile backended zaplogger is enabled after cfgmgr.Init(..).
 	// otherwise, printInfo will output to stdout, which can not be redirected to the log file on tiup-cluster.
+	//
+	// TODO: there is a race condition that printInfo and logmgr may concurrently execute:
+	// logmgr may havenot been initialized with logfile yet
 	printInfo(lg)
 
 	// setup metrics


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #453

Problem Summary: The root cause that tiup-cluster did not print the welcome log is that, tiproxy prints the message to stdout, which goes to system units.

And it is basically impossible/very hard to redirect that to the log file on tiup-cluster. Instead, we just print the log after config initialization,

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
