### PR TITLE
cmd: deprecate cmd args `log_level` and `log_encoder`

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -28,9 +28,10 @@ func main() {
 
 	sctx := &sctx.Context{}
 
+	var deprecatedStr string
 	rootCmd.PersistentFlags().StringVar(&sctx.ConfigFile, "config", "", "proxy config file path")
-	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Log.Encoder, "log_encoder", "", "log in format of tidb, console, or json")
-	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Log.Level, "log_level", "", "log level")
+	rootCmd.PersistentFlags().StringVar(&deprecatedStr, "log_encoder", "", "deprecated and will be removed")
+	rootCmd.PersistentFlags().StringVar(&deprecatedStr, "log_level", "", "deprecated and will be removed")
 	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Proxy.AdvertiseAddr, "advertise-addr", "", "advertise address")
 
 	metrics.MaxProcsGauge.Set(float64(runtime.GOMAXPROCS(0)))


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #449 

Problem Summary:
`log_level` and `log_encoder` conflict with the configs which support hot reload. This may confuse users when they update the config file.

What is changed and how it works:
Deprecate `log_level` and `log_encoder`. They will be removed in the future.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
$ bin/tiproxy --help
start the proxy server

Usage:
  bin/tiproxy [flags]

Flags:
      --advertise-addr string   advertise address
      --config string           proxy config file path
  -h, --help                    help for bin/tiproxy
      --log_encoder string      deprecated and will be removed
      --log_level string        deprecated and will be removed
  -v, --version                 version for bin/tiproxy


$ bin/tiproxy --log_level=debug
// started normally
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Deprecate the command line arguments `log_level` and `log_encoder`
```
