### PR TITLE
balance: match metric label with backend address

### DIFF
--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 )
 
@@ -40,6 +41,10 @@ func (mb *mockBackend) Addr() string {
 
 func (mb *mockBackend) ConnCount() int {
 	return mb.connCount
+}
+
+func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
+	return observer.BackendInfo{}
 }
 
 var _ Factor = (*mockFactor)(nil)

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -14,6 +14,7 @@ import (
 var _ policy.BackendCtx = (*mockBackend)(nil)
 
 type mockBackend struct {
+	observer.BackendInfo
 	addr      string
 	connScore int
 	connCount int
@@ -44,7 +45,7 @@ func (mb *mockBackend) ConnCount() int {
 }
 
 func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
-	return observer.BackendInfo{}
+	return mb.BackendInfo
 }
 
 var _ Factor = (*mockFactor)(nil)

--- a/pkg/balance/metricsreader/mock_test.go
+++ b/pkg/balance/metricsreader/mock_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/testkit"
 	"github.com/stretchr/testify/require"
@@ -78,4 +80,41 @@ func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 func (handler *mockHttpHandler) Close() {
 	require.NoError(handler.t, handler.server.Close())
 	handler.wg.Wait()
+}
+
+var _ policy.BackendCtx = (*mockBackend)(nil)
+
+type mockBackend struct {
+	observer.BackendInfo
+	addr string
+}
+
+func newMockBackend(addr string, ip string, port uint) *mockBackend {
+	return &mockBackend{
+		BackendInfo: observer.BackendInfo{
+			IP:         ip,
+			StatusPort: port,
+		},
+		addr: addr,
+	}
+}
+
+func (mb *mockBackend) Healthy() bool {
+	return false
+}
+
+func (mb *mockBackend) ConnScore() int {
+	return 0
+}
+
+func (mb *mockBackend) ConnCount() int {
+	return 0
+}
+
+func (mb *mockBackend) Addr() string {
+	return mb.addr
+}
+
+func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
+	return mb.BackendInfo
 }

--- a/pkg/balance/metricsreader/query_result_test.go
+++ b/pkg/balance/metricsreader/query_result_test.go
@@ -40,3 +40,67 @@ func TestParseMatrix(t *testing.T) {
 		require.Equal(t, test.expectedArray, pairs)
 	}
 }
+
+func TestMatchLabel(t *testing.T) {
+	tests := []struct {
+		jsonRes       string
+		addr          string
+		ip            string
+		port          uint
+		expectedPairs []model.SamplePair
+	}{
+		{
+			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			addr:          "10.10.11.1:4000",
+			ip:            "10.10.11.1",
+			port:          10080,
+			expectedPairs: []model.SamplePair{{Timestamp: 1712700000000, Value: 100}},
+		},
+		{
+			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			addr:          "10.10.11.1:4000",
+			ip:            "10.10.11.1",
+			port:          10082,
+			expectedPairs: nil,
+		},
+		{
+			jsonRes:       `[]`,
+			addr:          "10.10.11.1:4000",
+			ip:            "10.10.11.1",
+			port:          10080,
+			expectedPairs: nil,
+		},
+		{
+			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-0:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			addr:          "tidb-peer-0:4000",
+			ip:            "tidb-peer-0",
+			port:          10080,
+			expectedPairs: []model.SamplePair{{Timestamp: 1712700000000, Value: 100}},
+		},
+		{
+			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-0","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-1","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			addr:          "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
+			ip:            "tc-tidb-0.tc-tidb-peer.ns.svc",
+			port:          10080,
+			expectedPairs: []model.SamplePair{{Timestamp: 1712700000000, Value: 100}},
+		},
+		{
+			jsonRes:       `[]`,
+			addr:          "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
+			ip:            "tc-tidb-0.tc-tidb-peer.ns.svc",
+			port:          10080,
+			expectedPairs: nil,
+		},
+	}
+
+	for i, test := range tests {
+		var m model.Matrix
+		require.NoError(t, json.Unmarshal([]byte(test.jsonRes), &m))
+		qr := QueryResult{
+			Value: m,
+		}
+		backend := newMockBackend(test.addr, test.ip, test.port)
+		pairs := qr.GetMetric4Backend(backend)
+		require.Equal(t, test.expectedPairs, pairs, "test index %d", i)
+	}
+}

--- a/pkg/balance/observer/backend_health.go
+++ b/pkg/balance/observer/backend_health.go
@@ -6,6 +6,7 @@ package observer
 import "fmt"
 
 type BackendHealth struct {
+	BackendInfo
 	Healthy bool
 	// The error occurred when health check fails. It's used to log why the backend becomes unhealthy.
 	PingErr error

--- a/pkg/balance/observer/backend_observer.go
+++ b/pkg/balance/observer/backend_observer.go
@@ -115,9 +115,10 @@ func (bo *DefaultBackendObserver) checkHealth(ctx context.Context, backends map[
 	curBackendHealth := make(map[string]*BackendHealth, len(backends))
 	// Serverless tier checks health in Gateway instead of in TiProxy.
 	if !bo.healthCheckConfig.Enable {
-		for addr := range backends {
+		for addr, backend := range backends {
 			curBackendHealth[addr] = &BackendHealth{
-				Healthy: true,
+				BackendInfo: *backend,
+				Healthy:     true,
 			}
 		}
 		return curBackendHealth

--- a/pkg/balance/observer/health_check.go
+++ b/pkg/balance/observer/health_check.go
@@ -60,7 +60,8 @@ func NewDefaultHealthCheck(httpCli *http.Client, cfg *config.HealthCheck, logger
 
 func (dhc *DefaultHealthCheck) Check(ctx context.Context, addr string, info *BackendInfo) *BackendHealth {
 	bh := &BackendHealth{
-		Healthy: true,
+		BackendInfo: *info,
+		Healthy:     true,
 	}
 	if !dhc.cfg.Enable {
 		return bh

--- a/pkg/balance/observer/mock_test.go
+++ b/pkg/balance/observer/mock_test.go
@@ -86,6 +86,14 @@ func (mhc *mockHealthCheck) setBackend(addr string, health *BackendHealth) {
 	mhc.backends[addr] = health
 }
 
+func (mhc *mockHealthCheck) setHealth(addr string, healthy bool) {
+	mhc.Lock()
+	defer mhc.Unlock()
+	health := *mhc.backends[addr]
+	health.Healthy = healthy
+	mhc.backends[addr] = &health
+}
+
 func (mhc *mockHealthCheck) removeBackend(addr string) {
 	mhc.Lock()
 	defer mhc.Unlock()

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -3,7 +3,10 @@
 
 package policy
 
-import "go.uber.org/zap"
+import (
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	"go.uber.org/zap"
+)
 
 type BalancePolicy interface {
 	Init()
@@ -18,4 +21,5 @@ type BackendCtx interface {
 	// ConnScore = current connections + incoming connections - outgoing connections.
 	ConnScore() int
 	Healthy() bool
+	GetBackendInfo() observer.BackendInfo
 }

--- a/pkg/balance/policy/mock_test.go
+++ b/pkg/balance/policy/mock_test.go
@@ -3,6 +3,8 @@
 
 package policy
 
+import "github.com/pingcap/tiproxy/pkg/balance/observer"
+
 var _ BackendCtx = (*mockBackend)(nil)
 
 type mockBackend struct {
@@ -31,4 +33,8 @@ func (mb *mockBackend) ConnCount() int {
 
 func (mb *mockBackend) Addr() string {
 	return ""
+}
+
+func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
+	return observer.BackendInfo{}
 }

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -131,6 +131,13 @@ func (b *backendWrapper) ConnCount() int {
 	return b.connList.Len()
 }
 
+func (b *backendWrapper) GetBackendInfo() observer.BackendInfo {
+	b.mu.RLock()
+	info := b.mu.BackendInfo
+	b.mu.RUnlock()
+	return info
+}
+
 func (b *backendWrapper) Equals(health observer.BackendHealth) bool {
 	b.mu.RLock()
 	equal := b.mu.BackendHealth.Equals(health)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #527 

Problem Summary:
To get the metric for each backend, we need to match the backend label in metrics with the backend address in etcd.

What is changed and how it works:
- Add `BackendInfo` to struct `BackendHealth` so that factors can get the IP and status port from `BackendCtx`
- Match the metric label with `BackendCtx`, considering both TiUP and Operator deployment

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
