### PR TITLE
metricsreader: fix the metrics_reader.getPromAPI fun panic when there is no prometheus info in pd

### DIFF
--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -107,9 +107,15 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
 // Always refresh the prometheus Address just in case it changes.
 func (dmr *DefaultMetricsReader) getPromAPI(ctx context.Context) (promv1.API, error) {
 	promInfo, err := dmr.promFetcher.GetPromInfo(ctx)
-	if promInfo == nil && dmr.getPromRes != getPromFail {
-		dmr.getPromRes = getPromFail
+	if promInfo == nil {
+		if dmr.getPromRes != getPromFail {
+			dmr.getPromRes = getPromFail
+		}
+		if err == nil {
+			err = errors.New("no prometheus info found")
+		}
 		dmr.lg.Warn("get prometheus address fails", zap.Error(err))
+		return nil, err
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/balance/metricsreader/metrics_reader_test.go
+++ b/pkg/balance/metricsreader/metrics_reader_test.go
@@ -306,6 +306,20 @@ func TestNoPromAddr(t *testing.T) {
 	}
 }
 
+func TestGetPromAPI_NoPromAddr(t *testing.T) {
+	mpf := &mockPromFetcher{
+		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
+			return nil, nil
+		},
+	}
+	lg, _ := logger.CreateLoggerForTest(t)
+	mr := NewDefaultMetricsReader(lg, mpf, newHealthCheckConfigForTest())
+	promInfo, err := mr.getPromAPI(context.Background())
+	require.Nil(t, promInfo)
+	require.NotNil(t, err)
+	require.Equal(t, true, strings.Contains(err.Error(), "no prometheus info found"))
+}
+
 func setupTypicalMetricsReader(t *testing.T) (*mockHttpHandler, MetricsReader) {
 	httpHandler := &mockHttpHandler{
 		t: t,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #515 

Problem Summary:

the func metrics_reader.getPromAPI panic if there is no prometheus info in pd


What is changed and how it works:

the panic reson as below
net.JoinHostPort(promInfo.IP, strconv.Itoa(promInfo.Port)) panic since it get nil  promInfo when dmr.promFetcher.GetPromInfo(ctx) return  nil,nil
```
// Always refresh the prometheus Address just in case it changes.
func (dmr *DefaultMetricsReader) getPromAPI(ctx context.Context) (promv1.API, error) {
	promInfo, err := dmr.promFetcher.GetPromInfo(ctx)   // (promInfo,err) is (nil,nil) when there is no prometheus info in pd
	if promInfo == nil && dmr.getPromRes != getPromFail {
		dmr.getPromRes = getPromFail
		dmr.lg.Warn("get prometheus address fails", zap.Error(err))
	}
	if err != nil {
		return nil, err
	}
	// TODO: support TLS and authentication.
	promAddr := fmt.Sprintf("http://%s", net.JoinHostPort(promInfo.IP, strconv.Itoa(promInfo.Port))) // panic since promInfo is nil
        .......
}
```
it should  return directly when promInfo is nil 


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
first step: start tiproxy
second step: start tidb using tiup playground

- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
