### PR TITLE
router: fix backend scores are not ordered

### DIFF
--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -279,6 +279,9 @@ func (router *ScoreBasedRouter) OnConnClosed(addr string, conn RedirectableConn)
 	if redirectingBackend != nil {
 		redirectingBackend.connScore--
 		connWrapper.Value.redirectingBackend = nil
+		if redirectingBe := router.lookupBackend(redirectingBackend.addr, true); redirectingBe != nil {
+			router.adjustBackendList(redirectingBe, true)
+		}
 	} else {
 		be.Value.connScore--
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #458

Problem Summary:
When the connection score is updated, the backend is not reordered. Thus, subsequent rebalance may not work.

What is changed and how it works:
Adjust the backend order after the connection score is updated.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Before this PR, `TestBackendScore` fails most of the time.
After this PR, `TestBackendScore` always succeeds.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix that rebalance may not work after session migrations are interrupted.
```
