### PR TITLE
infosync:define TiDBTopologyInfo to replace TopologyInfo in tidb/domain/infosync

### DIFF
--- a/pkg/balance/observer/backend_fetcher.go
+++ b/pkg/balance/observer/backend_fetcher.go
@@ -51,7 +51,7 @@ func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInf
 			continue
 		}
 		// If topology is empty, maybe the backend is not ready yet.
-		if backend.TopologyInfo == nil {
+		if backend.TiDBTopologyInfo == nil {
 			continue
 		}
 		infos[addr] = &BackendInfo{

--- a/pkg/balance/observer/backend_fetcher_test.go
+++ b/pkg/balance/observer/backend_fetcher_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	tidbinfo "github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/stretchr/testify/require"
@@ -37,7 +36,7 @@ func TestPDFetcher(t *testing.T) {
 		{
 			infos: map[string]*infosync.TiDBInfo{
 				"1.1.1.1:4000": {
-					TopologyInfo: &tidbinfo.TopologyInfo{
+					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
 						IP:         "1.1.1.1",
 						StatusPort: 10080,
 					},
@@ -51,7 +50,7 @@ func TestPDFetcher(t *testing.T) {
 			infos: map[string]*infosync.TiDBInfo{
 				"1.1.1.1:4000": {
 					TTL: "123456789",
-					TopologyInfo: &tidbinfo.TopologyInfo{
+					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
 						IP:         "1.1.1.1",
 						StatusPort: 10080,
 					},
@@ -68,14 +67,14 @@ func TestPDFetcher(t *testing.T) {
 			infos: map[string]*infosync.TiDBInfo{
 				"1.1.1.1:4000": {
 					TTL: "123456789",
-					TopologyInfo: &tidbinfo.TopologyInfo{
+					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
 						IP:         "1.1.1.1",
 						StatusPort: 10080,
 					},
 				},
 				"2.2.2.2:4000": {
 					TTL: "123456789",
-					TopologyInfo: &tidbinfo.TopologyInfo{
+					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
 						IP:         "2.2.2.2",
 						StatusPort: 10080,
 					},

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	tidbinfo "github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/sys"
@@ -119,13 +118,13 @@ func TestFetchTiDBTopology(t *testing.T) {
 			check: func(info map[string]*TiDBInfo) {
 				require.Len(ts.t, info, 1)
 				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
-				require.Nil(ts.t, info["1.1.1.1:4000"].TopologyInfo)
+				require.Nil(ts.t, info["1.1.1.1:4000"].TiDBTopologyInfo)
 			},
 		},
 		{
 			// Then update info.
 			update: func() {
-				ts.updateInfo("1.1.1.1:4000", &tidbinfo.TopologyInfo{
+				ts.updateInfo("1.1.1.1:4000", &TiDBTopologyInfo{
 					IP:         "1.1.1.1",
 					StatusPort: 10080,
 				})
@@ -133,7 +132,7 @@ func TestFetchTiDBTopology(t *testing.T) {
 			check: func(info map[string]*TiDBInfo) {
 				require.Len(ts.t, info, 1)
 				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
-				require.NotNil(ts.t, info["1.1.1.1:4000"].TopologyInfo)
+				require.NotNil(ts.t, info["1.1.1.1:4000"].TiDBTopologyInfo)
 				require.Equal(ts.t, "1.1.1.1", info["1.1.1.1:4000"].IP)
 				require.Equal(ts.t, uint(10080), info["1.1.1.1:4000"].StatusPort)
 			},
@@ -142,7 +141,7 @@ func TestFetchTiDBTopology(t *testing.T) {
 			// Add another backend.
 			update: func() {
 				ts.updateTTL("2.2.2.2:4000", []byte("123456789"))
-				ts.updateInfo("2.2.2.2:4000", &tidbinfo.TopologyInfo{
+				ts.updateInfo("2.2.2.2:4000", &TiDBTopologyInfo{
 					IP:         "2.2.2.2",
 					StatusPort: 10080,
 				})
@@ -150,7 +149,7 @@ func TestFetchTiDBTopology(t *testing.T) {
 			check: func(info map[string]*TiDBInfo) {
 				require.Len(ts.t, info, 2)
 				require.Equal(ts.t, "123456789", info["2.2.2.2:4000"].TTL)
-				require.NotNil(ts.t, info["2.2.2.2:4000"].TopologyInfo)
+				require.NotNil(ts.t, info["2.2.2.2:4000"].TiDBTopologyInfo)
 				require.Equal(ts.t, "2.2.2.2", info["2.2.2.2:4000"].IP)
 				require.Equal(ts.t, uint(10080), info["2.2.2.2:4000"].StatusPort)
 			},
@@ -163,7 +162,7 @@ func TestFetchTiDBTopology(t *testing.T) {
 			check: func(info map[string]*TiDBInfo) {
 				require.Len(ts.t, info, 2)
 				require.Empty(ts.t, info["2.2.2.2:4000"].TTL)
-				require.NotNil(ts.t, info["2.2.2.2:4000"].TopologyInfo)
+				require.NotNil(ts.t, info["2.2.2.2:4000"].TiDBTopologyInfo)
 			},
 		},
 	}
@@ -365,20 +364,20 @@ func (ts *etcdTestSuite) getTTLAndInfo(prefix string) (string, string) {
 
 // Update the TTL for a backend.
 func (ts *etcdTestSuite) updateTTL(addr string, ttl []byte) {
-	_, err := ts.kv.Put(context.Background(), path.Join(tidbinfo.TopologyInformationPath, addr, ttlSuffix), string(ttl))
+	_, err := ts.kv.Put(context.Background(), path.Join(tidbTopologyInformationPath, addr, ttlSuffix), string(ttl))
 	require.NoError(ts.t, err)
 }
 
 func (ts *etcdTestSuite) deleteTTL(addr string) {
-	_, err := ts.kv.Delete(context.Background(), path.Join(tidbinfo.TopologyInformationPath, addr, ttlSuffix))
+	_, err := ts.kv.Delete(context.Background(), path.Join(tidbTopologyInformationPath, addr, ttlSuffix))
 	require.NoError(ts.t, err)
 }
 
 // Update the TopologyInfo for a backend.
-func (ts *etcdTestSuite) updateInfo(sqlAddr string, info *tidbinfo.TopologyInfo) {
+func (ts *etcdTestSuite) updateInfo(sqlAddr string, info *TiDBTopologyInfo) {
 	data, err := json.Marshal(info)
 	require.NoError(ts.t, err)
-	_, err = ts.kv.Put(context.Background(), path.Join(tidbinfo.TopologyInformationPath, sqlAddr, infoSuffix), string(data))
+	_, err = ts.kv.Put(context.Background(), path.Join(tidbTopologyInformationPath, sqlAddr, infoSuffix), string(data))
 	require.NoError(ts.t, err)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
 remove import "tidb/domain/infosyncin" in  infosync package.
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #523 

Problem Summary:

What is changed and how it works:
define TiDBTopologyInfo to replace TopologyInfo in tidb/domain/infosync

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
