### PR TITLE
router, observer: make router pull backends from observer

### DIFF
--- a/pkg/manager/metricsreader/metrics_reader.go
+++ b/pkg/manager/metricsreader/metrics_reader.go
@@ -228,6 +228,7 @@ func (dmr *DefaultMetricsReader) notifySubscribers(ctx context.Context) {
 		case <-time.After(100 * time.Millisecond):
 			dmr.lg.Warn("fails to notify metrics result", zap.String("receiver", name))
 		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -50,7 +50,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	rt := router.NewScoreBasedRouter(logger.Named("router"))
 	hc := observer.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	bo := observer.NewDefaultBackendObserver(logger.Named("observer"), healthCheckCfg, fetcher, hc)
-	bo.Start(context.Background(), rt)
+	bo.Start(context.Background())
 	rt.Init(context.Background(), bo)
 
 	return &Namespace{

--- a/pkg/manager/observer/backend_health.go
+++ b/pkg/manager/observer/backend_health.go
@@ -51,6 +51,10 @@ type BackendHealth struct {
 	ServerVersion string
 }
 
+func (bh *BackendHealth) Equals(health BackendHealth) bool {
+	return bh.Status == health.Status && bh.ServerVersion == health.ServerVersion
+}
+
 func (bh *BackendHealth) String() string {
 	str := fmt.Sprintf("status: %s", bh.Status.String())
 	if bh.PingErr != nil {
@@ -63,4 +67,32 @@ func (bh *BackendHealth) String() string {
 type BackendInfo struct {
 	IP         string
 	StatusPort uint
+}
+
+// HealthResult contains the health check results and is used to notify the routers.
+// It's read-only for subscribers.
+type HealthResult struct {
+	// `backends` is empty when `err` is not nil. It doesn't mean there are no backends.
+	backends map[string]*BackendHealth
+	err      error
+}
+
+// NewHealthResult is used for testing in other packages.
+func NewHealthResult(backends map[string]*BackendHealth, err error) HealthResult {
+	return HealthResult{
+		backends: backends,
+		err:      err,
+	}
+}
+
+func (hr HealthResult) Backends() map[string]*BackendHealth {
+	newMap := make(map[string]*BackendHealth, len(hr.backends))
+	for addr, health := range hr.backends {
+		newMap[addr] = health
+	}
+	return newMap
+}
+
+func (hr HealthResult) Error() error {
+	return hr.err
 }

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -135,6 +135,13 @@ func (b *backendWrapper) ServerVersion() string {
 	return version
 }
 
+func (b *backendWrapper) Equals(health observer.BackendHealth) bool {
+	b.mu.RLock()
+	equal := b.mu.BackendHealth.Equals(health)
+	b.mu.RUnlock()
+	return equal
+}
+
 func (b *backendWrapper) String() string {
 	b.mu.RLock()
 	str := b.mu.String()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #503 

Problem Summary:
Currently, BackendObserver pushes backend updates to Router. BackendObserver is shared among multiple tenants while Router is private for each tenant. The right way is that Router pulls from BackendObserver.

What is changed and how it works:
- ScoredBasedRouter subscribes backend (HealthResult) from BackendObserver
- BackendObserver notifies all the backends to Router, instead of updated backends

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
