### PR TITLE
balance: support cpu-based balance

### DIFF
--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -5,6 +5,7 @@ package factor
 
 import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"go.uber.org/zap"
 )
@@ -19,58 +20,61 @@ var _ policy.BalancePolicy = (*FactorBasedBalance)(nil)
 // It's not concurrency-safe for now.
 type FactorBasedBalance struct {
 	factors []Factor
-	lg      *zap.Logger
 	// to reduce memory allocation
 	cachedList  []scoredBackend
+	mr          metricsreader.MetricsReader
+	lg          *zap.Logger
 	totalBitNum int
 }
 
-func NewFactorBasedBalance(lg *zap.Logger) *FactorBasedBalance {
+func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsReader) *FactorBasedBalance {
 	return &FactorBasedBalance{
 		lg:         lg,
+		mr:         mr,
 		cachedList: make([]scoredBackend, 0, 512),
 	}
 }
 
 // Init creates factors at the first time.
 // TODO: create factors according to config and update policy when config changes.
-func (fm *FactorBasedBalance) Init() {
-	fm.factors = []Factor{
+func (fbb *FactorBasedBalance) Init() {
+	fbb.factors = []Factor{
 		NewFactorHealth(),
+		// NewFactorCPU(fbb.mr),
 		NewFactorConnCount(),
 	}
-	err := fm.updateBitNum()
+	err := fbb.updateBitNum()
 	if err != nil {
 		panic(err.Error())
 	}
 }
 
-func (fm *FactorBasedBalance) updateBitNum() error {
+func (fbb *FactorBasedBalance) updateBitNum() error {
 	totalBitNum := 0
-	for _, factor := range fm.factors {
+	for _, factor := range fbb.factors {
 		totalBitNum += factor.ScoreBitNum()
 	}
 	if totalBitNum > maxBitNum {
 		return errors.Errorf("the total bit number of factors is %d", totalBitNum)
 	}
-	fm.totalBitNum = totalBitNum
+	fbb.totalBitNum = totalBitNum
 	return nil
 }
 
 // BackendToRoute returns the idlest backend.
-func (fm *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) policy.BackendCtx {
+func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) policy.BackendCtx {
 	if len(backends) == 0 {
 		return nil
 	}
 	if len(backends) == 1 {
 		return backends[0]
 	}
-	scoredBackends := fm.cachedList[:0]
+	scoredBackends := fbb.cachedList[:0]
 	for _, backend := range backends {
 		scoredBackends = append(scoredBackends, newScoredBackend(backend))
 	}
 	// Update backend scores.
-	for _, factor := range fm.factors {
+	for _, factor := range fbb.factors {
 		factor.UpdateScore(scoredBackends)
 	}
 	// Find the idlest backend.
@@ -89,16 +93,16 @@ func (fm *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) polic
 // BackendsToBalance returns the busiest/unhealthy backend and the idlest backend.
 // balanceCount: the count of connections to migrate in this round. 0 indicates no need to balance.
 // reason: the debug information to be logged.
-func (fm *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount int, reason []zap.Field) {
+func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount int, reason []zap.Field) {
 	if len(backends) <= 1 {
 		return
 	}
 	// Update backend scores.
-	scoredBackends := fm.cachedList[:0]
+	scoredBackends := fbb.cachedList[:0]
 	for _, backend := range backends {
 		scoredBackends = append(scoredBackends, newScoredBackend(backend))
 	}
-	for _, factor := range fm.factors {
+	for _, factor := range fbb.factors {
 		factor.UpdateScore(scoredBackends)
 	}
 
@@ -125,8 +129,8 @@ func (fm *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (f
 
 	// Get the unbalanced factor and the connection count to migrate.
 	var factor Factor
-	leftBitNum := fm.totalBitNum
-	for _, factor = range fm.factors {
+	leftBitNum := fbb.totalBitNum
+	for _, factor = range fbb.factors {
 		bitNum := factor.ScoreBitNum()
 		score1 := maxScore << (maxBitNum - leftBitNum) >> (maxBitNum - bitNum)
 		score2 := minScore << (maxBitNum - leftBitNum) >> (maxBitNum - bitNum)

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRouteWithOneFactor(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	fm := NewFactorBasedBalance(lg)
+	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
 	factor := &mockFactor{bitNum: 2}
 	fm.factors = []Factor{factor}
 	require.NoError(t, fm.updateBitNum())
@@ -45,7 +45,7 @@ func TestRouteWithOneFactor(t *testing.T) {
 
 func TestRouteWith2Factors(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	fm := NewFactorBasedBalance(lg)
+	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
 	factor1, factor2 := &mockFactor{bitNum: 1}, &mockFactor{bitNum: 12}
 	fm.factors = []Factor{factor1, factor2}
 	require.NoError(t, fm.updateBitNum())
@@ -100,7 +100,7 @@ func TestRouteWith2Factors(t *testing.T) {
 
 func TestBalanceWithOneFactor(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	fm := NewFactorBasedBalance(lg)
+	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
 	factor := &mockFactor{bitNum: 2, balanceCount: 1}
 	fm.factors = []Factor{factor}
 	require.NoError(t, fm.updateBitNum())
@@ -149,7 +149,7 @@ func TestBalanceWithOneFactor(t *testing.T) {
 
 func TestBalanceWith2Factors(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	fm := NewFactorBasedBalance(lg)
+	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
 	factor1, factor2 := &mockFactor{bitNum: 1, balanceCount: 2}, &mockFactor{bitNum: 12, balanceCount: 1}
 	fm.factors = []Factor{factor1, factor2}
 	require.NoError(t, fm.updateBitNum())
@@ -228,7 +228,7 @@ func TestBalanceWith2Factors(t *testing.T) {
 
 func TestBalanceWith3Factors(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	fm := NewFactorBasedBalance(lg)
+	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
 	factors := []*mockFactor{{bitNum: 1}, {bitNum: 2}, {bitNum: 2}}
 	fm.factors = []Factor{factors[0], factors[1], factors[2]}
 	require.NoError(t, fm.updateBitNum())

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -1,0 +1,224 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package factor
+
+import (
+	"math"
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
+	"github.com/prometheus/common/model"
+)
+
+const (
+	cpuEwmaAlpha = 0.5
+	// If some metrics are missing, we use the old one temporarily for no longer than metricExpDuration.
+	metricExpDuration = 2 * time.Minute
+	cpuScoreStep      = 5
+	// 0.001 represents for 0.1%
+	minCpuPerConn    = 0.001
+	cpuBalancedRatio = 1.3
+	balanceCount4Cpu = 1
+)
+
+var _ Factor = (*FactorCPU)(nil)
+
+var (
+	cpuQueryExpr = metricsreader.QueryExpr{
+		PromQL:   `rate(process_cpu_seconds_total/tidb_server_maxprocs{%s="tidb"}[15s])`,
+		HasLabel: true,
+		Range:    3 * time.Minute,
+	}
+)
+
+type backendSnapshot struct {
+	updatedTime monotime.Time
+	avgUsage    float64
+	latestUsage float64
+	connCount   int
+}
+
+type FactorCPU struct {
+	// The snapshot of backend statistics when the matrix was updated.
+	snapshot map[string]backendSnapshot
+	// The updated time of the metric that we've read last time.
+	lastMetricTime monotime.Time
+	// The estimated average CPU usage used by one connection.
+	usagePerConn float64
+	mr           metricsreader.MetricsReader
+	queryID      uint64
+	bitNum       int
+}
+
+func NewFactorCPU(mr metricsreader.MetricsReader) *FactorCPU {
+	return &FactorCPU{
+		mr:       mr,
+		queryID:  mr.AddQueryExpr(cpuQueryExpr),
+		bitNum:   5,
+		snapshot: make(map[string]backendSnapshot),
+	}
+}
+
+func (fc *FactorCPU) Name() string {
+	return "cpu"
+}
+
+func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
+	if len(backends) <= 1 {
+		return
+	}
+	qr := fc.mr.GetQueryResult(fc.queryID)
+	if qr.Err != nil || qr.Empty() {
+		return
+	}
+
+	if qr.UpdateTime != fc.lastMetricTime {
+		// Metrics have updated.
+		fc.lastMetricTime = qr.UpdateTime
+		fc.updateSnapshot(qr, backends)
+		fc.updateCpuPerConn()
+	}
+	if monotime.Since(fc.lastMetricTime) > metricExpDuration {
+		// The metrics have not been updated for a long time (maybe Prometheus is unavailable).
+		return
+	}
+
+	for i := 0; i < len(backends); i++ {
+		// Negative indicates missing metric.
+		avgUsage := -1.0
+		addr := backends[i].Addr()
+		// Estimate the current cpu usage by the latest CPU usage, the latest connection count, and the current connection count.
+		if snapshot, ok := fc.snapshot[addr]; ok {
+			histConnCount := snapshot.connCount
+			curConnCount := backends[i].ConnScore()
+			if snapshot.avgUsage >= 0 {
+				avgUsage = snapshot.avgUsage + float64(curConnCount-histConnCount)*fc.usagePerConn
+				if avgUsage < 0 {
+					avgUsage = 0
+				}
+			}
+		}
+		// If the metric of one backend is missing, treat it as unhealthy.
+		// If the metrics of all backends are missing, give them the same scores.
+		if avgUsage < 0 || avgUsage > 1 {
+			avgUsage = 1
+		}
+		backends[i].addScore(int(avgUsage*100)/cpuScoreStep, fc.bitNum)
+	}
+}
+
+func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []scoredBackend) {
+	snapshots := make(map[string]backendSnapshot, len(fc.snapshot))
+	for _, backend := range backends {
+		addr := backend.Addr()
+		valid := false
+		// If a backend exists in metrics but not in the backend list, ignore it for this round.
+		// The backend will be in the next round if it's healthy.
+		pairs := qr.GetMetric4Backend(backend)
+		if len(pairs) > 0 {
+			avgUsage, latestUsage := calcAvgUsage(pairs)
+			if avgUsage >= 0 {
+				snapshots[addr] = backendSnapshot{
+					avgUsage:    avgUsage,
+					latestUsage: latestUsage,
+					connCount:   backend.ConnCount(),
+					updatedTime: qr.UpdateTime,
+				}
+				valid = true
+			}
+		}
+		// Merge the old snapshot just in case some metrics have missed for a short period.
+		if !valid {
+			if snapshot, ok := fc.snapshot[addr]; ok {
+				if monotime.Since(snapshot.updatedTime) < metricExpDuration {
+					snapshots[addr] = snapshot
+				}
+			}
+		}
+	}
+	fc.snapshot = snapshots
+}
+
+func calcAvgUsage(usageHistory []model.SamplePair) (avgUsage, latestUsage float64) {
+	avgUsage, latestUsage = -1, -1
+	if len(usageHistory) == 0 {
+		return
+	}
+	// The CPU usage jitters too much, so use the EWMA algorithm to make it smooth.
+	for _, usage := range usageHistory {
+		value := float64(usage.Value)
+		if math.IsNaN(value) {
+			continue
+		}
+		latestUsage = value
+		if avgUsage < 0 {
+			avgUsage = value
+		} else {
+			avgUsage = avgUsage*(1-cpuEwmaAlpha) + value*cpuEwmaAlpha
+		}
+	}
+	if avgUsage > 1 {
+		avgUsage = 1
+	}
+	return
+}
+
+// Estimate the average CPU usage used by one connection.
+// Don't fetch the global connection count (tidb_server_connections) because the connScore is also based on the local count.
+// Don't estimate it based on each backend because background jobs may use much CPU.
+// E.g. auto-analyze uses 30% CPU and the backend has 1 connection. You may mistakenly think the connection uses 30% CPU.
+func (fc *FactorCPU) updateCpuPerConn() {
+	totalUsage, totalConns := 0.0, 0
+	for _, backend := range fc.snapshot {
+		if backend.latestUsage > 0 && backend.connCount > 0 {
+			totalUsage += backend.latestUsage
+			totalConns += backend.connCount
+		}
+	}
+	if totalConns > 0 {
+		fc.usagePerConn = totalUsage / float64(totalConns)
+		// When the cluster is idle and the clients are connecting to it all at once (e.g. when sysbench starts),
+		// the CPU usage lags behind, so the usagePerConn may be very low. In this case, all the connections may be
+		// routed to the same backend just because the CPU usage of the backend is a little lower.
+		if fc.usagePerConn < minCpuPerConn && totalUsage < 0.2 {
+			fc.usagePerConn = minCpuPerConn
+		}
+	}
+	if fc.usagePerConn <= 0 {
+		fc.usagePerConn = minCpuPerConn
+	}
+}
+
+func (fc *FactorCPU) ScoreBitNum() int {
+	return fc.bitNum
+}
+
+func (fc *FactorCPU) BalanceCount(from, to scoredBackend) int {
+	var fromUsage, toUsage float64
+	if fromSnapshot, ok := fc.snapshot[from.Addr()]; !ok || fromSnapshot.avgUsage < 0 {
+		// The metric has missed for minutes.
+		fromUsage = 1
+	} else {
+		fromUsage = fromSnapshot.avgUsage + float64(from.ConnScore()-fromSnapshot.connCount)*fc.usagePerConn
+		if fromUsage > 1 {
+			fromUsage = 1
+		}
+	}
+	if toSnapshot, ok := fc.snapshot[to.Addr()]; !ok || toSnapshot.avgUsage < 0 {
+		// impossible
+		return 0
+	} else {
+		toUsage = toSnapshot.avgUsage + float64(to.ConnScore()-toSnapshot.connCount)*fc.usagePerConn
+		if toUsage > 1 {
+			toUsage = 1
+		}
+	}
+	// The higher the CPU usage, the more sensitive the load balance should be.
+	// E.g. 10% vs 25% don't need rebalance, but 80% vs 95% need rebalance.
+	if 1.1-toUsage > (1.1-fromUsage)*cpuBalancedRatio {
+		return balanceCount4Cpu
+	}
+	return 0
+}

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -1,0 +1,261 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package factor
+
+import (
+	"math"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCPUBalanceOnce(t *testing.T) {
+	tests := []struct {
+		cpus         [][]float64
+		scoreOrder   []int
+		balanceCount int
+	}{
+		{
+			cpus:         [][]float64{{0}, {0.2}},
+			scoreOrder:   []int{0, 1},
+			balanceCount: 0,
+		},
+		{
+			cpus:         [][]float64{{1, 0.5, 0.25, 0}, {0, 0.25, 0.5, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}},
+			scoreOrder:   []int{2, 0, 1, 3},
+			balanceCount: balanceCount4Cpu,
+		},
+		{
+			cpus:         [][]float64{{0.25}, {}, {0.5}},
+			scoreOrder:   []int{0, 2, 1},
+			balanceCount: balanceCount4Cpu,
+		},
+		{
+			cpus:         [][]float64{{0.95, 0.92, 0.93, 0.94, 0.92, 0.94}, {0.81, 0.79, 0.82, 0.83, 0.76, 0.78}},
+			scoreOrder:   []int{1, 0},
+			balanceCount: balanceCount4Cpu,
+		},
+		{
+			cpus:         [][]float64{{0.35, 0.42, 0.37, 0.45, 0.42, 0.44}, {0.56, 0.62, 0.58, 0.57, 0.59, 0.63}},
+			scoreOrder:   []int{0, 1},
+			balanceCount: balanceCount4Cpu,
+		},
+		{
+			cpus:         [][]float64{{0, 0.1, 0, 0.1}, {0.15, 0.1, 0.15, 0.1}, {0.1, 0, 0.1, 0}},
+			scoreOrder:   []int{2, 0, 1},
+			balanceCount: 0,
+		},
+		{
+			cpus:         [][]float64{{0.5}, {}, {0.1, 0.3, 0.5}},
+			scoreOrder:   []int{2, 0, 1},
+			balanceCount: balanceCount4Cpu,
+		},
+		{
+			cpus:         [][]float64{{1.0}, {0.97}},
+			scoreOrder:   []int{1, 0},
+			balanceCount: 0,
+		},
+	}
+
+	for i, test := range tests {
+		backends := make([]scoredBackend, 0, len(test.cpus))
+		values := make([]*model.SampleStream, 0, len(test.cpus))
+		for j := 0; j < len(test.cpus); j++ {
+			backends = append(backends, createBackend(j, 0, 0))
+			values = append(values, createSampleStream(test.cpus[j], j))
+		}
+		mmr := &mockMetricsReader{
+			qr: metricsreader.QueryResult{
+				UpdateTime: monotime.Now(),
+				Value:      model.Matrix(values),
+			},
+		}
+		fc := NewFactorCPU(mmr)
+		updateScore(fc, backends)
+		sortedIdx := make([]int, 0, len(test.cpus))
+		for _, backend := range backends {
+			idx, err := strconv.Atoi(backend.Addr())
+			require.NoError(t, err)
+			sortedIdx = append(sortedIdx, idx)
+		}
+		require.Equal(t, test.scoreOrder, sortedIdx, "test index %d", i)
+		from, to := backends[len(backends)-1], backends[0]
+		balanceCount := fc.BalanceCount(from, to)
+		require.Equal(t, test.balanceCount, balanceCount, "test index %d", i)
+	}
+}
+
+func TestCPUBalanceContinuously(t *testing.T) {
+	tests := []struct {
+		cpus          [][]float64
+		connCounts    []int
+		connScores    []int
+		newConnScores []int
+	}{
+		{
+			cpus:          [][]float64{{}, {}},
+			connCounts:    []int{0, 0},
+			connScores:    []int{0, 0},
+			newConnScores: []int{0, 0},
+		},
+		{
+			cpus:          [][]float64{{0.1, 0.1, 0.1, 0.1, 0.1}, {0.05, 0.07, 0.05, 0.04, 0.03}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{200, 100},
+			newConnScores: []int{200, 100},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{200, 100},
+			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{170, 130},
+			connScores:    []int{170, 130},
+			newConnScores: []int{140, 160},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{}, {}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{170, 130},
+		},
+	}
+
+	mmr := newMockMetricsReader()
+	fc := NewFactorCPU(mmr)
+	for i, test := range tests {
+		backends := make([]scoredBackend, 0, len(test.cpus))
+		values := make([]*model.SampleStream, 0, len(test.cpus))
+		for j := 0; j < len(test.cpus); j++ {
+			backends = append(backends, createBackend(j, test.connCounts[j], test.connScores[j]))
+			values = append(values, createSampleStream(test.cpus[j], j))
+		}
+		mmr.qr = metricsreader.QueryResult{
+			UpdateTime: monotime.Now(),
+			Value:      model.Matrix(values),
+		}
+		// Rebalance until it stops. The final scores should be newConnScores.
+		for k := 0; ; k++ {
+			if k > 300 {
+				t.Fatal("balance doesn't stop")
+			}
+			updateScore(fc, backends)
+			balanceCount := fc.BalanceCount(backends[len(backends)-1], backends[0])
+			if balanceCount == 0 {
+				break
+			}
+			backends[len(backends)-1].BackendCtx.(*mockBackend).connScore -= balanceCount
+			backends[0].BackendCtx.(*mockBackend).connScore += balanceCount
+		}
+		connScores := make([]int, len(test.connScores))
+		for _, backend := range backends {
+			idx, err := strconv.Atoi(backend.Addr())
+			require.NoError(t, err)
+			connScores[idx] = backend.ConnScore()
+		}
+		require.Equal(t, test.newConnScores, connScores, "test index %d", i)
+	}
+}
+
+func TestNoCPUMetric(t *testing.T) {
+	tests := []struct {
+		cpus       [][]float64
+		updateTime monotime.Time
+	}{
+		{
+			cpus: nil,
+		},
+		{
+			cpus:       [][]float64{{1.0}, {0.0}},
+			updateTime: monotime.Now().Sub(metricExpDuration * 2),
+		},
+		{
+			cpus:       [][]float64{{math.NaN()}, {math.NaN()}},
+			updateTime: monotime.Now(),
+		},
+	}
+
+	mmr := newMockMetricsReader()
+	fc := NewFactorCPU(mmr)
+	backends := make([]scoredBackend, 0, 2)
+	for i := 0; i < 2; i++ {
+		backends = append(backends, createBackend(i, i*100, i*100))
+	}
+	for i, test := range tests {
+		values := make([]*model.SampleStream, 0, len(test.cpus))
+		for j := 0; j < len(test.cpus); j++ {
+			values = append(values, createSampleStream(test.cpus[j], j))
+		}
+		mmr.qr = metricsreader.QueryResult{
+			UpdateTime: test.updateTime,
+			Value:      model.Matrix(values),
+		}
+		updateScore(fc, backends)
+		require.Equal(t, backends[0].score(), backends[1].score(), "test index %d", i)
+	}
+}
+
+func createBackend(backendIdx, connCount, connScore int) scoredBackend {
+	addr := strconv.Itoa(backendIdx)
+	return scoredBackend{
+		BackendCtx: &mockBackend{
+			addr:      addr,
+			connCount: connCount,
+			connScore: connScore,
+			healthy:   true,
+		},
+	}
+}
+
+func createSampleStream(cpus []float64, backendIdx int) *model.SampleStream {
+	addr := strconv.Itoa(backendIdx)
+	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(addr)}
+	pairs := make([]model.SamplePair, 0, len(cpus))
+	for _, cpu := range cpus {
+		pairs = append(pairs, model.SamplePair{Value: model.SampleValue(cpu)})
+	}
+	return &model.SampleStream{Metric: labelSet, Values: pairs}
+}
+
+func updateScore(fc *FactorCPU, backends []scoredBackend) {
+	for i := 0; i < len(backends); i++ {
+		backends[i].scoreBits = 0
+	}
+	fc.UpdateScore(backends)
+	sort.Slice(backends, func(i, j int) bool {
+		return backends[i].score() < backends[j].score()
+	})
+}

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -61,6 +61,11 @@ func TestCPUBalanceOnce(t *testing.T) {
 			scoreOrder:   []int{1, 0},
 			balanceCount: 0,
 		},
+		{
+			cpus:         [][]float64{{1.0}, {0.9}, {0.8}, {0.7}, {0.6}, {0.5}, {0.4}, {0.3}, {0.1}},
+			scoreOrder:   []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
+			balanceCount: balanceCount4Cpu,
+		},
 	}
 
 	for i, test := range tests {
@@ -105,6 +110,12 @@ func TestCPUBalanceContinuously(t *testing.T) {
 			newConnScores: []int{0, 0},
 		},
 		{
+			cpus:          [][]float64{{0.01}, {0.02}},
+			connCounts:    []int{100, 200},
+			connScores:    []int{100, 200},
+			newConnScores: []int{100, 200},
+		},
+		{
 			cpus:          [][]float64{{0.1, 0.1, 0.1, 0.1, 0.1}, {0.05, 0.07, 0.05, 0.04, 0.03}},
 			connCounts:    []int{200, 100},
 			connScores:    []int{200, 100},
@@ -127,6 +138,12 @@ func TestCPUBalanceContinuously(t *testing.T) {
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
 			newConnScores: []int{170, 130},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{0, 300},
+			newConnScores: []int{86, 214},
 		},
 		{
 			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {}},

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -3,13 +3,20 @@
 
 package factor
 
-import "github.com/pingcap/tiproxy/pkg/balance/policy"
+import (
+	"context"
+
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/balance/policy"
+)
 
 var _ policy.BackendCtx = (*mockBackend)(nil)
 
 type mockBackend struct {
-	healthy   bool
+	addr      string
 	connScore int
+	connCount int
+	healthy   bool
 }
 
 func newMockBackend(healthy bool, connScore int) *mockBackend {
@@ -25,6 +32,14 @@ func (mb *mockBackend) Healthy() bool {
 
 func (mb *mockBackend) ConnScore() int {
 	return mb.connScore
+}
+
+func (mb *mockBackend) Addr() string {
+	return mb.addr
+}
+
+func (mb *mockBackend) ConnCount() int {
+	return mb.connCount
 }
 
 var _ Factor = (*mockFactor)(nil)
@@ -49,4 +64,40 @@ func (mf *mockFactor) ScoreBitNum() int {
 
 func (mf *mockFactor) BalanceCount(from, to scoredBackend) int {
 	return mf.balanceCount
+}
+
+var _ metricsreader.MetricsReader = (*mockMetricsReader)(nil)
+
+type mockMetricsReader struct {
+	queryID uint64
+	qr      metricsreader.QueryResult
+}
+
+func newMockMetricsReader() *mockMetricsReader {
+	return &mockMetricsReader{}
+}
+
+func (mmr *mockMetricsReader) Start(ctx context.Context) {
+}
+
+func (mmr *mockMetricsReader) AddQueryExpr(queryExpr metricsreader.QueryExpr) uint64 {
+	mmr.queryID++
+	return mmr.queryID
+}
+
+func (mmr *mockMetricsReader) RemoveQueryExpr(id uint64) {
+}
+
+func (mmr *mockMetricsReader) GetQueryResult(id uint64) metricsreader.QueryResult {
+	return mmr.qr
+}
+
+func (mmr *mockMetricsReader) Subscribe(receiverName string) <-chan struct{} {
+	return nil
+}
+
+func (mmr *mockMetricsReader) Unsubscribe(receiverName string) {
+}
+
+func (mmr *mockMetricsReader) Close() {
 }

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -99,7 +99,7 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
 	}, nil, dmr.lg)
 }
 
-// Always refresh the prometheus Address just in case it changes.
+// Always refresh the prometheus address just in case it changes.
 func (dmr *DefaultMetricsReader) getPromAPI(ctx context.Context) (promv1.API, error) {
 	promInfo, err := dmr.promFetcher.GetPromInfo(ctx)
 	if promInfo == nil {

--- a/pkg/balance/metricsreader/query_result_test.go
+++ b/pkg/balance/metricsreader/query_result_test.go
@@ -1,0 +1,42 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMatrix(t *testing.T) {
+	tests := []struct {
+		jsonRes       string
+		expectedArray []model.SamplePair
+	}{
+		{
+			jsonRes:       `[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]`,
+			expectedArray: []model.SamplePair{{Timestamp: 1712742184054, Value: 229}, {Timestamp: 1712742199054, Value: 229}, {Timestamp: 1712742214054, Value: 229}, {Timestamp: 1712742229054, Value: 229}, {Timestamp: 1712742244054, Value: 229}},
+		},
+		{
+			jsonRes:       `[]`,
+			expectedArray: nil,
+		},
+	}
+
+	for _, test := range tests {
+		var m model.Matrix
+		require.NoError(t, json.Unmarshal([]byte(test.jsonRes), &m))
+		qr := QueryResult{
+			Value: m,
+		}
+		if len(test.expectedArray) == 0 {
+			require.Len(t, qr.Value.(model.Matrix), 0)
+			continue
+		}
+		pairs := qr.Value.(model.Matrix)[0].Values
+		require.Equal(t, test.expectedArray, pairs)
+	}
+}

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -12,6 +12,9 @@ type BalancePolicy interface {
 }
 
 type BackendCtx interface {
+	Addr() string
+	// ConnCount indicates the count of current connections.
+	ConnCount() int
 	// ConnScore = current connections + incoming connections - outgoing connections.
 	ConnScore() int
 	Healthy() bool

--- a/pkg/balance/policy/mock_test.go
+++ b/pkg/balance/policy/mock_test.go
@@ -24,3 +24,11 @@ func (mb *mockBackend) Healthy() bool {
 func (mb *mockBackend) ConnScore() int {
 	return mb.connScore
 }
+
+func (mb *mockBackend) ConnCount() int {
+	return mb.connScore
+}
+
+func (mb *mockBackend) Addr() string {
+	return ""
+}

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -52,7 +52,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	hc := observer.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	bo := observer.NewDefaultBackendObserver(logger.Named("observer"), healthCheckCfg, fetcher, hc)
 	bo.Start(context.Background())
-	rt.Init(context.Background(), bo, factor.NewFactorBasedBalance(logger.Named("factor")))
+	rt.Init(context.Background(), bo, factor.NewFactorBasedBalance(logger.Named("factor"), mgr.metricsReader))
 
 	return &Namespace{
 		name:   cfg.Namespace,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #519

Problem Summary:
Support CPU-based balance

What is changed and how it works:
- Add a new factor `FactorCPU` that scores backend by CPU usage
- `MetricsReader` doesn't update `QueryResult` if fetching metrics fails so that factors can reuse the old `QueryResult`
- Add some timeouts to existing tests

TODO:
This is not finished because I need some work to match the metric label with the backend address. It's not simple so I'll do it in another PR.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support CPU-based load balance
```
