### PR TITLE
backend: fix panic when reading result set fails

### DIFF
--- a/pkg/proxy/backend/cmd_processor_query.go
+++ b/pkg/proxy/backend/cmd_processor_query.go
@@ -39,8 +39,9 @@ func (cp *CmdProcessor) query(packetIO *pnet.PacketIO, sql string) (result *mysq
 		err = errors.WithStack(mysql.ErrMalformPacket)
 	default:
 		var rs *mysql.Result
-		rs, err = cp.readResultSet(packetIO, response)
-		result = rs.Resultset
+		if rs, err = cp.readResultSet(packetIO, response); err == nil {
+			result = rs.Resultset
+		}
 	}
 	return
 }

--- a/pkg/proxy/backend/cmd_processor_test.go
+++ b/pkg/proxy/backend/cmd_processor_test.go
@@ -1068,3 +1068,35 @@ func TestNetworkError(t *testing.T) {
 	ts.query(t, proxyErrChecker)
 	clean()
 }
+
+// Test that TiProxy won't panic when query encounters an error.
+func TestQueryError(t *testing.T) {
+	tc := newTCPConnSuite(t)
+	tests := []struct {
+		cfg cfgOverrider
+		c   checker
+	}{
+		{
+			cfg: func(cfg *testConfig) {
+				cfg.backendConfig.abnormalExit = true
+			},
+		},
+		{
+			cfg: func(cfg *testConfig) {
+				cfg.backendConfig.respondType = responseTypeErr
+			},
+		},
+		{
+			cfg: func(cfg *testConfig) {
+				cfg.backendConfig.respondType = responseTypeResultSet
+				cfg.backendConfig.columns = 1
+				cfg.backendConfig.exitInResult = true
+			},
+		},
+	}
+	for _, test := range tests {
+		ts, clean := newTestSuite(t, tc, test.cfg)
+		ts.query(t, func(t *testing.T, ts *testSuite) {})
+		clean()
+	}
+}

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -28,6 +28,7 @@ type backendConfig struct {
 	proxyProtocol bool
 	authSucceed   bool
 	abnormalExit  bool
+	exitInResult  bool
 }
 
 func newBackendConfig() *backendConfig {
@@ -292,6 +293,12 @@ func (mb *mockBackend) writeResultSet(packetIO *pnet.PacketIO, names []string, v
 			if err := packetIO.WritePacket(field.Dump(), false); err != nil {
 				return err
 			}
+		}
+		if mb.exitInResult {
+			if err := packetIO.Flush(); err != nil {
+				return err
+			}
+			return packetIO.Close()
 		}
 
 		if status&mysql.SERVER_STATUS_CURSOR_EXISTS == 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #485 

Problem Summary:
TiProxy doesn't handle errors when processing result sets, and it reports nil pointer reference.

What is changed and how it works:
Check the error first.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix panic when a TiDB fails during session migration.
```
