### PR TITLE
backend: optimize updating command metrics

### DIFF
--- a/pkg/proxy/backend/metrics_test.go
+++ b/pkg/proxy/backend/metrics_test.go
@@ -9,8 +9,18 @@ import (
 
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+func BenchmarkAddCmdMetrics(b *testing.B) {
+	cmd := pnet.ComQuery
+	addr := "127.0.0.1:4000"
+	startTime := monotime.Now()
+	for i := 0; i < b.N; i++ {
+		addCmdMetrics(cmd, addr, startTime)
+	}
+}
 
 func BenchmarkAddCmdMetricsArrayPointer(b *testing.B) {
 	cmd := pnet.ComQuery

--- a/pkg/proxy/backend/metrics_test.go
+++ b/pkg/proxy/backend/metrics_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pingcap/tiproxy/pkg/metrics"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkAddCmdMetricsArrayPointer(b *testing.B) {
+	cmd := pnet.ComQuery
+	addr := "127.0.0.1:4000"
+	var lock sync.Mutex
+	counter := make(map[string]*[pnet.ComEnd]prometheus.Counter)
+	for i := 0; i < b.N; i++ {
+		lock.Lock()
+
+		addrCounter, ok := counter[addr]
+		if !ok {
+			addrCounter = &[pnet.ComEnd]prometheus.Counter{}
+			counter[addr] = addrCounter
+		}
+		counter := addrCounter[cmd]
+		if counter == nil {
+			counter = metrics.QueryTotalCounter.WithLabelValues(addr, cmd.String())
+			addrCounter[cmd] = counter
+		}
+		counter.Inc()
+
+		lock.Unlock()
+	}
+}
+
+func BenchmarkAddCmdMetricsArray(b *testing.B) {
+	cmd := pnet.ComQuery
+	addr := "127.0.0.1:4000"
+	var lock sync.Mutex
+	counter := make(map[string][pnet.ComEnd]prometheus.Counter)
+	for i := 0; i < b.N; i++ {
+		lock.Lock()
+
+		addrCounter, ok := counter[addr]
+		if !ok {
+			addrCounter = [pnet.ComEnd]prometheus.Counter{}
+			counter[addr] = addrCounter
+		}
+		counter := addrCounter[cmd]
+		if counter == nil {
+			counter = metrics.QueryTotalCounter.WithLabelValues(addr, cmd.String())
+			addrCounter[cmd] = counter
+		}
+		counter.Inc()
+
+		lock.Unlock()
+	}
+}
+
+func BenchmarkAddCmdMetricsMap(b *testing.B) {
+	cmd := pnet.ComQuery
+	addr := "127.0.0.1:4000"
+	var lock sync.Mutex
+	counter := make(map[string]map[pnet.Command]prometheus.Counter)
+	for i := 0; i < b.N; i++ {
+		lock.Lock()
+
+		addrCounter, ok := counter[addr]
+		if !ok {
+			addrCounter = make(map[pnet.Command]prometheus.Counter)
+			counter[addr] = addrCounter
+		}
+		counter, ok := addrCounter[cmd]
+		if !ok {
+			counter = metrics.QueryTotalCounter.WithLabelValues(addr, cmd.String())
+			addrCounter[cmd] = counter
+		}
+		counter.Inc()
+
+		lock.Unlock()
+	}
+}
+
+func BenchmarkAddCmdMetricsSimple(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		metrics.QueryTotalCounter.WithLabelValues("127.0.0.1:4000", pnet.ComQuery.String()).Inc()
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #420

Problem Summary:
When running sysbench point select, the CPU cost of adding metrics of CPS and duration per cmd is about 3.6%.

What is changed and how it works:
- Cache the results of `WithLabelValues(...)` to avoid calling it every time.
- Add several benchmarks and it proves that storing array pointers in the map is the best. It's 6x faster than before.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Frame Graph
Before (3.6%):
![metrics_profile](https://github.com/pingcap/tiproxy/assets/29590578/31d0dc7b-9c5a-4bc8-b7b4-f4d54d4bfaff)
After (1%):
![metrics_array](https://github.com/pingcap/tiproxy/assets/29590578/db95edcc-61bf-4b68-8c45-bc3022c41fc9)

Benchmark Result:
```
BenchmarkAddCmdMetricsArrayPointer
BenchmarkAddCmdMetricsArrayPointer-8   	55810723	        22.11 ns/op
BenchmarkAddCmdMetricsArray
BenchmarkAddCmdMetricsArray-8          	 6619735	       169.0 ns/op
BenchmarkAddCmdMetricsMap
BenchmarkAddCmdMetricsMap-8            	37847948	        33.26 ns/op
BenchmarkAddCmdMetricsSimple
BenchmarkAddCmdMetricsSimple-8         	 8657454	       140.9 ns/op
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Optimize updating metrics to improve the performance by around 3%
```
