### PR TITLE
metricsreader, infosync: read metrics from prometheus

### DIFF
--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -32,27 +32,33 @@ const (
 	healthCheckMaxRetries    = 3
 	healthCheckRetryInterval = 1 * time.Second
 	healthCheckTimeout       = 2 * time.Second
+	readMetricsInterval      = 15 * time.Second
+	readMetricsTimeout       = 3 * time.Second
 )
 
 // HealthCheck contains some configurations for health check.
 // Some general configurations of them may be exposed to users in the future.
 // We can use shorter durations to speed up unit tests.
 type HealthCheck struct {
-	Enable        bool          `yaml:"enable" json:"enable" toml:"enable"`
-	Interval      time.Duration `yaml:"interval" json:"interval" toml:"interval"`
-	MaxRetries    int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
-	RetryInterval time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
-	DialTimeout   time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
+	Enable          bool          `yaml:"enable" json:"enable" toml:"enable"`
+	Interval        time.Duration `yaml:"interval" json:"interval" toml:"interval"`
+	MaxRetries      int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
+	RetryInterval   time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
+	DialTimeout     time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
+	MetricsInterval time.Duration `yaml:"metrics-interval" json:"metrics-interval" toml:"metrics-interval"`
+	MetricsTimeout  time.Duration `yaml:"metrics-timeout" json:"metrics-timeout" toml:"metrics-timeout"`
 }
 
 // NewDefaultHealthCheckConfig creates a default HealthCheck.
 func NewDefaultHealthCheckConfig() *HealthCheck {
 	return &HealthCheck{
-		Enable:        true,
-		Interval:      healthCheckInterval,
-		MaxRetries:    healthCheckMaxRetries,
-		RetryInterval: healthCheckRetryInterval,
-		DialTimeout:   healthCheckTimeout,
+		Enable:          true,
+		Interval:        healthCheckInterval,
+		MaxRetries:      healthCheckMaxRetries,
+		RetryInterval:   healthCheckRetryInterval,
+		DialTimeout:     healthCheckTimeout,
+		MetricsInterval: readMetricsInterval,
+		MetricsTimeout:  readMetricsTimeout,
 	}
 }
 
@@ -68,6 +74,12 @@ func (hc *HealthCheck) Check() {
 	}
 	if hc.DialTimeout == 0 {
 		hc.DialTimeout = healthCheckTimeout
+	}
+	if hc.MetricsInterval == 0 {
+		hc.MetricsInterval = readMetricsInterval
+	}
+	if hc.MetricsTimeout == 0 {
+		hc.MetricsTimeout = readMetricsTimeout
 	}
 }
 

--- a/pkg/manager/metricsreader/metrics_reader.go
+++ b/pkg/manager/metricsreader/metrics_reader.go
@@ -1,0 +1,259 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"go.uber.org/zap"
+)
+
+type QueryExpr struct {
+	PromQL   string
+	Range    time.Duration
+	HasLabel bool
+}
+
+const (
+	getPromNone = iota
+	getPromOK
+	getPromFail
+)
+
+type PromInfoFetcher interface {
+	GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, error)
+}
+
+type MetricsReader interface {
+	Start(ctx context.Context)
+	AddQueryExpr(queryExpr QueryExpr) uint64
+	RemoveQueryExpr(id uint64)
+	GetQueryResult(id uint64) QueryResult
+	Subscribe(receiverName string) <-chan struct{}
+	Close()
+}
+
+var _ MetricsReader = (*DefaultMetricsReader)(nil)
+
+type DefaultMetricsReader struct {
+	sync.Mutex
+	queryExprs   map[uint64]QueryExpr
+	queryResults map[uint64]QueryResult
+	notifyCh     map[string]chan struct{}
+	wg           waitgroup.WaitGroup
+	promFetcher  PromInfoFetcher
+	cancel       context.CancelFunc
+	lg           *zap.Logger
+	cfg          *config.HealthCheck
+	lastID       uint64
+	getPromRes   int
+}
+
+func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, cfg *config.HealthCheck) *DefaultMetricsReader {
+	return &DefaultMetricsReader{
+		lg:           lg,
+		promFetcher:  promFetcher,
+		cfg:          cfg,
+		queryExprs:   make(map[uint64]QueryExpr),
+		queryResults: make(map[uint64]QueryResult),
+		notifyCh:     make(map[string]chan struct{}),
+	}
+}
+
+func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
+	childCtx, cancel := context.WithCancel(ctx)
+	dmr.cancel = cancel
+	dmr.wg.RunWithRecover(func() {
+		ticker := time.NewTicker(dmr.cfg.MetricsInterval)
+		defer ticker.Stop()
+		for childCtx.Err() == nil {
+			if results, err := dmr.readMetrics(childCtx); err != nil {
+				dmr.lg.Warn("read metrics failed", zap.Error(err))
+			} else if len(results) > 0 {
+				dmr.Lock()
+				dmr.queryResults = results
+				dmr.Unlock()
+				dmr.notifySubscribers(ctx)
+			}
+			select {
+			case <-ticker.C:
+			case <-childCtx.Done():
+				return
+			}
+		}
+	}, nil, dmr.lg)
+}
+
+// Always refresh the prometheus Address just in case it changes.
+func (dmr *DefaultMetricsReader) getPromAPI(ctx context.Context) (promv1.API, error) {
+	promInfo, err := dmr.promFetcher.GetPromInfo(ctx)
+	if promInfo == nil && dmr.getPromRes != getPromFail {
+		dmr.getPromRes = getPromFail
+		dmr.lg.Warn("get prometheus address fails", zap.Error(err))
+	}
+	if err != nil {
+		return nil, err
+	}
+	// TODO: support TLS and authentication.
+	promAddr := fmt.Sprintf("http://%s", net.JoinHostPort(promInfo.IP, strconv.Itoa(promInfo.Port)))
+	if dmr.getPromRes != getPromOK {
+		dmr.getPromRes = getPromOK
+		dmr.lg.Info("get prometheus address succeeds", zap.String("addr", promAddr))
+	}
+	promClient, err := api.NewClient(api.Config{
+		Address: promAddr,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return promv1.NewAPI(promClient), nil
+}
+
+func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) (map[uint64]QueryResult, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	promQLAPI, err := dmr.getPromAPI(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dmr.Lock()
+	copyedMap := make(map[uint64]QueryExpr, len(dmr.queryExprs))
+	for id, expr := range dmr.queryExprs {
+		copyedMap[id] = expr
+	}
+	dmr.Unlock()
+	results := make(map[uint64]QueryResult, len(copyedMap))
+	now := time.Now()
+	for id, expr := range copyedMap {
+		results[id] = dmr.queryMetric(ctx, promQLAPI, expr, now)
+	}
+	return results, nil
+}
+
+func (dmr *DefaultMetricsReader) queryMetric(ctx context.Context, promQLAPI promv1.API, expr QueryExpr, curTime time.Time) QueryResult {
+	promRange := promv1.Range{Start: curTime.Add(-expr.Range), End: curTime, Step: 15 * time.Second}
+	if !expr.HasLabel {
+		return dmr.queryOnce(ctx, promQLAPI, expr.PromQL, promRange)
+	}
+
+	// The label key is `job` in TiUP but is `component` in TiOperator. We don't know which, so try them both.
+	var qr QueryResult
+	for _, label := range [2]string{"job", "component"} {
+		promQL := fmt.Sprintf(expr.PromQL, label)
+		qr = dmr.queryOnce(ctx, promQLAPI, promQL, promRange)
+		if qr.Err != nil {
+			break
+		}
+		if !qr.Empty() {
+			expr.PromQL = promQL
+			expr.HasLabel = false
+			break
+		}
+	}
+	return qr
+}
+
+func (dmr *DefaultMetricsReader) queryOnce(ctx context.Context, promQLAPI promv1.API, promQL string, promRange promv1.Range) QueryResult {
+	childCtx, cancel := context.WithTimeout(ctx, dmr.cfg.MetricsTimeout)
+	var qr QueryResult
+	qr.Err = backoff.Retry(func() error {
+		var err error
+		qr.Value, _, err = promQLAPI.QueryRange(childCtx, promQL, promRange)
+		if !isRetryableError(err) {
+			return backoff.Permanent(errors.WithStack(err))
+		}
+		return errors.WithStack(err)
+	}, backoff.WithContext(backoff.NewConstantBackOff(0), childCtx))
+	cancel()
+	return qr
+}
+
+func (dmr *DefaultMetricsReader) AddQueryExpr(queryExpr QueryExpr) uint64 {
+	dmr.Lock()
+	defer dmr.Unlock()
+	dmr.lastID++
+	dmr.queryExprs[dmr.lastID] = queryExpr
+	return dmr.lastID
+}
+
+func (dmr *DefaultMetricsReader) RemoveQueryExpr(id uint64) {
+	dmr.Lock()
+	defer dmr.Unlock()
+	delete(dmr.queryExprs, id)
+}
+
+func (dmr *DefaultMetricsReader) GetQueryResult(id uint64) QueryResult {
+	dmr.Lock()
+	defer dmr.Unlock()
+	// Return an empty QueryResult if it's not found.
+	return dmr.queryResults[id]
+}
+
+func (dmr *DefaultMetricsReader) Subscribe(receiverName string) <-chan struct{} {
+	ch := make(chan struct{}, 1)
+	dmr.Lock()
+	dmr.notifyCh[receiverName] = ch
+	dmr.Unlock()
+	return ch
+}
+
+func (dmr *DefaultMetricsReader) notifySubscribers(ctx context.Context) {
+	dmr.Lock()
+	defer dmr.Unlock()
+	for name, ch := range dmr.notifyCh {
+		// If one receiver blocks or panics and doesn't read the channel, we should skip and continue.
+		select {
+		case ch <- struct{}{}:
+		case <-time.After(100 * time.Millisecond):
+			dmr.lg.Warn("fails to notify metrics result", zap.String("receiver", name))
+		case <-ctx.Done():
+		}
+	}
+}
+
+func (dmr *DefaultMetricsReader) Close() {
+	if dmr.cancel != nil {
+		dmr.cancel()
+	}
+	dmr.wg.Wait()
+	dmr.Lock()
+	for _, ch := range dmr.notifyCh {
+		close(ch)
+	}
+	dmr.Unlock()
+}
+
+// TODO: Move health_check to this package and remove this duplicated function.
+// When the server refused to connect, the port is shut down, so no need to retry.
+var notRetryableError = []string{
+	"connection refused",
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, errStr := range notRetryableError {
+		if strings.Contains(msg, errStr) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/manager/metricsreader/metrics_reader_test.go
+++ b/pkg/manager/metricsreader/metrics_reader_test.go
@@ -1,0 +1,415 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadMetrics(t *testing.T) {
+	httpHandler, mr := setupTypicalMetricsReader(t)
+	ch := mr.Subscribe("test")
+
+	tests := []struct {
+		promQL         string
+		hasLabel       bool
+		respBody       string
+		expectedString string
+		expectedType   model.ValueType
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+			expectedType:   model.ValMatrix,
+		},
+		{
+			promQL:         `go_goroutines{%s="tidb"}`,
+			hasLabel:       true,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+			expectedType:   model.ValMatrix,
+		},
+		{
+			promQL:         `unknown`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+			expectedString: ``,
+			expectedType:   model.ValMatrix,
+		},
+	}
+
+	for i, test := range tests {
+		id := mr.AddQueryExpr(QueryExpr{
+			PromQL:   test.promQL,
+			Range:    time.Minute,
+			HasLabel: test.hasLabel,
+		})
+		f := func(reqBody string) string {
+			return test.respBody
+		}
+		httpHandler.getRespBody.Store(&f)
+		msg := fmt.Sprintf("%dth test", i)
+		var qr QueryResult
+		require.Eventually(t, func() bool {
+			<-ch
+			qr = mr.GetQueryResult(id)
+			return qr.Value != nil || qr.Err != nil
+		}, 3*time.Second, time.Millisecond, msg)
+		require.NoError(t, qr.Err, msg)
+		require.Equal(t, test.expectedType, qr.Value.Type(), msg)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+		mr.RemoveQueryExpr(id)
+	}
+}
+
+func TestMultiExprs(t *testing.T) {
+	httpHandler, mr := setupTypicalMetricsReader(t)
+	ch := mr.Subscribe("test")
+
+	tests := []struct {
+		promQL         string
+		respBody       string
+		expectedString string
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+		},
+		{
+			promQL:         `go_goroutines`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		},
+		{
+			promQL:         `unknown`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+			expectedString: ``,
+		},
+	}
+
+	f := func(reqBody string) string {
+		for _, test := range tests {
+			if strings.Contains(reqBody, "query="+test.promQL) {
+				return test.respBody
+			}
+		}
+		return ""
+	}
+	httpHandler.getRespBody.Store(&f)
+	for _, test := range tests {
+		mr.AddQueryExpr(QueryExpr{
+			PromQL: test.promQL,
+			Range:  time.Minute,
+		})
+	}
+
+	waitResultReady(t, mr, ch, len(tests))
+	for i, test := range tests {
+		msg := fmt.Sprintf("%dth test", i)
+		qr := mr.GetQueryResult(uint64(i + 1))
+		require.NoError(t, qr.Err, msg)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+	}
+	mr.RemoveQueryExpr(1)
+	require.Eventually(t, func() bool {
+		<-ch
+		qr := mr.GetQueryResult(uint64(1))
+		return qr.Value == nil && qr.Err == nil
+	}, 3*time.Second, time.Millisecond)
+}
+
+func TestBackendLabel(t *testing.T) {
+	httpHandler, mr := setupTypicalMetricsReader(t)
+	ch := mr.Subscribe("test")
+
+	tests := []struct {
+		promQL         string
+		respBody       string
+		expectedString string
+		label          string
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			label:          `job`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+		},
+		{
+			promQL:         `go_goroutines`,
+			label:          `component`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","component":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{component=\"tidb\", instance=\"127.0.0.1:10080\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		},
+	}
+
+	f := func(reqBody string) string {
+		for _, test := range tests {
+			if strings.Contains(reqBody, test.promQL) {
+				if strings.Contains(reqBody, test.label) {
+					return test.respBody
+				} else {
+					return `{"status":"success","data":{"resultType":"matrix","result":[]}}`
+				}
+			}
+		}
+		return ""
+	}
+	httpHandler.getRespBody.Store(&f)
+	for _, test := range tests {
+		mr.AddQueryExpr(QueryExpr{
+			PromQL:   test.promQL + `{%s="tidb"}`,
+			Range:    time.Minute,
+			HasLabel: true,
+		})
+	}
+
+	waitResultReady(t, mr, ch, len(tests))
+	for i, test := range tests {
+		msg := fmt.Sprintf("%dth test", i)
+		qr := mr.GetQueryResult(uint64(i + 1))
+		require.NoError(t, qr.Err, msg)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+	}
+}
+
+func TestMultiSubscribers(t *testing.T) {
+	httpHandler, mr := setupTypicalMetricsReader(t)
+	tests := []struct {
+		promQL         string
+		hasLabel       bool
+		respBody       string
+		expectedString string
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+		},
+		{
+			promQL:         `go_goroutines`,
+			hasLabel:       true,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		},
+		{
+			promQL:         `unknown`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+			expectedString: ``,
+		},
+	}
+
+	f := func(reqBody string) string {
+		for _, test := range tests {
+			if strings.Contains(reqBody, test.promQL) {
+				return test.respBody
+			}
+		}
+		return ""
+	}
+	httpHandler.getRespBody.Store(&f)
+
+	for _, test := range tests {
+		promQL := test.promQL
+		if test.hasLabel {
+			promQL += `{%s="tidb"}`
+		}
+		mr.AddQueryExpr(QueryExpr{
+			PromQL:   promQL,
+			Range:    time.Minute,
+			HasLabel: test.hasLabel,
+		})
+	}
+
+	// This channel never reads again after Eventually to test block.
+	ch := mr.Subscribe("test")
+	waitResultReady(t, mr, ch, len(tests))
+
+	var wg waitgroup.WaitGroup
+	childCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	for i := 0; i < 10; i++ {
+		func(i int) {
+			wg.Run(func() {
+				ch := mr.Subscribe(fmt.Sprintf("test%d", i))
+				for childCtx.Err() == nil {
+					select {
+					case <-ch:
+					case <-time.After(500 * time.Millisecond):
+						t.Fatal("block for over 500ms")
+					case <-childCtx.Done():
+						return
+					}
+
+					for i, test := range tests {
+						msg := fmt.Sprintf("%dth test", i)
+						qr := mr.GetQueryResult(uint64(i + 1))
+						require.NoError(t, qr.Err, msg)
+						require.Equal(t, test.expectedString, qr.Value.String(), msg)
+					}
+				}
+			})
+		}(i)
+	}
+	wg.Wait()
+	cancel()
+}
+
+func TestPromUnavailable(t *testing.T) {
+	mpf := newMockPromFetcher(10000)
+	lg, _ := logger.CreateLoggerForTest(t)
+	mr := NewDefaultMetricsReader(lg, mpf, newHealthCheckConfigForTest())
+	mr.Start(context.Background())
+	t.Cleanup(mr.Close)
+	ch := mr.Subscribe("test")
+	id := mr.AddQueryExpr(QueryExpr{
+		PromQL: "any",
+		Range:  time.Minute,
+	})
+	<-ch
+	qr := mr.GetQueryResult(id)
+	require.True(t, qr.Empty())
+	require.Error(t, qr.Err)
+}
+
+func TestNoPromAddr(t *testing.T) {
+	mpf := &mockPromFetcher{
+		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
+			return nil, nil
+		},
+	}
+	lg, _ := logger.CreateLoggerForTest(t)
+	mr := NewDefaultMetricsReader(lg, mpf, newHealthCheckConfigForTest())
+	mr.Start(context.Background())
+	t.Cleanup(mr.Close)
+	ch := mr.Subscribe("test")
+	mr.AddQueryExpr(QueryExpr{
+		PromQL: "any",
+		Range:  time.Minute,
+	})
+	select {
+	case <-ch:
+		t.Fatal("should not notify")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func setupTypicalMetricsReader(t *testing.T) (*mockHttpHandler, MetricsReader) {
+	httpHandler := &mockHttpHandler{
+		t: t,
+	}
+	port := httpHandler.Start()
+	t.Cleanup(httpHandler.Close)
+	mpf := newMockPromFetcher(port)
+	lg, _ := logger.CreateLoggerForTest(t)
+	mr := NewDefaultMetricsReader(lg, mpf, newHealthCheckConfigForTest())
+	mr.Start(context.Background())
+	t.Cleanup(mr.Close)
+	return httpHandler, mr
+}
+
+type mockPromFetcher struct {
+	getPromInfo func(ctx context.Context) (*infosync.PrometheusInfo, error)
+}
+
+func (mpf *mockPromFetcher) GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, error) {
+	return mpf.getPromInfo(ctx)
+}
+
+func newMockPromFetcher(port int) *mockPromFetcher {
+	return &mockPromFetcher{
+		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
+			return &infosync.PrometheusInfo{
+				IP:   "127.0.0.1",
+				Port: port,
+			}, nil
+		},
+	}
+}
+
+type mockHttpHandler struct {
+	getRespBody atomic.Pointer[func(reqBody string) string]
+	wg          waitgroup.WaitGroup
+	t           *testing.T
+	server      *http.Server
+}
+
+func (handler *mockHttpHandler) Start() int {
+	statusListener, addr := startListener(handler.t, "")
+	_, port := parseHostPort(handler.t, addr)
+	handler.server = &http.Server{Addr: addr, Handler: handler}
+	handler.wg.Run(func() {
+		_ = handler.server.Serve(statusListener)
+	})
+	return int(port)
+}
+
+func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	body, err := io.ReadAll(r.Body)
+	require.NoError(handler.t, err)
+	respBody := (*handler.getRespBody.Load())(string(body))
+	require.True(handler.t, len(respBody) > 0, string(body))
+	_, err = w.Write([]byte(respBody))
+	require.NoError(handler.t, err)
+}
+
+func (handler *mockHttpHandler) Close() {
+	require.NoError(handler.t, handler.server.Close())
+	handler.wg.Wait()
+}
+
+func waitResultReady(t *testing.T, mr MetricsReader, ch <-chan struct{}, resultNum int) {
+	require.Eventually(t, func() bool {
+		<-ch
+		for i := 0; i < resultNum; i++ {
+			qr := mr.GetQueryResult(uint64(i + 1))
+			if qr.Value == nil && qr.Err == nil {
+				return false
+			}
+		}
+		return true
+	}, 3*time.Second, time.Millisecond)
+}
+
+// TODO: move health_check to this package and remove these duplicated functions.
+func newHealthCheckConfigForTest() *config.HealthCheck {
+	return &config.HealthCheck{
+		Enable:          true,
+		MetricsInterval: 10 * time.Millisecond,
+		MetricsTimeout:  100 * time.Millisecond,
+	}
+}
+
+func startListener(t *testing.T, addr string) (net.Listener, string) {
+	if len(addr) == 0 {
+		addr = "127.0.0.1:0"
+	}
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	return listener, listener.Addr().String()
+}
+
+func parseHostPort(t *testing.T, addr string) (string, uint) {
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 32)
+	require.NoError(t, err)
+	return host, uint(p)
+}

--- a/pkg/manager/metricsreader/mock_test.go
+++ b/pkg/manager/metricsreader/mock_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/stretchr/testify/require"
+)
+
+type mockPromFetcher struct {
+	getPromInfo func(ctx context.Context) (*infosync.PrometheusInfo, error)
+}
+
+func (mpf *mockPromFetcher) GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, error) {
+	return mpf.getPromInfo(ctx)
+}
+
+func newMockPromFetcher(port int) *mockPromFetcher {
+	return &mockPromFetcher{
+		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
+			return &infosync.PrometheusInfo{
+				IP:   "127.0.0.1",
+				Port: port,
+			}, nil
+		},
+	}
+}
+
+type mockHttpHandler struct {
+	getRespBody atomic.Pointer[func(reqBody string) string]
+	wg          waitgroup.WaitGroup
+	t           *testing.T
+	server      *http.Server
+}
+
+func (handler *mockHttpHandler) Start() int {
+	statusListener, addr := startListener(handler.t, "")
+	_, port := parseHostPort(handler.t, addr)
+	handler.server = &http.Server{Addr: addr, Handler: handler}
+	handler.wg.Run(func() {
+		_ = handler.server.Serve(statusListener)
+	})
+	return int(port)
+}
+
+func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	body, err := io.ReadAll(r.Body)
+	require.NoError(handler.t, err)
+	respBody := (*handler.getRespBody.Load())(string(body))
+	require.True(handler.t, len(respBody) > 0, string(body))
+	_, err = w.Write([]byte(respBody))
+	require.NoError(handler.t, err)
+}
+
+func (handler *mockHttpHandler) Close() {
+	require.NoError(handler.t, handler.server.Close())
+	handler.wg.Wait()
+}

--- a/pkg/manager/metricsreader/query_result.go
+++ b/pkg/manager/metricsreader/query_result.go
@@ -1,0 +1,30 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import "github.com/prometheus/common/model"
+
+type QueryResult struct {
+	Value model.Value
+	Err   error
+}
+
+func (qr QueryResult) Empty() bool {
+	if qr.Value == nil {
+		return true
+	}
+	switch qr.Value.Type() {
+	case model.ValNone:
+		return true
+	case model.ValMatrix:
+		matrix := qr.Value.(model.Matrix)
+		return len(matrix) == 0
+	case model.ValVector:
+		vector := qr.Value.(model.Vector)
+		return len(vector) == 0
+	default:
+		// We don't need other value types.
+		return false
+	}
+}

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -7,6 +7,7 @@
 package namespace
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -14,16 +15,19 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/manager/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/manager/router"
 	"go.uber.org/zap"
 )
 
 type NamespaceManager struct {
 	sync.RWMutex
-	tpFetcher router.TopologyFetcher
-	httpCli   *http.Client
-	logger    *zap.Logger
-	nsm       map[string]*Namespace
+	tpFetcher     router.TopologyFetcher
+	promFetcher   metricsreader.PromInfoFetcher
+	metricsReader metricsreader.MetricsReader
+	httpCli       *http.Client
+	logger        *zap.Logger
+	nsm           map[string]*Namespace
 }
 
 func NewNamespaceManager() *NamespaceManager {
@@ -33,18 +37,22 @@ func NewNamespaceManager() *NamespaceManager {
 func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, error) {
 	logger := mgr.logger.With(zap.String("namespace", cfg.Namespace))
 
+	// init BackendFetcher
 	var fetcher router.BackendFetcher
+	healthCheckCfg := config.NewDefaultHealthCheckConfig()
 	if !reflect.ValueOf(mgr.tpFetcher).IsNil() {
-		fetcher = router.NewPDFetcher(mgr.tpFetcher, logger.Named("be_fetcher"), config.NewDefaultHealthCheckConfig())
+		fetcher = router.NewPDFetcher(mgr.tpFetcher, logger.Named("be_fetcher"), healthCheckCfg)
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
+
+	// init Router
 	rt := router.NewScoreBasedRouter(logger.Named("router"))
-	healthCheckCfg := config.NewDefaultHealthCheckConfig()
 	hc := router.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	if err := rt.Init(fetcher, hc, healthCheckCfg); err != nil {
 		return nil, errors.Errorf("build router error: %w", err)
 	}
+
 	return &Namespace{
 		name:   cfg.Namespace,
 		user:   cfg.Frontend.User,
@@ -79,29 +87,34 @@ func (mgr *NamespaceManager) CommitNamespaces(nss []*config.Namespace, nss_delet
 	return nil
 }
 
-func (mgr *NamespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher router.TopologyFetcher, httpCli *http.Client) error {
+func (mgr *NamespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher router.TopologyFetcher,
+	promFetcher metricsreader.PromInfoFetcher, httpCli *http.Client) error {
 	mgr.Lock()
 	mgr.tpFetcher = tpFetcher
+	mgr.promFetcher = promFetcher
 	mgr.httpCli = httpCli
 	mgr.logger = logger
+	healthCheckCfg := config.NewDefaultHealthCheckConfig()
+	mgr.metricsReader = metricsreader.NewDefaultMetricsReader(logger.Named("mr"), mgr.promFetcher, healthCheckCfg)
 	mgr.Unlock()
 
+	mgr.metricsReader.Start(context.Background())
 	return mgr.CommitNamespaces(nscs, nil)
 }
 
-func (n *NamespaceManager) GetNamespace(nm string) (*Namespace, bool) {
-	n.RLock()
-	defer n.RUnlock()
+func (mgr *NamespaceManager) GetNamespace(nm string) (*Namespace, bool) {
+	mgr.RLock()
+	defer mgr.RUnlock()
 
-	ns, ok := n.nsm[nm]
+	ns, ok := mgr.nsm[nm]
 	return ns, ok
 }
 
-func (n *NamespaceManager) GetNamespaceByUser(user string) (*Namespace, bool) {
-	n.RLock()
-	defer n.RUnlock()
+func (mgr *NamespaceManager) GetNamespaceByUser(user string) (*Namespace, bool) {
+	mgr.RLock()
+	defer mgr.RUnlock()
 
-	for _, ns := range n.nsm {
+	for _, ns := range mgr.nsm {
 		if ns.User() == user {
 			return ns, true
 		}
@@ -109,12 +122,12 @@ func (n *NamespaceManager) GetNamespaceByUser(user string) (*Namespace, bool) {
 	return nil, false
 }
 
-func (n *NamespaceManager) RedirectConnections() []error {
-	n.RLock()
-	defer n.RUnlock()
+func (mgr *NamespaceManager) RedirectConnections() []error {
+	mgr.RLock()
+	defer mgr.RUnlock()
 
 	var errs []error
-	for _, ns := range n.nsm {
+	for _, ns := range mgr.nsm {
 		err1 := ns.GetRouter().RedirectConnections()
 		if err1 != nil {
 			errs = append(errs, err1)
@@ -123,11 +136,12 @@ func (n *NamespaceManager) RedirectConnections() []error {
 	return errs
 }
 
-func (n *NamespaceManager) Close() error {
-	n.RLock()
-	for _, ns := range n.nsm {
+func (mgr *NamespaceManager) Close() error {
+	mgr.RLock()
+	for _, ns := range mgr.nsm {
 		ns.Close()
 	}
-	n.RUnlock()
+	mgr.RUnlock()
+	mgr.metricsReader.Close()
 	return nil
 }

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -101,7 +101,7 @@ func TestCancelObserver(t *testing.T) {
 		childCtx, cancelFunc := context.WithCancel(context.Background())
 		var wg waitgroup.WaitGroup
 		wg.Run(func() {
-			for childCtx.Err() != nil {
+			for childCtx.Err() == nil {
 				ts.bo.checkHealth(childCtx, info)
 			}
 		})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -125,7 +125,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 			nscs = append(nscs, nsc)
 		}
 
-		err = srv.NamespaceManager.Init(lg.Named("nsmgr"), nscs, srv.InfoSyncer, srv.Http)
+		err = srv.NamespaceManager.Init(lg.Named("nsmgr"), nscs, srv.InfoSyncer, srv.InfoSyncer, srv.Http)
 		if err != nil {
 			err = errors.WithStack(err)
 			return


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #499

Problem Summary:
TiProxy collects TiDB metrics so that it can balance by CPU, memory, and health.
I do not collect them from TiDB `/metrics` because each response is 800KB, which is too much.

What is changed and how it works:
- Read the Prometheus address from etcd.
- Read metrics from Prometheus.
- Add some configurations but not exposed to users.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
