### PR TITLE
router: speed up health check by checking in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stathat/consistent v1.0.0 // indirect
-	github.com/tiancaiamao/gp v0.0.0-20221221095600-1a473d1f9b4b // indirect
+	github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5 // indirect
 	github.com/tikv/client-go/v2 v2.0.4-0.20221226080148-018c59dbd837 // indirect
 	github.com/tikv/pd/client v0.0.0-20221031025758-80f0d8ca4d07 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,8 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tiancaiamao/gp v0.0.0-20221221095600-1a473d1f9b4b h1:4RNtqw1/tW67qP9fFgfQpTVd7DrfkaAWu4vsC18QmBo=
-github.com/tiancaiamao/gp v0.0.0-20221221095600-1a473d1f9b4b/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
+github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5 h1:4bvGDLXwsP4edNa9igJz+oU1kmZ6S3PSjrnOFgh5Xwk=
+github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 github.com/tidwall/btree v1.5.2 h1:5eA83Gfki799V3d3bJo9sWk+yL2LRoTEah3O/SA6/8w=
 github.com/tidwall/btree v1.5.2/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tikv/client-go/v2 v2.0.4-0.20221226080148-018c59dbd837 h1:m6glgBGCIds9QURbk8Mn+8mjLKDcv6nWrNwYh92fydQ=

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.1
+	github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5
 	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.23.0
 )

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -39,6 +39,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5 h1:4bvGDLXwsP4edNa9igJz+oU1kmZ6S3PSjrnOFgh5Xwk=
+github.com/tiancaiamao/gp v0.0.0-20230126082955-4f9e4f1ed9b5/go.mod h1:h4xBhSNtOeEosLJ4P7JyKXX7Cabg7AVkWCK5gV2vOrM=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/lib/util/waitgroup/waitgroup.go
+++ b/lib/util/waitgroup/waitgroup.go
@@ -5,7 +5,9 @@ package waitgroup
 
 import (
 	"sync"
+	"time"
 
+	"github.com/tiancaiamao/gp"
 	"go.uber.org/zap"
 )
 
@@ -32,23 +34,53 @@ func (w *WaitGroup) Run(exec func()) {
 func (w *WaitGroup) RunWithRecover(exec func(), recoverFn func(r interface{}), logger *zap.Logger) {
 	w.Add(1)
 	go func() {
-		defer func() {
-			r := recover()
-			defer func() {
-				// If it panics again in recovery, quit ASAP.
-				_ = recover()
-			}()
-			if r != nil && logger != nil {
-				logger.Error("panic in the recoverable goroutine",
-					zap.Reflect("r", r),
-					zap.Stack("stack trace"))
-			}
-			// Call Done() before recoverFn because recoverFn normally calls `Close()`, which may call `wg.Wait()`.
-			w.Done()
-			if r != nil && recoverFn != nil {
-				recoverFn(r)
-			}
-		}()
+		defer recoverFromErr(&w.WaitGroup, recoverFn, logger)
 		exec()
 	}()
+}
+
+func recoverFromErr(wg *sync.WaitGroup, recoverFn func(r interface{}), logger *zap.Logger) {
+	r := recover()
+	defer func() {
+		// If it panics again in recovery, quit ASAP.
+		_ = recover()
+	}()
+	if r != nil && logger != nil {
+		logger.Error("panic in the recoverable goroutine",
+			zap.Reflect("r", r),
+			zap.Stack("stack trace"))
+	}
+	// Call Done() before recoverFn because recoverFn normally calls `Close()`, which may call `wg.Wait()`.
+	wg.Done()
+	if r != nil && recoverFn != nil {
+		recoverFn(r)
+	}
+}
+
+// WaitGroupPool is a wrapper for sync.WaitGroup and gp.Pool.
+type WaitGroupPool struct {
+	sync.WaitGroup
+	pool *gp.Pool
+}
+
+// NewWaitGroupPool returns WaitGroupPool.
+func NewWaitGroupPool(n int, idleDuration time.Duration) *WaitGroupPool {
+	return &WaitGroupPool{
+		pool: gp.New(n, idleDuration),
+	}
+}
+
+// RunWithRecover runs a function in a goroutine, adds 1 to WaitGroup
+// and calls done when function returns.
+func (w *WaitGroupPool) RunWithRecover(exec func(), recoverFn func(r interface{}), logger *zap.Logger) {
+	w.Add(1)
+	w.pool.Go(func() {
+		defer recoverFromErr(&w.WaitGroup, recoverFn, logger)
+		exec()
+	})
+}
+
+func (w *WaitGroupPool) Close() {
+	w.pool.Close()
+	w.Wait()
 }

--- a/lib/util/waitgroup/waitgroup_test.go
+++ b/lib/util/waitgroup/waitgroup_test.go
@@ -5,6 +5,7 @@ package waitgroup
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
@@ -28,4 +29,22 @@ func TestWithRecoveryPanic(t *testing.T) {
 		panic("mock panic2")
 	}, nil)
 	wg.Wait()
+}
+
+func TestWaitGroupPool(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	wgp := NewWaitGroupPool(5, time.Millisecond)
+	for i := 0; i < 10; i++ {
+		wgp.RunWithRecover(func() {
+			time.Sleep(10 * time.Millisecond)
+		}, nil, lg)
+	}
+	wgp.Wait()
+	time.Sleep(10 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		wgp.RunWithRecover(func() {
+			time.Sleep(10 * time.Millisecond)
+		}, nil, lg)
+	}
+	wgp.Close()
 }

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -111,6 +111,17 @@ func TestCancelObserver(t *testing.T) {
 	}
 }
 
+func TestDisableHealthCheck2(t *testing.T) {
+	ts := newObserverTestSuite(t)
+	ts.bo.healthCheckConfig.Enable = false
+	t.Cleanup(ts.close)
+
+	backend1 := ts.addBackend()
+	ts.setHealth(backend1, StatusCannotConnect)
+	ts.bo.Start()
+	ts.checkStatus(backend1, StatusHealthy)
+}
+
 type observerTestSuite struct {
 	t           *testing.T
 	bo          *BackendObserver

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -68,6 +68,22 @@ func TestObserveBackends(t *testing.T) {
 	ts.checkStatus(backend1, StatusCannotConnect)
 }
 
+func TestObserveInParallel(t *testing.T) {
+	ts := newObserverTestSuite(t)
+	t.Cleanup(ts.close)
+
+	var backend string
+	for i := 0; i < 100; i++ {
+		backend = ts.addBackend()
+	}
+	ts.bo.Start()
+	backends := ts.getBackendsFromCh()
+	require.Equal(ts.t, 100, len(backends))
+	// Wait for next loop.
+	ts.setHealth(backend, StatusCannotConnect)
+	ts.checkStatus(backend, StatusCannotConnect)
+}
+
 // Test that the health check can exit when the context is cancelled.
 func TestCancelObserver(t *testing.T) {
 	ts := newObserverTestSuite(t)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #216 

Problem Summary:
In a large cluster, checking health serially is impractical.

What is changed and how it works:
- Define a wrapper for wait group and goroutine pool
- Check the health by the goroutine pool

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Speed up health check by checking in parallel
```
