### PR TITLE
config, info: add config `proxy.advertise-addr`

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -2,6 +2,7 @@
 
 [proxy]
 # addr = "0.0.0.0:6000"
+# advertise-addr = ""
 # tcp-keep-alive = true
 
 # possible values:

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -56,6 +56,7 @@ type ProxyServerOnline struct {
 
 type ProxyServer struct {
 	Addr              string `yaml:"addr,omitempty" toml:"addr,omitempty" json:"addr,omitempty"`
+	AdvertiseAddr     string `yaml:"advertise-addr,omitempty" toml:"advertise-addr,omitempty" json:"advertise-addr,omitempty"`
 	PDAddrs           string `yaml:"pd-addrs,omitempty" toml:"pd-addrs,omitempty" json:"pd-addrs,omitempty"`
 	ProxyServerOnline `yaml:",inline" toml:",inline" json:",inline"`
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #494

Problem Summary:
TiProxy registers its IP to ETCD and TiDB/TiDB-Dashboard queries its config/pprof through IP, while the certificates in TiProxy may only contain DNS (especially in k8s) and the query fails.

What is changed and how it works:
Add `proxy.advertise-addr` to the config. Later, I'll update TiUP and TiDB-Operator to pass the DNS in the config.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Add configuration `proxy.advertise-addr`
```
