### PR TITLE
backend: optimize `resetCheckBackendTicker`

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -814,7 +814,6 @@ func TestHandlerReturnError(t *testing.T) {
 func TestOnTraffic(t *testing.T) {
 	var inBytes, outBytes uint64
 	ts := newBackendMgrTester(t, func(config *testConfig) {
-		config.proxyConfig.bcConfig.CheckBackendInterval = 10 * time.Millisecond
 		config.proxyConfig.handler.onTraffic = func(cc ConnContext) {
 			require.Greater(t, cc.ClientInBytes(), uint64(0))
 			require.GreaterOrEqual(t, cc.ClientInBytes(), inBytes)
@@ -906,6 +905,7 @@ func TestGetBackendIO(t *testing.T) {
 
 func TestBackendInactive(t *testing.T) {
 	ts := newBackendMgrTester(t, func(config *testConfig) {
+		config.proxyConfig.bcConfig.TickerInterval = time.Millisecond
 		config.proxyConfig.bcConfig.CheckBackendInterval = 10 * time.Millisecond
 	})
 	runners := []runner{
@@ -989,9 +989,7 @@ func TestBackendInactive(t *testing.T) {
 }
 
 func TestKeepAlive(t *testing.T) {
-	ts := newBackendMgrTester(t, func(config *testConfig) {
-		config.proxyConfig.bcConfig.CheckBackendInterval = 10 * time.Millisecond
-	})
+	ts := newBackendMgrTester(t)
 	runners := []runner{
 		{
 			client: ts.mc.authenticate,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #470 

Problem Summary:
Currently, `resetCheckBackendTicker` uses around 1.4% CPU usage. It is called for every command, which is unnecessary.

What is changed and how it works:
Just update `lastActiveTime` after each execution. The ticker just checks if it exceeds the interval.
This ticker will also be used for #414 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Run sysbench and it proves that the performance doesn't change much. It's expected.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
