### PR TITLE
backend, net: add more logs

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-
 	"net"
 	"os"
 	"strings"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -277,11 +277,27 @@ func (mgr *BackendConnManager) getBackendIO(ctx context.Context, cctx ConnContex
 // ExecuteCmd forwards messages between the client and the backend.
 // If it finds that the session is ready for redirection, it migrates the session.
 func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (err error) {
+	startTime := monotime.Now()
 	mgr.processLock.Lock()
 	defer func() {
 		mgr.setQuitSourceByErr(err)
 		mgr.handshakeHandler.OnTraffic(mgr)
-		mgr.lastActiveTime = monotime.Now()
+		now := monotime.Now()
+		cmd, data := pnet.Command(request[0]), request[1:]
+		var query string
+		if cmd == pnet.ComQuery {
+			query = parser.Normalize(pnet.ParseQueryPacket(data))
+			if len(query) > 256 {
+				query = query[:256]
+			}
+		}
+		if err != nil && errors.Is(err, ErrBackendConn) {
+			// idle_time: maybe the idle time exceeds wait_timeout?
+			// execute_time and query: maybe this query causes TiDB OOM?
+			mgr.logger.Info("backend disconnects", zap.Duration("idle_time", time.Duration(now-mgr.lastActiveTime)),
+				zap.Duration("execute_time", time.Duration(now-startTime)), zap.Stringer("cmd", cmd), zap.String("query", query))
+		}
+		mgr.lastActiveTime = now
 		mgr.processLock.Unlock()
 	}()
 	if len(request) < 1 {
@@ -289,7 +305,6 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 		return
 	}
 	cmd := pnet.Command(request[0])
-	startTime := monotime.Now()
 
 	// Once the request is accepted, it's treated in the transaction, so we don't check graceful shutdown here.
 	if mgr.closeStatus.Load() >= statusClosing {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -283,15 +283,15 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 		mgr.setQuitSourceByErr(err)
 		mgr.handshakeHandler.OnTraffic(mgr)
 		now := monotime.Now()
-		cmd, data := pnet.Command(request[0]), request[1:]
-		var query string
-		if cmd == pnet.ComQuery {
-			query = parser.Normalize(pnet.ParseQueryPacket(data))
-			if len(query) > 256 {
-				query = query[:256]
-			}
-		}
 		if err != nil && errors.Is(err, ErrBackendConn) {
+			cmd, data := pnet.Command(request[0]), request[1:]
+			var query string
+			if cmd == pnet.ComQuery {
+				query = parser.Normalize(pnet.ParseQueryPacket(data))
+				if len(query) > 256 {
+					query = query[:256]
+				}
+			}
 			// idle_time: maybe the idle time exceeds wait_timeout?
 			// execute_time and query: maybe this query causes TiDB OOM?
 			mgr.logger.Info("backend disconnects", zap.Duration("idle_time", time.Duration(now-mgr.lastActiveTime)),

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -467,3 +467,12 @@ func Attr2ZapFields(attrs map[string]string) []zap.Field {
 	}
 	return fields
 }
+
+// ParseQueryPacket returns the statement in the CMD_QUERY packet.
+// data is the payload after byte CMD_QUERY.
+func ParseQueryPacket(data []byte) string {
+	if len(data) > 0 && data[len(data)-1] == 0 {
+		data = data[:len(data)-1]
+	}
+	return hack.String(data)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #406 

Problem Summary:
Add more logs for observability.

What is changed and how it works:
Add logs:
- the duration and text of the query when TiDB disconnects (may relate to OOM)
- the idle time of the connection when TiDB disconnects (maybe disconnected by TiDB because of wait_timeout)
- report a warning when the sequence mismatches

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
