### PR TITLE
main: make sure the Welcome TiProxy info is always printed. 

### DIFF
--- a/pkg/manager/logger/manager.go
+++ b/pkg/manager/logger/manager.go
@@ -52,6 +52,10 @@ func (lm *LoggerManager) Init(cfgch <-chan *config.Config) {
 	}, nil, lm.logger)
 }
 
+func (lm *LoggerManager) SetLoggerLevel(l zapcore.Level) {
+	lm.level.SetLevel(l)
+}
+
 func (lm *LoggerManager) watchCfg(ctx context.Context, cfgch <-chan *config.Config) {
 	for {
 		select {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -75,7 +75,11 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	//
 	// TODO: there is a race condition that printInfo and logmgr may concurrently execute:
 	// logmgr may havenot been initialized with logfile yet
+	// Make sure the TiProxy info is always printed.
+	level := lg.Level()
+	srv.LoggerManager.SetLoggerLevel(zap.InfoLevel)
 	printInfo(lg)
+	srv.LoggerManager.SetLoggerLevel(level)
 
 	// setup metrics
 	srv.MetricsManager.Init(ctx, lg.Named("metrics"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #506 

Problem Summary:

What is changed and how it works:
update the log level to "info" before print TiProxy info to make sure the info log is always printed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code
step 1 set the log level to "error" in config file, such as :
```
[log]
level = "error"
```
set 2 start the TiProxy and check the TiProxy info is printed.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [x] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
