### PR TITLE
infosync: set longer duration to stabilize tests

### DIFF
--- a/lib/util/retry/retry.go
+++ b/lib/util/retry/retry.go
@@ -27,12 +27,18 @@ func NewBackOff(ctx context.Context, retryInterval time.Duration, retryCnt uint6
 }
 
 func Retry(o backoff.Operation, ctx context.Context, retryInterval time.Duration, retryCnt uint64) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	bo := NewBackOff(ctx, retryInterval, retryCnt)
 	return backoff.Retry(o, bo)
 }
 
 func RetryNotify(o backoff.Operation, ctx context.Context, retryInterval time.Duration, retryCnt uint64,
 	notify backoff.Notify, notifyInterval uint64) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	bo := NewBackOff(ctx, retryInterval, retryCnt)
 	var cnt uint64
 	return backoff.RetryNotify(o, bo, func(err error, duration time.Duration) {

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -45,7 +45,7 @@ func TestTTLRefresh(t *testing.T) {
 				}
 			}
 			return satisfied
-		}, 3*time.Second, 100*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 	}
 }
 
@@ -65,7 +65,7 @@ func TestEtcdServerDown4Sync(t *testing.T) {
 			ttl = newTTL
 		}
 		return satisfied
-	}, 5*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 // TTL and info are erased after the client shuts down normally.
@@ -75,7 +75,7 @@ func TestClientShutDown4Sync(t *testing.T) {
 	require.Eventually(t, func() bool {
 		ttl, info := ts.getTTLAndInfo(tiproxyTopologyPath)
 		return len(ttl) > 0 && len(info) > 0
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 	ts.closeInfoSyncer()
 	ttl, info := ts.getTTLAndInfo(tiproxyTopologyPath)
 	require.True(t, len(ttl) == 0 && len(info) == 0)
@@ -88,12 +88,12 @@ func TestClientDown4Sync(t *testing.T) {
 	require.Eventually(t, func() bool {
 		ttl, info := ts.getTTLAndInfo(tiproxyTopologyPath)
 		return len(ttl) > 0 && len(info) > 0
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 	ts.stopInfoSyncer()
 	require.Eventually(t, func() bool {
 		ttl, info := ts.getTTLAndInfo(tiproxyTopologyPath)
 		return len(ttl) == 0 && len(info) == 0
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 // Test that the result of GetTiDBTopology is right.
@@ -373,7 +373,7 @@ func (ts *etcdTestSuite) createEtcdServer(addr string) {
 			ts.t.Logf("start etcd failed, error: %s", err.Error())
 		}
 		return err == nil
-	}, 5*time.Second, 10*time.Millisecond)
+	}, 10*time.Second, 10*time.Millisecond)
 	<-etcd.Server.ReadyNotify()
 	ts.server = etcd
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #452

Problem Summary:
`TestClientDown4Sync` sometimes fails because the TTL info is not erased after the etcd client is down.

What is changed and how it works:
- Set longer wait duration
- Avoid unnecessary retrial by checking context before the first retrial

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
