### PR TITLE
*: reduce memory allocation for plenty of idle connections

### DIFF
--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -325,12 +325,14 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 }
 
 func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
+	ticker := time.NewTicker(rebalanceInterval)
 	for {
-		router.rebalance(rebalanceConnsPerLoop)
 		select {
 		case <-ctx.Done():
+			ticker.Stop()
 			return
-		case <-time.After(rebalanceInterval):
+		case <-ticker.C:
+			router.rebalance(rebalanceConnsPerLoop)
 		}
 	}
 }

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -142,11 +142,7 @@ func NewBackendConnManager(logger *zap.Logger, handshakeHandler HandshakeHandler
 		connectionID:     connectionID,
 		cmdProcessor:     NewCmdProcessor(logger.Named("cp")),
 		handshakeHandler: handshakeHandler,
-		authenticator: &Authenticator{
-			proxyProtocol:     config.ProxyProtocol,
-			requireBackendTLS: config.RequireBackendTLS,
-			salt:              GenerateSalt(20),
-		},
+		authenticator:    NewAuthenticator(config),
 		// There are 2 types of signals, which may be sent concurrently.
 		signalReceived: make(chan signalType, signalTypeNums),
 		redirectResCh:  make(chan *redirectResult, 1),

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1218,4 +1219,23 @@ func TestCloseWhileGracefulClose(t *testing.T) {
 	}
 
 	ts.runTests(runners)
+}
+
+func BenchmarkSyncMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var m sync.Map
+		m.Store("1", "1")
+		m.Load("1")
+	}
+}
+
+func BenchmarkLockedMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m := make(map[string]string)
+		var lock sync.Mutex
+		lock.Lock()
+		m["1"] = "1"
+		_ = m["1"]
+		lock.Unlock()
+	}
 }

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 type backendConfig struct {
+	salt          [20]byte
 	tlsConfig     *tls.Config
 	authPlugin    string
 	sessionStates string
-	salt          []byte
 	columns       int
 	loops         int
 	params        int

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -34,7 +34,7 @@ const (
 var (
 	mockUsername      = "test_user"
 	mockDBName        = "test_db"
-	mockSalt          = []byte("01234567890123456789")
+	mockSalt          = [20]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	mockAuthData      = []byte("123456")
 	mockToken         = strings.Repeat("t", 512)
 	mockCmdStr        = "str"

--- a/pkg/proxy/backend/util.go
+++ b/pkg/proxy/backend/util.go
@@ -10,13 +10,11 @@ func Uint32N(a uint64) uint64
 
 // Buf generates a random string using ASCII characters but avoid separator character.
 // Ref https://github.com/mysql/mysql-server/blob/5.7/mysys_ssl/crypt_genhash_impl.cc#L435.
-func GenerateSalt(size int) []byte {
-	buf := make([]byte, size)
+func GenerateSalt(buf *[20]byte) {
 	for i := range buf {
 		buf[i] = byte(Uint32N(127))
 		for buf[i] == 0 || buf[i] == byte('$') {
 			buf[i] = byte(Uint32N(127))
 		}
 	}
-	return buf
 }

--- a/pkg/proxy/net/packetio_mysql.go
+++ b/pkg/proxy/net/packetio_mysql.go
@@ -17,14 +17,8 @@ var (
 
 // WriteInitialHandshake writes an initial handshake as a server.
 // It's used for tenant-aware routing and testing.
-func (p *PacketIO) WriteInitialHandshake(capability Capability, salt []byte, authPlugin string, serverVersion string, connID uint64) error {
+func (p *PacketIO) WriteInitialHandshake(capability Capability, salt [20]byte, authPlugin string, serverVersion string, connID uint64) error {
 	saltLen := len(salt)
-	if saltLen < 8 {
-		return ErrSaltNotLongEnough
-	} else if saltLen > 20 {
-		saltLen = 20
-	}
-
 	data := make([]byte, 0, 128)
 
 	// min version 10
@@ -61,14 +55,14 @@ func (p *PacketIO) WriteInitialHandshake(capability Capability, salt []byte, aut
 }
 
 // WriteSwitchRequest writes a switch request to the client. It's only for testing.
-func (p *PacketIO) WriteSwitchRequest(authPlugin string, salt []byte) error {
+func (p *PacketIO) WriteSwitchRequest(authPlugin string, salt [20]byte) error {
 	length := 1 + len(authPlugin) + 1 + len(salt) + 1
 	data := make([]byte, 0, length)
 	// check https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_auth_switch_request.html
 	data = append(data, byte(AuthSwitchHeader))
 	data = append(data, authPlugin...)
 	data = append(data, 0x00)
-	data = append(data, salt...)
+	data = append(data, salt[:]...)
 	data = append(data, 0x00)
 	return p.WritePacket(data, true)
 }

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -76,7 +76,7 @@ func TestPacketIO(t *testing.T) {
 			require.NoError(t, err)
 		},
 		func(t *testing.T, srv *PacketIO) {
-			var salt [40]byte
+			var salt [20]byte
 			var msg []byte
 			var err error
 
@@ -95,10 +95,7 @@ func TestPacketIO(t *testing.T) {
 			}
 
 			// send handshake
-			require.NoError(t, srv.WriteInitialHandshake(0, salt[:], AuthNativePassword, ServerVersion, 100))
-			// salt should not be long enough
-			require.ErrorIs(t, srv.WriteInitialHandshake(0, make([]byte, 4), AuthNativePassword, ServerVersion, 100), ErrSaltNotLongEnough)
-
+			require.NoError(t, srv.WriteInitialHandshake(0, salt, AuthNativePassword, ServerVersion, 100))
 			// expect correct and wrong capability flags
 			_, isSSL, err := srv.ReadSSLRequestOrHandshakeResp()
 			require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #472

Problem Summary:
When there are many idle connections on a TiProxy instance, the CPU usage jitters every 2 minutes because of GC.

What is changed and how it works:
- Replace `time.After` to `time.Ticker`
- Replace `sync.Map` with `map` and `sync.Lock`
- Other optimizations like `header`, `salt`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Run and profile to see the frame graph and the overhead disappears.

alloc_objects:
![alloc](https://github.com/pingcap/tiproxy/assets/29590578/7e663e32-b27c-4737-9e91-c403a5564494)

inuse_objects:
![inuse](https://github.com/pingcap/tiproxy/assets/29590578/df54ff33-5850-4f1b-a7e9-fb91a8fa9d10)

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Reduce GC CPU usage by 1% in the case of plenty of connections
```
