### PR TITLE
proxy: reject connection after graceful wait

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -148,29 +148,23 @@ func (s *SQLServer) Run(ctx context.Context, cfgch <-chan *config.Config) {
 }
 
 func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
-	var tcpKeepAlive bool
-	var logger *zap.Logger
-	var connID uint64
-	var clientConn *client.ClientConnection
-	func() {
+	tcpKeepAlive, logger, connID, clientConn := func() (bool, *zap.Logger, uint64, *client.ClientConnection) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
 		conns := uint64(len(s.mu.clients))
 		maxConns := s.mu.maxConnections
-		tcpKeepAlive = s.mu.tcpKeepAlive
-
 		// 'maxConns == 0' => unlimited connections
 		if maxConns != 0 && conns >= maxConns {
 			s.logger.Warn("too many connections", zap.Uint64("max connections", maxConns), zap.String("client_addr", conn.RemoteAddr().Network()), zap.Error(conn.Close()))
-			return
+			return false, nil, 0, nil
 		}
 
-		connID = s.mu.connID
+		connID := s.mu.connID
 		s.mu.connID++
-		logger = s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()),
+		logger := s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()),
 			zap.String("addr", addr))
-		clientConn = client.NewClientConnection(logger.Named("conn"), conn, s.certMgr.ServerSQLTLS(), s.certMgr.SQLTLS(),
+		clientConn := client.NewClientConnection(logger.Named("conn"), conn, s.certMgr.ServerSQLTLS(), s.certMgr.SQLTLS(),
 			s.hsHandler, connID, addr, &backend.BCConfig{
 				ProxyProtocol:      s.mu.proxyProtocol,
 				RequireBackendTLS:  s.mu.requireBackendTLS,
@@ -180,7 +174,12 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
 			})
 		s.mu.clients[connID] = clientConn
 		logger.Debug("new connection", zap.Bool("proxy-protocol", s.mu.proxyProtocol), zap.Bool("require_backend_tls", s.mu.requireBackendTLS))
+		return s.mu.tcpKeepAlive, logger, connID, clientConn
 	}()
+
+	if clientConn == nil {
+		return
+	}
 
 	metrics.ConnGauge.Inc()
 	metrics.CreateConnCounter.Inc()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #524 

Problem Summary:
In https://github.com/pingcap/tiproxy/pull/400, I intended to accept connection during graceful wait so that client connections won't fail during tiproxy shutting down.
However, in https://github.com/pingcap/tiproxy/pull/443, I somehow broke that behavior when I was fixing a data race.

What is changed and how it works:
- Do not reject connections during graceful-wait-before-shutdown
- Defer unlocking just in case it panics and all other connections block

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Do not reject new connections until `graceful-wait-before-shutdown` finishes
```
