### PR TITLE
config: replace fsnotify with reloading config file periodically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/cenkalti/backoff/v4 v4.2.1
-	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-contrib/pprof v1.4.0
 	github.com/gin-gonic/gin v1.8.1
 	github.com/go-mysql-org/go-mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1041,7 +1039,6 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -7,49 +7,24 @@ import (
 	"bytes"
 	"hash/crc32"
 	"os"
-	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/fsnotify/fsnotify"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"go.uber.org/zap"
 )
 
 func (e *ConfigManager) reloadConfigFile(file string) error {
-	proxyConfigData, err := os.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	return e.SetTOMLConfig(proxyConfigData)
-}
-
-func (e *ConfigManager) handleFSEvent(ev fsnotify.Event, f string) {
-	switch {
-	case ev.Has(fsnotify.Create), ev.Has(fsnotify.Write), ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
-		// The file may be the log file, triggering reload will cause more logs and thus cause reload again,
-		// so we need to filter the wrong files.
-		// The filesystem differs from OS to OS, so don't use string comparison.
-		f1, err := os.Stat(ev.Name)
-		if err != nil {
-			break
-		}
-		f2, err := os.Stat(f)
-		if err != nil {
-			break
-		}
-		if !os.SameFile(f1, f2) {
-			break
-		}
-		if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
-			// in case of remove/rename the file, files are not present at filesystem for a while
-			// it may be too fast to read the config file now, sleep for a while
-			time.Sleep(50 * time.Millisecond)
-		}
-		// try to reload it
-		e.logger.Info("config file reloaded", zap.Stringer("event", ev), zap.Error(e.reloadConfigFile(f)))
+	if bytes.Equal(content, e.fileContent) {
+		return nil
 	}
+	e.fileContent = content
+
+	return e.SetTOMLConfig(content)
 }
 
 // SetTOMLConfig will do partial config update. Usually, user will expect config changes

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -260,7 +260,7 @@ func TestFilePath(t *testing.T) {
 		}
 
 		for i, test := range tests {
-			t.Log(fmt.Sprintf("%dth test", i+1))
+			t.Logf("%dth test", i+1)
 			if test.createFile != nil {
 				test.createFile()
 			} else {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #468 

Problem Summary:
When the watched directory is removed and recreated immediately, sometimes fsnotify doesn't report an error and TiProxy is not aware of file change.

What is changed and how it works:
Simply reload the file periodically and set config if the file content changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix the bug that the config file may not be reloaded if the directory is removed and recreated immediately.
```
