### PR TITLE
router, observer: move BackendObserver from package router to observer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/pingcap/tiproxy/lib v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
+	github.com/prometheus/common v0.39.0
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
@@ -91,7 +92,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
-	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -528,6 +529,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=

--- a/pkg/manager/metricsreader/metrics_reader.go
+++ b/pkg/manager/metricsreader/metrics_reader.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -75,6 +76,10 @@ func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, cfg *c
 }
 
 func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
+	// No PD, using static backends.
+	if dmr.promFetcher == nil || reflect.ValueOf(dmr.promFetcher).IsNil() {
+		return
+	}
 	childCtx, cancel := context.WithCancel(ctx)
 	dmr.cancel = cancel
 	dmr.wg.RunWithRecover(func() {

--- a/pkg/manager/metricsreader/metrics_reader_test.go
+++ b/pkg/manager/metricsreader/metrics_reader_test.go
@@ -6,8 +6,6 @@ package metricsreader
 import (
 	"context"
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -334,28 +332,10 @@ func waitResultReady(t *testing.T, mr MetricsReader, ch <-chan struct{}, resultN
 	}, 3*time.Second, time.Millisecond)
 }
 
-// TODO: move health_check to this package and remove these duplicated functions.
 func newHealthCheckConfigForTest() *config.HealthCheck {
 	return &config.HealthCheck{
 		Enable:          true,
 		MetricsInterval: 10 * time.Millisecond,
 		MetricsTimeout:  100 * time.Millisecond,
 	}
-}
-
-func startListener(t *testing.T, addr string) (net.Listener, string) {
-	if len(addr) == 0 {
-		addr = "127.0.0.1:0"
-	}
-	listener, err := net.Listen("tcp", addr)
-	require.NoError(t, err)
-	return listener, listener.Addr().String()
-}
-
-func parseHostPort(t *testing.T, addr string) (string, uint) {
-	host, port, err := net.SplitHostPort(addr)
-	require.NoError(t, err)
-	p, err := strconv.ParseUint(port, 10, 32)
-	require.NoError(t, err)
-	return host, uint(p)
 }

--- a/pkg/manager/metricsreader/mock_test.go
+++ b/pkg/manager/metricsreader/mock_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/pingcap/tiproxy/pkg/testkit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,8 +43,8 @@ type mockHttpHandler struct {
 }
 
 func (handler *mockHttpHandler) Start() int {
-	statusListener, addr := startListener(handler.t, "")
-	_, port := parseHostPort(handler.t, addr)
+	statusListener, addr := testkit.StartListener(handler.t, "")
+	_, port := testkit.ParseHostPort(handler.t, addr)
 	handler.server = &http.Server{Addr: addr, Handler: handler}
 	handler.wg.Run(func() {
 		_ = handler.server.Serve(statusListener)

--- a/pkg/manager/namespace/namespace.go
+++ b/pkg/manager/namespace/namespace.go
@@ -7,12 +7,14 @@
 package namespace
 
 import (
+	"github.com/pingcap/tiproxy/pkg/manager/observer"
 	"github.com/pingcap/tiproxy/pkg/manager/router"
 )
 
 type Namespace struct {
 	name   string
 	user   string
+	bo     observer.BackendObserver
 	router router.Router
 }
 
@@ -30,4 +32,5 @@ func (n *Namespace) GetRouter() router.Router {
 
 func (n *Namespace) Close() {
 	n.router.Close()
+	n.bo.Close()
 }

--- a/pkg/manager/observer/backend_fetcher.go
+++ b/pkg/manager/observer/backend_fetcher.go
@@ -1,7 +1,7 @@
 // Copyright 2023 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package router
+package observer
 
 import (
 	"context"

--- a/pkg/manager/observer/backend_fetcher_test.go
+++ b/pkg/manager/observer/backend_fetcher_test.go
@@ -1,7 +1,7 @@
 // Copyright 2023 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package router
+package observer
 
 import (
 	"context"
@@ -115,20 +115,4 @@ func TestPDFetcher(t *testing.T) {
 		test.check(info)
 		require.NoError(t, err)
 	}
-}
-
-type mockTpFetcher struct {
-	t     *testing.T
-	infos map[string]*infosync.TiDBInfo
-	err   error
-}
-
-func newMockTpFetcher(t *testing.T) *mockTpFetcher {
-	return &mockTpFetcher{
-		t: t,
-	}
-}
-
-func (ft *mockTpFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error) {
-	return ft.infos, ft.err
 }

--- a/pkg/manager/observer/backend_health.go
+++ b/pkg/manager/observer/backend_health.go
@@ -1,0 +1,66 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import "fmt"
+
+type BackendStatus int
+
+func (bs BackendStatus) ToScore() int {
+	return statusScores[bs]
+}
+
+func (bs BackendStatus) String() string {
+	status, ok := statusNames[bs]
+	if !ok {
+		return "unknown"
+	}
+	return status
+}
+
+const (
+	StatusHealthy BackendStatus = iota
+	StatusCannotConnect
+	StatusMemoryHigh
+	StatusRunSlow
+	StatusSchemaOutdated
+)
+
+var statusNames = map[BackendStatus]string{
+	StatusHealthy:        "healthy",
+	StatusCannotConnect:  "down",
+	StatusMemoryHigh:     "memory high",
+	StatusRunSlow:        "run slow",
+	StatusSchemaOutdated: "schema outdated",
+}
+
+var statusScores = map[BackendStatus]int{
+	StatusHealthy:        0,
+	StatusCannotConnect:  10000000,
+	StatusMemoryHigh:     5000,
+	StatusRunSlow:        5000,
+	StatusSchemaOutdated: 10000000,
+}
+
+type BackendHealth struct {
+	Status BackendStatus
+	// The error occurred when health check fails. It's used to log why the backend becomes unhealthy.
+	PingErr error
+	// The backend version that returned to the client during handshake.
+	ServerVersion string
+}
+
+func (bh *BackendHealth) String() string {
+	str := fmt.Sprintf("status: %s", bh.Status.String())
+	if bh.PingErr != nil {
+		str += fmt.Sprintf(", err: %s", bh.PingErr.Error())
+	}
+	return str
+}
+
+// BackendInfo stores the status info of each backend.
+type BackendInfo struct {
+	IP         string
+	StatusPort uint
+}

--- a/pkg/manager/observer/backend_observer_test.go
+++ b/pkg/manager/observer/backend_observer_test.go
@@ -1,12 +1,11 @@
 // Copyright 2023 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package router
+package observer
 
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -50,7 +49,7 @@ func newHealthCheckConfigForTest() *config.HealthCheck {
 func TestObserveBackends(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	t.Cleanup(ts.close)
-	ts.bo.Start()
+	ts.bo.Start(context.Background(), ts.mer)
 
 	backend1 := ts.addBackend()
 	ts.checkStatus(backend1, StatusHealthy)
@@ -76,7 +75,7 @@ func TestObserveInParallel(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		backend = ts.addBackend()
 	}
-	ts.bo.Start()
+	ts.bo.Start(context.Background(), ts.mer)
 	backends := ts.getBackendsFromCh()
 	require.Equal(ts.t, 100, len(backends))
 	// Wait for next loop.
@@ -111,22 +110,23 @@ func TestCancelObserver(t *testing.T) {
 	}
 }
 
-func TestDisableHealthCheck2(t *testing.T) {
+func TestDisableHealthCheck(t *testing.T) {
 	ts := newObserverTestSuite(t)
 	ts.bo.healthCheckConfig.Enable = false
 	t.Cleanup(ts.close)
 
 	backend1 := ts.addBackend()
 	ts.setHealth(backend1, StatusCannotConnect)
-	ts.bo.Start()
+	ts.bo.Start(context.Background(), ts.mer)
 	ts.checkStatus(backend1, StatusHealthy)
 }
 
 type observerTestSuite struct {
 	t           *testing.T
-	bo          *BackendObserver
+	bo          *DefaultBackendObserver
 	hc          *mockHealthCheck
 	fetcher     *mockBackendFetcher
+	mer         *mockEventReceiver
 	backendIdx  int
 	backendChan chan map[string]*BackendHealth
 }
@@ -137,12 +137,13 @@ func newObserverTestSuite(t *testing.T) *observerTestSuite {
 	fetcher := newMockBackendFetcher()
 	hc := newMockHealthCheck()
 	lg, _ := logger.CreateLoggerForTest(t)
-	bo := NewBackendObserver(lg, mer, newHealthCheckConfigForTest(), fetcher, hc)
+	bo := NewDefaultBackendObserver(lg, newHealthCheckConfigForTest(), fetcher, hc)
 	return &observerTestSuite{
 		t:           t,
 		bo:          bo,
 		fetcher:     fetcher,
 		hc:          hc,
+		mer:         mer,
 		backendChan: backendChan,
 	}
 }
@@ -199,82 +200,4 @@ func (ts *observerTestSuite) setHealth(addr string, health BackendStatus) {
 func (ts *observerTestSuite) removeBackend(addr string) {
 	ts.fetcher.removeBackend(addr)
 	ts.hc.removeBackend(addr)
-}
-
-type mockBackendFetcher struct {
-	sync.Mutex
-	backends map[string]*BackendInfo
-}
-
-func newMockBackendFetcher() *mockBackendFetcher {
-	return &mockBackendFetcher{
-		backends: make(map[string]*BackendInfo),
-	}
-}
-
-func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
-	mbf.Lock()
-	defer mbf.Unlock()
-	backends := make(map[string]*BackendInfo, len(mbf.backends))
-	for addr, backend := range mbf.backends {
-		backends[addr] = backend
-	}
-	return backends, nil
-}
-
-func (mbf *mockBackendFetcher) setBackend(addr string, info *BackendInfo) {
-	mbf.Lock()
-	defer mbf.Unlock()
-	mbf.backends[addr] = info
-}
-
-func (mbf *mockBackendFetcher) removeBackend(addr string) {
-	mbf.Lock()
-	defer mbf.Unlock()
-	delete(mbf.backends, addr)
-}
-
-// ExternalFetcher fetches backend list from a given callback.
-type ExternalFetcher struct {
-	backendGetter func() ([]string, error)
-}
-
-func NewExternalFetcher(backendGetter func() ([]string, error)) *ExternalFetcher {
-	return &ExternalFetcher{
-		backendGetter: backendGetter,
-	}
-}
-
-func (ef *ExternalFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
-	addrs, err := ef.backendGetter()
-	return backendListToMap(addrs), err
-}
-
-type mockHealthCheck struct {
-	sync.Mutex
-	backends map[string]*BackendHealth
-}
-
-func newMockHealthCheck() *mockHealthCheck {
-	return &mockHealthCheck{
-		backends: make(map[string]*BackendHealth),
-	}
-}
-
-func (mhc *mockHealthCheck) Check(_ context.Context, addr string, _ *BackendInfo) *BackendHealth {
-	mhc.Lock()
-	defer mhc.Unlock()
-	return mhc.backends[addr]
-}
-
-func (mhc *mockHealthCheck) setBackend(addr string, health *BackendHealth) {
-	mhc.Lock()
-	defer mhc.Unlock()
-	mhc.backends[addr] = health
-}
-
-func (mhc *mockHealthCheck) removeBackend(addr string) {
-	mhc.Lock()
-	defer mhc.Unlock()
-	delete(mhc.backends, addr)
 }

--- a/pkg/manager/observer/health_check.go
+++ b/pkg/manager/observer/health_check.go
@@ -97,9 +97,8 @@ func (dhc *DefaultHealthCheck) checkStatusPort(ctx context.Context, info *Backen
 	if ctx.Err() != nil {
 		return
 	}
+	// Using static backends, no status port.
 	if info == nil || len(info.IP) == 0 {
-		bh.Status = StatusCannotConnect
-		bh.PingErr = errors.New("no status port to read status")
 		return
 	}
 	schema := "http"

--- a/pkg/manager/observer/health_check.go
+++ b/pkg/manager/observer/health_check.go
@@ -1,14 +1,13 @@
 // Copyright 2023 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package router
+package observer
 
 import (
 	"context"
 	"fmt"
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -58,42 +57,21 @@ func (dhc *DefaultHealthCheck) Check(ctx context.Context, addr string, info *Bac
 	if !dhc.cfg.Enable {
 		return bh
 	}
-	// Skip checking the status port if it's not fetched.
-	if info != nil && len(info.IP) > 0 {
-		// When a backend gracefully shut down, the status port returns 500 but the SQL port still accepts
-		// new connections, so we must check the status port first.
-		schema := "http"
-		if dhc.httpTLS {
-			schema = "https"
-		}
-		httpCli := *dhc.httpCli
-		httpCli.Timeout = dhc.cfg.DialTimeout
-		url := fmt.Sprintf("%s://%s:%d%s", schema, info.IP, info.StatusPort, statusPathSuffix)
-		err := dhc.connectWithRetry(ctx, func() error {
-			resp, err := httpCli.Get(url)
-			if err == nil {
-				if resp.StatusCode != http.StatusOK {
-					err = backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
-				}
-				if ignoredErr := resp.Body.Close(); ignoredErr != nil {
-					dhc.logger.Warn("close http response in health check failed", zap.Error(ignoredErr))
-				}
-			}
-			return err
-		})
-		if err != nil {
-			bh.Status = StatusCannotConnect
-			bh.PingErr = errors.Wrapf(err, "connect status port failed")
-			return bh
-		}
+	dhc.checkStatusPort(ctx, info, bh)
+	if bh.Status != StatusHealthy {
+		return bh
 	}
+	dhc.checkSqlPort(ctx, addr, bh)
+	return bh
+}
 
+func (dhc *DefaultHealthCheck) checkSqlPort(ctx context.Context, addr string, bh *BackendHealth) {
 	// Also dial the SQL port just in case that the SQL port hangs.
 	var serverVersion string
 	err := dhc.connectWithRetry(ctx, func() error {
 		startTime := monotime.Now()
 		conn, err := net.DialTimeout("tcp", addr, dhc.cfg.DialTimeout)
-		setPingBackendMetrics(addr, err == nil, startTime)
+		setPingBackendMetrics(addr, startTime)
 		if err != nil {
 			return err
 		}
@@ -111,34 +89,51 @@ func (dhc *DefaultHealthCheck) Check(ctx context.Context, addr string, info *Bac
 		bh.Status = StatusCannotConnect
 		bh.PingErr = errors.Wrapf(err, "connect sql port failed")
 	}
-	return bh
+}
+
+// When a backend gracefully shut down, the status port returns 500 but the SQL port still accepts
+// new connections.
+func (dhc *DefaultHealthCheck) checkStatusPort(ctx context.Context, info *BackendInfo, bh *BackendHealth) {
+	if ctx.Err() != nil {
+		return
+	}
+	if info == nil || len(info.IP) == 0 {
+		bh.Status = StatusCannotConnect
+		bh.PingErr = errors.New("no status port to read status")
+		return
+	}
+	schema := "http"
+	if dhc.httpTLS {
+		schema = "https"
+	}
+	httpCli := *dhc.httpCli
+	httpCli.Timeout = dhc.cfg.DialTimeout
+	url := fmt.Sprintf("%s://%s:%d%s", schema, info.IP, info.StatusPort, statusPathSuffix)
+	err := dhc.connectWithRetry(ctx, func() error {
+		resp, err := httpCli.Get(url)
+		if err == nil {
+			if resp.StatusCode != http.StatusOK {
+				err = backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
+			}
+			if ignoredErr := resp.Body.Close(); ignoredErr != nil {
+				dhc.logger.Warn("close http response in health check failed", zap.Error(ignoredErr))
+			}
+		}
+		return err
+	})
+	if err != nil {
+		bh.Status = StatusCannotConnect
+		bh.PingErr = errors.Wrapf(err, "connect status port failed")
+	}
 }
 
 func (dhc *DefaultHealthCheck) connectWithRetry(ctx context.Context, connect func() error) error {
 	err := backoff.Retry(func() error {
 		err := connect()
-		if !isRetryableError(err) {
+		if !pnet.IsRetryableError(err) {
 			return backoff.Permanent(err)
 		}
 		return err
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(dhc.cfg.RetryInterval), uint64(dhc.cfg.MaxRetries)), ctx))
 	return err
-}
-
-// When the server refused to connect, the port is shut down, so no need to retry.
-var notRetryableError = []string{
-	"connection refused",
-}
-
-func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	for _, errStr := range notRetryableError {
-		if strings.Contains(msg, errStr) {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/manager/observer/metrics.go
+++ b/pkg/manager/observer/metrics.go
@@ -1,0 +1,34 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import (
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/metrics"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
+)
+
+func updateBackendStatusMetrics(addr string, prevStatus, curStatus BackendStatus) {
+	metrics.BackendStatusGauge.WithLabelValues(addr, prevStatus.String()).Set(0)
+	metrics.BackendStatusGauge.WithLabelValues(addr, curStatus.String()).Set(1)
+}
+
+func checkBackendStatusMetrics(addr string, status BackendStatus) bool {
+	val, err := metrics.ReadGauge(metrics.BackendStatusGauge.WithLabelValues(addr, status.String()))
+	if err != nil {
+		return false
+	}
+	return int(val) == 1
+}
+
+func setPingBackendMetrics(addr string, startTime monotime.Time) {
+	cost := monotime.Since(startTime)
+	metrics.PingBackendGauge.WithLabelValues(addr).Set(cost.Seconds())
+}
+
+func readHealthCheckCycle() (time.Duration, error) {
+	seconds, err := metrics.ReadGauge(metrics.HealthCheckCycleGauge)
+	return time.Duration(int(seconds * float64(time.Second))), err
+}

--- a/pkg/manager/observer/mock_test.go
+++ b/pkg/manager/observer/mock_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+)
+
+type mockTpFetcher struct {
+	t     *testing.T
+	infos map[string]*infosync.TiDBInfo
+	err   error
+}
+
+func newMockTpFetcher(t *testing.T) *mockTpFetcher {
+	return &mockTpFetcher{
+		t: t,
+	}
+}
+
+func (ft *mockTpFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error) {
+	return ft.infos, ft.err
+}
+
+type mockBackendFetcher struct {
+	sync.Mutex
+	backends map[string]*BackendInfo
+}
+
+func newMockBackendFetcher() *mockBackendFetcher {
+	return &mockBackendFetcher{
+		backends: make(map[string]*BackendInfo),
+	}
+}
+
+func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+	mbf.Lock()
+	defer mbf.Unlock()
+	backends := make(map[string]*BackendInfo, len(mbf.backends))
+	for addr, backend := range mbf.backends {
+		backends[addr] = backend
+	}
+	return backends, nil
+}
+
+func (mbf *mockBackendFetcher) setBackend(addr string, info *BackendInfo) {
+	mbf.Lock()
+	defer mbf.Unlock()
+	mbf.backends[addr] = info
+}
+
+func (mbf *mockBackendFetcher) removeBackend(addr string) {
+	mbf.Lock()
+	defer mbf.Unlock()
+	delete(mbf.backends, addr)
+}
+
+type mockHealthCheck struct {
+	sync.Mutex
+	backends map[string]*BackendHealth
+}
+
+func newMockHealthCheck() *mockHealthCheck {
+	return &mockHealthCheck{
+		backends: make(map[string]*BackendHealth),
+	}
+}
+
+func (mhc *mockHealthCheck) Check(_ context.Context, addr string, _ *BackendInfo) *BackendHealth {
+	mhc.Lock()
+	defer mhc.Unlock()
+	return mhc.backends[addr]
+}
+
+func (mhc *mockHealthCheck) setBackend(addr string, health *BackendHealth) {
+	mhc.Lock()
+	defer mhc.Unlock()
+	mhc.backends[addr] = health
+}
+
+func (mhc *mockHealthCheck) removeBackend(addr string) {
+	mhc.Lock()
+	defer mhc.Unlock()
+	delete(mhc.backends, addr)
+}
+
+type mockHttpHandler struct {
+	t      *testing.T
+	httpOK atomic.Bool
+	wait   atomic.Int64
+}
+
+func (handler *mockHttpHandler) setHTTPResp(succeed bool) {
+	handler.httpOK.Store(succeed)
+}
+
+func (handler *mockHttpHandler) setHTTPWait(wait time.Duration) {
+	handler.wait.Store(int64(wait))
+}
+
+func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	wait := handler.wait.Load()
+	if wait > 0 {
+		time.Sleep(time.Duration(wait))
+	}
+	if handler.httpOK.Load() {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/pkg/manager/router/metrics.go
+++ b/pkg/manager/router/metrics.go
@@ -4,24 +4,9 @@
 package router
 
 import (
-	"time"
-
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/pingcap/tiproxy/pkg/util/monotime"
 )
-
-func updateBackendStatusMetrics(addr string, prevStatus, curStatus BackendStatus) {
-	metrics.BackendStatusGauge.WithLabelValues(addr, prevStatus.String()).Set(0)
-	metrics.BackendStatusGauge.WithLabelValues(addr, curStatus.String()).Set(1)
-}
-
-func checkBackendStatusMetrics(addr string, status BackendStatus) bool {
-	val, err := metrics.ReadGauge(metrics.BackendStatusGauge.WithLabelValues(addr, status.String()))
-	if err != nil {
-		return false
-	}
-	return int(val) == 1
-}
 
 func setBackendConnMetrics(addr string, conns int) {
 	metrics.BackendConnGauge.WithLabelValues(addr).Set(float64(conns))
@@ -49,14 +34,4 @@ func addMigrateMetrics(from, to string, succeed bool, startTime monotime.Time) {
 
 func readMigrateCounter(from, to string, succeed bool) (int, error) {
 	return metrics.ReadCounter(metrics.MigrateCounter.WithLabelValues(from, to, succeedToLabel(succeed)))
-}
-
-func setPingBackendMetrics(addr string, succeed bool, startTime monotime.Time) {
-	cost := monotime.Since(startTime)
-	metrics.PingBackendGauge.WithLabelValues(addr).Set(cost.Seconds())
-}
-
-func readHealthCheckCycle() (time.Duration, error) {
-	seconds, err := metrics.ReadGauge(metrics.HealthCheckCycleGauge)
-	return time.Duration(int(seconds * float64(time.Second))), err
 }

--- a/pkg/manager/router/mock_test.go
+++ b/pkg/manager/router/mock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package router

--- a/pkg/manager/router/mock_test.go
+++ b/pkg/manager/router/mock_test.go
@@ -1,0 +1,150 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/pingcap/tiproxy/pkg/manager/observer"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRedirectableConn struct {
+	sync.Mutex
+	t        *testing.T
+	kv       map[any]any
+	connID   uint64
+	from     BackendInst
+	to       BackendInst
+	receiver ConnEventReceiver
+}
+
+func newMockRedirectableConn(t *testing.T, id uint64) *mockRedirectableConn {
+	return &mockRedirectableConn{
+		t:      t,
+		connID: id,
+		kv:     make(map[any]any),
+	}
+}
+
+func (conn *mockRedirectableConn) SetEventReceiver(receiver ConnEventReceiver) {
+	conn.Lock()
+	conn.receiver = receiver
+	conn.Unlock()
+}
+
+func (conn *mockRedirectableConn) SetValue(k, v any) {
+	conn.Lock()
+	conn.kv[k] = v
+	conn.Unlock()
+}
+
+func (conn *mockRedirectableConn) Value(k any) any {
+	conn.Lock()
+	v := conn.kv[k]
+	conn.Unlock()
+	return v
+}
+
+func (conn *mockRedirectableConn) Redirect(inst BackendInst) bool {
+	conn.Lock()
+	require.Nil(conn.t, conn.to)
+	require.True(conn.t, inst.Healthy())
+	conn.to = inst
+	conn.Unlock()
+	return true
+}
+
+func (conn *mockRedirectableConn) GetRedirectingAddr() string {
+	conn.Lock()
+	defer conn.Unlock()
+	if conn.to == nil {
+		return ""
+	}
+	return conn.to.Addr()
+}
+
+func (conn *mockRedirectableConn) ConnectionID() uint64 {
+	return conn.connID
+}
+
+func (conn *mockRedirectableConn) getAddr() (string, string) {
+	conn.Lock()
+	defer conn.Unlock()
+	var to string
+	if conn.to != nil && !reflect.ValueOf(conn.to).IsNil() {
+		to = conn.to.Addr()
+	}
+	return conn.from.Addr(), to
+}
+
+func (conn *mockRedirectableConn) redirectSucceed() {
+	conn.Lock()
+	require.True(conn.t, conn.to != nil && !reflect.ValueOf(conn.to).IsNil())
+	conn.from = conn.to
+	conn.to = nil
+	conn.Unlock()
+}
+
+func (conn *mockRedirectableConn) redirectFail() {
+	conn.Lock()
+	require.True(conn.t, conn.to != nil && !reflect.ValueOf(conn.to).IsNil())
+	conn.to = nil
+	conn.Unlock()
+}
+
+type mockBackendObserver struct {
+	sync.Mutex
+	healths       map[string]*observer.BackendHealth
+	eventReceiver observer.BackendEventReceiver
+}
+
+func newMockBackendObserver() *mockBackendObserver {
+	return &mockBackendObserver{
+		healths: make(map[string]*observer.BackendHealth),
+	}
+}
+
+func (mbo *mockBackendObserver) toggleBackendHealth(addr string) {
+	mbo.Lock()
+	defer mbo.Unlock()
+	health := mbo.healths[addr]
+	if health.Status == observer.StatusHealthy {
+		health.Status = observer.StatusCannotConnect
+	} else {
+		health.Status = observer.StatusHealthy
+	}
+}
+
+func (mbo *mockBackendObserver) addBackend(addr string) {
+	mbo.Lock()
+	defer mbo.Unlock()
+	mbo.healths[addr] = &observer.BackendHealth{
+		Status: observer.StatusHealthy,
+	}
+}
+
+func (mbo *mockBackendObserver) Start(ctx context.Context, eventReceiver observer.BackendEventReceiver) {
+	mbo.eventReceiver = eventReceiver
+}
+
+func (mbo *mockBackendObserver) Refresh() {
+	mbo.addBackend("0")
+}
+
+func (mbo *mockBackendObserver) notify(err error) {
+	mbo.Lock()
+	healths := make(map[string]*observer.BackendHealth, len(mbo.healths))
+	for addr, health := range mbo.healths {
+		healths[addr] = health
+	}
+	mbo.Unlock()
+	mbo.eventReceiver.OnBackendChanged(healths, err)
+}
+
+func (mbo *mockBackendObserver) Close() {
+}

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -9,6 +9,7 @@ import (
 
 	glist "github.com/bahlo/generic-list-go"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/manager/observer"
 	"github.com/pingcap/tiproxy/pkg/util/monotime"
 )
 
@@ -84,7 +85,7 @@ type BackendInst interface {
 type backendWrapper struct {
 	mu struct {
 		sync.RWMutex
-		BackendHealth
+		observer.BackendHealth
 	}
 	addr string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
@@ -95,7 +96,7 @@ type backendWrapper struct {
 	connList *glist.List[*connWrapper]
 }
 
-func (b *backendWrapper) setHealth(health BackendHealth) {
+func (b *backendWrapper) setHealth(health observer.BackendHealth) {
 	b.mu.Lock()
 	b.mu.BackendHealth = health
 	b.mu.Unlock()
@@ -113,7 +114,7 @@ func (b *backendWrapper) Addr() string {
 	return b.addr
 }
 
-func (b *backendWrapper) Status() BackendStatus {
+func (b *backendWrapper) Status() observer.BackendStatus {
 	b.mu.RLock()
 	status := b.mu.Status
 	b.mu.RUnlock()
@@ -122,7 +123,7 @@ func (b *backendWrapper) Status() BackendStatus {
 
 func (b *backendWrapper) Healthy() bool {
 	b.mu.RLock()
-	healthy := b.mu.Status == StatusHealthy
+	healthy := b.mu.Status == observer.StatusHealthy
 	b.mu.RUnlock()
 	return healthy
 }

--- a/pkg/manager/router/router_test.go
+++ b/pkg/manager/router/router_test.go
@@ -9,101 +9,16 @@ import (
 	"math/rand"
 	"reflect"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/observer"
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/stretchr/testify/require"
 )
-
-type mockRedirectableConn struct {
-	sync.Mutex
-	t        *testing.T
-	kv       map[any]any
-	connID   uint64
-	from     BackendInst
-	to       BackendInst
-	receiver ConnEventReceiver
-}
-
-func newMockRedirectableConn(t *testing.T, id uint64) *mockRedirectableConn {
-	return &mockRedirectableConn{
-		t:      t,
-		connID: id,
-		kv:     make(map[any]any),
-	}
-}
-
-func (conn *mockRedirectableConn) SetEventReceiver(receiver ConnEventReceiver) {
-	conn.Lock()
-	conn.receiver = receiver
-	conn.Unlock()
-}
-
-func (conn *mockRedirectableConn) SetValue(k, v any) {
-	conn.Lock()
-	conn.kv[k] = v
-	conn.Unlock()
-}
-
-func (conn *mockRedirectableConn) Value(k any) any {
-	conn.Lock()
-	v := conn.kv[k]
-	conn.Unlock()
-	return v
-}
-
-func (conn *mockRedirectableConn) Redirect(inst BackendInst) bool {
-	conn.Lock()
-	require.Nil(conn.t, conn.to)
-	require.True(conn.t, inst.Healthy())
-	conn.to = inst
-	conn.Unlock()
-	return true
-}
-
-func (conn *mockRedirectableConn) GetRedirectingAddr() string {
-	conn.Lock()
-	defer conn.Unlock()
-	if conn.to == nil {
-		return ""
-	}
-	return conn.to.Addr()
-}
-
-func (conn *mockRedirectableConn) ConnectionID() uint64 {
-	return conn.connID
-}
-
-func (conn *mockRedirectableConn) getAddr() (string, string) {
-	conn.Lock()
-	defer conn.Unlock()
-	var to string
-	if conn.to != nil && !reflect.ValueOf(conn.to).IsNil() {
-		to = conn.to.Addr()
-	}
-	return conn.from.Addr(), to
-}
-
-func (conn *mockRedirectableConn) redirectSucceed() {
-	conn.Lock()
-	require.True(conn.t, conn.to != nil && !reflect.ValueOf(conn.to).IsNil())
-	conn.from = conn.to
-	conn.to = nil
-	conn.Unlock()
-}
-
-func (conn *mockRedirectableConn) redirectFail() {
-	conn.Lock()
-	require.True(conn.t, conn.to != nil && !reflect.ValueOf(conn.to).IsNil())
-	conn.to = nil
-	conn.Unlock()
-}
 
 type routerTester struct {
 	t         *testing.T
@@ -130,12 +45,12 @@ func (tester *routerTester) createConn() *mockRedirectableConn {
 }
 
 func (tester *routerTester) addBackends(num int) {
-	backends := make(map[string]*BackendHealth)
+	backends := make(map[string]*observer.BackendHealth)
 	for i := 0; i < num; i++ {
 		tester.backendID++
 		addr := strconv.Itoa(tester.backendID)
-		backends[addr] = &BackendHealth{
-			Status: StatusHealthy,
+		backends[addr] = &observer.BackendHealth{
+			Status: observer.StatusHealthy,
 		}
 		metrics.BackendConnGauge.WithLabelValues(addr).Set(0)
 	}
@@ -144,7 +59,7 @@ func (tester *routerTester) addBackends(num int) {
 }
 
 func (tester *routerTester) killBackends(num int) {
-	backends := make(map[string]*BackendHealth)
+	backends := make(map[string]*observer.BackendHealth)
 	indexes := rand.Perm(tester.router.backends.Len())
 	for _, index := range indexes {
 		if len(backends) >= num {
@@ -152,19 +67,19 @@ func (tester *routerTester) killBackends(num int) {
 		}
 		// set the ith backend as unhealthy
 		backend := tester.getBackendByIndex(index)
-		if backend.Status() == StatusCannotConnect {
+		if backend.Status() == observer.StatusCannotConnect {
 			continue
 		}
-		backends[backend.addr] = &BackendHealth{
-			Status: StatusCannotConnect,
+		backends[backend.addr] = &observer.BackendHealth{
+			Status: observer.StatusCannotConnect,
 		}
 	}
 	tester.router.OnBackendChanged(backends, nil)
 	tester.checkBackendOrder()
 }
 
-func (tester *routerTester) updateBackendStatusByAddr(addr string, status BackendStatus) {
-	backends := map[string]*BackendHealth{
+func (tester *routerTester) updateBackendStatusByAddr(addr string, status observer.BackendStatus) {
+	backends := map[string]*observer.BackendHealth{
 		addr: {
 			Status: status,
 		},
@@ -186,7 +101,7 @@ func (tester *routerTester) checkBackendOrder() {
 	for be := tester.router.backends.Front(); be != nil; be = be.Next() {
 		backend := be.Value
 		// Empty unhealthy backends should be removed.
-		if backend.Status() == StatusCannotConnect {
+		if backend.Status() == observer.StatusCannotConnect {
 			require.True(tester.t, backend.connList.Len() > 0 || backend.connScore > 0)
 		}
 		curScore := backend.score()
@@ -282,7 +197,7 @@ func (tester *routerTester) checkBalanced() {
 	for be := tester.router.backends.Front(); be != nil; be = be.Next() {
 		backend := be.Value
 		// Empty unhealthy backends should be removed.
-		require.Equal(tester.t, StatusHealthy, backend.Status())
+		require.Equal(tester.t, observer.StatusHealthy, backend.Status())
 		curScore := backend.score()
 		if curScore > maxNum {
 			maxNum = curScore
@@ -477,13 +392,13 @@ func TestRollingRestart(t *testing.T) {
 
 	for i := 0; i < backendNum+1; i++ {
 		if i > 0 {
-			tester.updateBackendStatusByAddr(backendAddrs[i-1], StatusHealthy)
+			tester.updateBackendStatusByAddr(backendAddrs[i-1], observer.StatusHealthy)
 			tester.rebalance(100)
 			tester.redirectFinish(100, true)
 			tester.checkBalanced()
 		}
 		if i < backendNum {
-			tester.updateBackendStatusByAddr(backendAddrs[i], StatusCannotConnect)
+			tester.updateBackendStatusByAddr(backendAddrs[i], observer.StatusCannotConnect)
 			tester.rebalance(100)
 			tester.redirectFinish(100, true)
 			tester.checkBalanced()
@@ -623,24 +538,21 @@ func TestRebalanceCornerCase(t *testing.T) {
 
 // Test all kinds of events occur concurrently.
 func TestConcurrency(t *testing.T) {
-	// Disable health check so that it just reads BackendFetcher.
-	healthCheckConfig := &config.HealthCheck{
-		Enable:   false,
-		Interval: 10 * time.Millisecond,
-	}
-	fetcher := newMockBackendFetcher()
 	lg, _ := logger.CreateLoggerForTest(t)
-	hc := NewDefaultHealthCheck(nil, healthCheckConfig, lg)
 	router := NewScoreBasedRouter(lg)
-	err := router.Init(fetcher, hc, healthCheckConfig)
-	require.NoError(t, err)
+	bo := newMockBackendObserver()
+	bo.Start(context.Background(), router)
+	router.Init(context.Background(), bo)
+	t.Cleanup(router.Close)
+	t.Cleanup(bo.Close)
 
 	var wg waitgroup.WaitGroup
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	// Create 3 backends and change their status randomly.
-	fetcher.setBackend("0", &BackendInfo{})
-	fetcher.setBackend("1", &BackendInfo{})
-	fetcher.setBackend("2", &BackendInfo{})
+	bo.addBackend("0")
+	bo.addBackend("1")
+	bo.addBackend("2")
+	bo.notify(nil)
 	wg.Run(func() {
 		for {
 			waitTime := rand.Intn(20) + 10
@@ -651,13 +563,8 @@ func TestConcurrency(t *testing.T) {
 			}
 			idx := rand.Intn(3)
 			addr := strconv.Itoa(idx)
-			backends, err := fetcher.GetBackendList(context.Background())
-			require.NoError(t, err)
-			if _, ok := backends[addr]; ok {
-				fetcher.removeBackend(addr)
-			} else {
-				fetcher.setBackend(addr, &BackendInfo{})
-			}
+			bo.toggleBackendHealth(addr)
+			bo.notify(nil)
 		}
 	})
 
@@ -719,111 +626,45 @@ func TestConcurrency(t *testing.T) {
 	}
 	wg.Wait()
 	cancel()
-	router.Close()
 }
 
 // Test that the backends are refreshed immediately after it's empty.
 func TestRefresh(t *testing.T) {
-	fetcher := newMockBackendFetcher()
-	hc := newMockHealthCheck()
 	lg, _ := logger.CreateLoggerForTest(t)
-	// Create a router with a very long health check interval.
 	rt := NewScoreBasedRouter(lg)
-	cfg := config.NewDefaultHealthCheckConfig()
-	cfg.Interval = time.Minute
-	observer := StartBackendObserver(lg, rt, cfg, fetcher, hc)
-	rt.Lock()
-	rt.observer = observer
-	rt.Unlock()
-	defer rt.Close()
+	bo := newMockBackendObserver()
+	bo.Start(context.Background(), rt)
+	rt.Init(context.Background(), bo)
+	t.Cleanup(rt.Close)
+	t.Cleanup(bo.Close)
 	// The initial backends are empty.
 	selector := rt.GetBackendSelector()
 	_, err := selector.Next()
 	require.Equal(t, ErrNoBackend, err)
-	// Create a new backend and add to the list.
-	fetcher.setBackend("127.0.0.1:4000", &BackendInfo{})
-	hc.setBackend("127.0.0.1:4000", &BackendHealth{Status: StatusHealthy})
-	// The backends are refreshed very soon.
-	require.Eventually(t, func() bool {
-		_, err := selector.Next()
-		return err == nil
-	}, 3*time.Second, 100*time.Millisecond)
+	// Refresh is called internally and there comes a new one.
+	bo.notify(nil)
+	_, err = selector.Next()
+	require.NoError(t, err)
 }
 
 func TestObserveError(t *testing.T) {
-	backends := make([]string, 0, 1)
-	var observeError error
-	var m sync.Mutex
-	fetcher := NewExternalFetcher(func() ([]string, error) {
-		m.Lock()
-		defer m.Unlock()
-		return backends, observeError
-	})
-	hc := newMockHealthCheck()
-	// Create a router with a very short health check interval.
 	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
-	err := rt.Init(fetcher, hc, newHealthCheckConfigForTest())
-	require.NoError(t, err)
-	defer rt.Close()
-	// No backends.
-	selector := rt.GetBackendSelector()
-	_, err = selector.Next()
-	require.Equal(t, ErrNoBackend, err)
-	// Create a new backend and add to the list.
-	hc.setBackend("127.0.0.1:4000", &BackendHealth{Status: StatusHealthy})
-	m.Lock()
-	backends = append(backends, "127.0.0.1:4000")
-	m.Unlock()
-	// The backends are refreshed very soon.
-	require.Eventually(t, func() bool {
-		_, err := selector.Next()
-		return err == nil
-	}, 3*time.Second, 100*time.Millisecond)
+	bo := newMockBackendObserver()
+	bo.Start(context.Background(), rt)
+	rt.Init(context.Background(), bo)
+	t.Cleanup(rt.Close)
+	t.Cleanup(bo.Close)
 	// Mock an observe error.
-	m.Lock()
-	observeError = errors.New("mock observe error")
-	m.Unlock()
-	require.Eventually(t, func() bool {
-		_, err = selector.Next()
-		return err != nil && err != ErrNoBackend
-	}, 3*time.Second, 100*time.Millisecond)
-	// Clear the observe error.
-	m.Lock()
-	observeError = nil
-	m.Unlock()
-	require.Eventually(t, func() bool {
-		_, err = selector.Next()
-		return err == nil
-	}, 3*time.Second, 100*time.Millisecond)
-}
-
-func TestDisableHealthCheck(t *testing.T) {
-	fetcher := newMockBackendFetcher()
-	fetcher.setBackend("127.0.0.1:4000", nil)
-	healtchCheckConfig := &config.HealthCheck{Enable: false}
-	// Create a router with a very short health check interval.
-	lg, _ := logger.CreateLoggerForTest(t)
-	hc := NewDefaultHealthCheck(nil, healtchCheckConfig, lg)
-	rt := NewScoreBasedRouter(lg)
-	err := rt.Init(fetcher, hc, healtchCheckConfig)
-	require.NoError(t, err)
-	defer rt.Close()
-	// No backends and no error.
+	bo.notify(errors.New("mock observe error"))
 	selector := rt.GetBackendSelector()
-	// The backends are refreshed very soon.
-	require.Eventually(t, func() bool {
-		backend, err := selector.Next()
-		require.NoError(t, err)
-		return backend.Addr() == "127.0.0.1:4000"
-	}, 3*time.Second, 100*time.Millisecond)
-	// Replace the backend.
-	fetcher.setBackend("127.0.0.1:5000", nil)
-	require.Eventually(t, func() bool {
-		backend, err := selector.Next()
-		require.NoError(t, err)
-		return backend.Addr() == "127.0.0.1:5000"
-	}, 3*time.Second, 100*time.Millisecond)
+	_, err := selector.Next()
+	require.True(t, err != nil && err != ErrNoBackend)
+	// Clear the observe error.
+	bo.addBackend("0")
+	bo.notify(nil)
+	_, err = selector.Next()
+	require.NoError(t, err)
 }
 
 func TestSetBackendStatus(t *testing.T) {
@@ -834,7 +675,7 @@ func TestSetBackendStatus(t *testing.T) {
 	for _, conn := range tester.conns {
 		require.False(t, conn.from.Healthy())
 	}
-	tester.updateBackendStatusByAddr(tester.getBackendByIndex(0).addr, StatusHealthy)
+	tester.updateBackendStatusByAddr(tester.getBackendByIndex(0).addr, observer.StatusHealthy)
 	for _, conn := range tester.conns {
 		require.True(t, conn.from.Healthy())
 	}
@@ -844,13 +685,13 @@ func TestGetServerVersion(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
 	t.Cleanup(rt.Close)
-	backends := map[string]*BackendHealth{
+	backends := map[string]*observer.BackendHealth{
 		"0": {
-			Status:        StatusHealthy,
+			Status:        observer.StatusHealthy,
 			ServerVersion: "1.0",
 		},
 		"1": {
-			Status:        StatusHealthy,
+			Status:        observer.StatusHealthy,
 			ServerVersion: "2.0",
 		},
 	}
@@ -888,7 +729,7 @@ func TestCloseRedirectingConns(t *testing.T) {
 	require.Equal(t, 0, tester.getBackendByIndex(0).connScore)
 	require.Equal(t, 1, tester.getBackendByIndex(1).connScore)
 	// Close the connection.
-	tester.updateBackendStatusByAddr(tester.getBackendByIndex(0).Addr(), StatusHealthy)
+	tester.updateBackendStatusByAddr(tester.getBackendByIndex(0).Addr(), observer.StatusHealthy)
 	tester.closeConnections(1, true)
 	require.Equal(t, 0, tester.getBackendByIndex(0).connScore)
 	require.Equal(t, 0, tester.getBackendByIndex(1).connScore)

--- a/pkg/proxy/net/error.go
+++ b/pkg/proxy/net/error.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -31,4 +32,22 @@ func IsDisconnectError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// When the server refused to connect, the port is shut down, so no need to retry.
+var notRetryableError = []string{
+	"connection refused",
+}
+
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, errStr := range notRetryableError {
+		if strings.Contains(msg, errStr) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/testkit/main.go
+++ b/pkg/testkit/main.go
@@ -5,6 +5,7 @@ package testkit
 
 import (
 	"net"
+	"strconv"
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -70,4 +71,21 @@ func TestTCPConnWithListener(t *testing.T, listen func(*testing.T, string, strin
 		})
 		wg.Wait()
 	}
+}
+
+func StartListener(t *testing.T, addr string) (net.Listener, string) {
+	if len(addr) == 0 {
+		addr = "127.0.0.1:0"
+	}
+	listener, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	return listener, listener.Addr().String()
+}
+
+func ParseHostPort(t *testing.T, addr string) (string, uint) {
+	host, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	p, err := strconv.ParseUint(port, 10, 32)
+	require.NoError(t, err)
+	return host, uint(p)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #501 

Problem Summary:
Health check, backend observer, and backend fetcher are independent of the router. Multiple router implementations can reuse the same backend observer.

What is changed and how it works:
- Move `HealthCheck`, `BackendObserver`, and `BackendFetcher` from package `router` to `observer`.
- `NamespaceMgr` creates `BackendObserver` and passes it to `ScoreBasedRouter`.
- Move mocked objects to `mock_test.go`.
- Move some common functions to common packages.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
