### PR TITLE
api: support get json format for config by setting Accept header

### DIFF
--- a/pkg/server/api/config.go
+++ b/pkg/server/api/config.go
@@ -37,6 +37,7 @@ func (h *Server) ConfigSet(c *gin.Context) {
 
 func (h *Server) ConfigGet(c *gin.Context) {
 	// TiDB cluster_config uses format=json, while tiproxyctl expects toml (both PUT and GET) by default.
+	// Users can choose the format on TiDB-Dashboard.
 	if strings.EqualFold(c.Query("format"), "json") || c.GetHeader("Accept") == "application/json" {
 		c.JSON(http.StatusOK, h.mgr.cfg.GetConfig())
 	} else {

--- a/pkg/server/api/config.go
+++ b/pkg/server/api/config.go
@@ -6,6 +6,7 @@ package api
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -35,10 +36,10 @@ func (h *Server) ConfigSet(c *gin.Context) {
 }
 
 func (h *Server) ConfigGet(c *gin.Context) {
-	switch c.Query("format") {
-	case "json":
+	// TiDB cluster_config uses format=json, while tiproxyctl expects toml (both PUT and GET) by default.
+	if strings.EqualFold(c.Query("format"), "json") || c.GetHeader("Accept") == "application/json" {
 		c.JSON(http.StatusOK, h.mgr.cfg.GetConfig())
-	default:
+	} else {
 		c.TOML(http.StatusOK, h.mgr.cfg.GetConfig())
 	}
 }

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -124,8 +124,10 @@ func TestAcceptType(t *testing.T) {
 		var cfg config.Config
 		switch expectedType {
 		case "json":
+			require.Contains(t, r.Header.Get("Content-Type"), "application/json")
 			require.NoError(t, json.Unmarshal(data, &cfg))
 		default:
+			require.Contains(t, r.Header.Get("Content-Type"), "application/toml")
 			require.NoError(t, toml.Unmarshal(data, &cfg))
 		}
 	}

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -4,19 +4,22 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/BurntSushi/toml"
+	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
 	_, doHTTP := createServer(t, nil)
 
-	doHTTP(t, http.MethodGet, "/api/admin/config", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `
@@ -72,7 +75,7 @@ max-backups = 3
 `, string(regexp.MustCompile("workdir = '.+'\n").ReplaceAll(all, nil)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `{"proxy":{"addr":"0.0.0.0:6000","pd-addrs":"127.0.0.1:2379","frontend-keepalive":{"enabled":true},"backend-healthy-keepalive":{"enabled":true,"idle":60000000000,"cnt":5,"intvl":3000000000,"timeout":15000000000},"backend-unhealthy-keepalive":{"enabled":true,"idle":10000000000,"cnt":5,"intvl":1000000000,"timeout":5000000000},"graceful-close-conn-timeout":15},"api":{"addr":"0.0.0.0:3080"},"advance":{"ignore-wrong-namespace":true},"security":{"server-tls":{"min-tls-version":"1.2"},"server-http-tls":{"min-tls-version":"1.2"},"cluster-tls":{"min-tls-version":"1.2"},"sql-tls":{"min-tls-version":"1.2"}},"log":{"encoder":"tidb","level":"info","log-file":{"max-size":300,"max-days":3,"max-backups":3}}}`,
@@ -80,34 +83,65 @@ max-backups = 3
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = true"), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = true"), nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	sum := ""
 	sumreg := regexp.MustCompile(`{"config_checksum":(.+)}`)
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		sum = string(sumreg.Find(all))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("proxy.require-back = false"), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("proxy.require-back = false"), nil, func(t *testing.T, r *http.Response) {
 		// no error
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, sum, string(sumreg.Find(all)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = false"), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = false"), nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.NotEqual(t, sum, string(sumreg.Find(all)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+}
+
+func TestAcceptType(t *testing.T) {
+	_, doHTTP := createServer(t, nil)
+	checkRespContentType := func(expectedType string, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var cfg config.Config
+		switch expectedType {
+		case "json":
+			require.NoError(t, json.Unmarshal(data, &cfg))
+		default:
+			require.NoError(t, toml.Unmarshal(data, &cfg))
+		}
+	}
+	doHTTP(t, http.MethodGet, "/api/admin/config", nil, nil, func(t *testing.T, r *http.Response) {
+		checkRespContentType("toml", r)
+	})
+	doHTTP(t, http.MethodGet, "/api/admin/config", nil, map[string]string{"Accept": "application/json"}, func(t *testing.T, r *http.Response) {
+		checkRespContentType("json", r)
+	})
+	doHTTP(t, http.MethodGet, "/api/admin/config", nil, map[string]string{"Accept": "application/toml"}, func(t *testing.T, r *http.Response) {
+		checkRespContentType("toml", r)
+	})
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, nil, func(t *testing.T, r *http.Response) {
+		checkRespContentType("json", r)
+	})
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=JSON", nil, nil, func(t *testing.T, r *http.Response) {
+		checkRespContentType("json", r)
 	})
 }

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -14,23 +14,23 @@ func TestDebug(t *testing.T) {
 	closing := true
 	_, doHTTP := createServer(t, &closing)
 
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 	})
 
 	closing = false
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodPost, "/api/debug/redirect", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/debug/redirect", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/redirect", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/redirect", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusNotFound, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodGet, "/api/debug/pprof", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/pprof", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 }

--- a/pkg/server/api/metrics_test.go
+++ b/pkg/server/api/metrics_test.go
@@ -13,7 +13,7 @@ import (
 func TestMetrics(t *testing.T) {
 	_, doHTTP := createServer(t, nil)
 
-	doHTTP(t, http.MethodGet, "/api/metrics", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/metrics", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 }

--- a/pkg/server/api/namespace_test.go
+++ b/pkg/server/api/namespace_test.go
@@ -16,7 +16,7 @@ func TestNamespace(t *testing.T) {
 	_, doHTTP := createServer(t, nil)
 
 	// test list
-	doHTTP(t, http.MethodGet, "/api/admin/namespace", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `""`, string(all))
@@ -24,15 +24,15 @@ func TestNamespace(t *testing.T) {
 	})
 
 	// test set
-	doHTTP(t, http.MethodPut, "/api/admin/namespace/gg", strings.NewReader(`{}`), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/namespace/gg", strings.NewReader(`{}`), nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/namespace", strings.NewReader(`{"namespace": "dge"}`), func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/namespace", strings.NewReader(`{"namespace": "dge"}`), nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
 	// test get
-	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `{"namespace":"dge","frontend":{"user":"","security":{}},"backend":{"instances":null,"security":{}}}`, string(all))
@@ -40,18 +40,18 @@ func TestNamespace(t *testing.T) {
 	})
 
 	// test remove
-	doHTTP(t, http.MethodDelete, "/api/admin/namespace/dge", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodDelete, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
 
 	// test commit
-	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit?namespace=xx", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit?namespace=xx", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit", nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #483 

Problem Summary:
`/api/admin/config` doesn't respect `Accept` field in the request header, while some applications may expect a json format.

What is changed and how it works:
If `Accept` is `json` or `format` is `json`, return a json format.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support get JSON format config for /api/admin/config by setting Accept='application/json' in the request header
```
