### PR TITLE
metricsreader, factor: fix wrong PromQL expression

### DIFF
--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -40,7 +40,7 @@ func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsReader) *Fact
 func (fbb *FactorBasedBalance) Init() {
 	fbb.factors = []Factor{
 		NewFactorHealth(),
-		NewFactorCPU(fbb.mr, fbb.lg),
+		NewFactorCPU(fbb.mr),
 		NewFactorConnCount(),
 	}
 	err := fbb.updateBitNum()

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -40,7 +40,7 @@ func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsReader) *Fact
 func (fbb *FactorBasedBalance) Init() {
 	fbb.factors = []Factor{
 		NewFactorHealth(),
-		// NewFactorCPU(fbb.mr),
+		NewFactorCPU(fbb.mr, fbb.lg),
 		NewFactorConnCount(),
 	}
 	err := fbb.updateBitNum()

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/util/monotime"
 	"github.com/prometheus/common/model"
+	"go.uber.org/zap"
 )
 
 const (
@@ -50,14 +51,16 @@ type FactorCPU struct {
 	mr           metricsreader.MetricsReader
 	queryID      uint64
 	bitNum       int
+	lg           *zap.Logger
 }
 
-func NewFactorCPU(mr metricsreader.MetricsReader) *FactorCPU {
+func NewFactorCPU(mr metricsreader.MetricsReader, lg *zap.Logger) *FactorCPU {
 	return &FactorCPU{
 		mr:       mr,
 		queryID:  mr.AddQueryExpr(cpuQueryExpr),
 		bitNum:   5,
 		snapshot: make(map[string]backendSnapshot),
+		lg:       lg,
 	}
 }
 
@@ -66,6 +69,9 @@ func (fc *FactorCPU) Name() string {
 }
 
 func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
+	for _, backend := range backends {
+		fc.lg.Info(backend.Addr(), zap.String("IP", backend.GetBackendInfo().IP), zap.Uint("status port", backend.GetBackendInfo().StatusPort))
+	}
 	if len(backends) <= 1 {
 		return
 	}
@@ -73,7 +79,7 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 	if qr.Err != nil || qr.Empty() {
 		return
 	}
-
+	fc.lg.Info("query result", zap.Any("result", qr))
 	if qr.UpdateTime != fc.lastMetricTime {
 		// Metrics have updated.
 		fc.lastMetricTime = qr.UpdateTime
@@ -106,6 +112,9 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 			avgUsage = 1
 		}
 		backends[i].addScore(int(avgUsage*100)/cpuScoreStep, fc.bitNum)
+	}
+	for addr, snapshot := range fc.snapshot {
+		fc.lg.Info("snapshot", zap.String("addr", addr), zap.Any("usage", snapshot.avgUsage))
 	}
 }
 

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -28,7 +28,7 @@ var _ Factor = (*FactorCPU)(nil)
 
 var (
 	cpuQueryExpr = metricsreader.QueryExpr{
-		PromQL:   `rate(process_cpu_seconds_total/tidb_server_maxprocs{%s="tidb"}[15s])`,
+		PromQL:   `rate(process_cpu_seconds_total{%s="tidb"}[30s])/tidb_server_maxprocs`,
 		HasLabel: true,
 		Range:    3 * time.Minute,
 	}

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -73,6 +73,7 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 	if qr.Err != nil || qr.Empty() {
 		return
 	}
+
 	if qr.UpdateTime != fc.lastMetricTime {
 		// Metrics have updated.
 		fc.lastMetricTime = qr.UpdateTime

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -82,7 +82,7 @@ func TestCPUBalanceOnce(t *testing.T) {
 				Value:      model.Matrix(values),
 			},
 		}
-		fc := NewFactorCPU(mmr, nil)
+		fc := NewFactorCPU(mmr)
 		updateScore(fc, backends)
 		sortedIdx := make([]int, 0, len(test.cpus))
 		for _, backend := range backends {
@@ -173,7 +173,7 @@ func TestCPUBalanceContinuously(t *testing.T) {
 	}
 
 	mmr := newMockMetricsReader()
-	fc := NewFactorCPU(mmr, nil)
+	fc := NewFactorCPU(mmr)
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
 		values := make([]*model.SampleStream, 0, len(test.cpus))
@@ -227,7 +227,7 @@ func TestNoCPUMetric(t *testing.T) {
 	}
 
 	mmr := newMockMetricsReader()
-	fc := NewFactorCPU(mmr, nil)
+	fc := NewFactorCPU(mmr)
 	backends := make([]scoredBackend, 0, 2)
 	for i := 0; i < 2; i++ {
 		backends = append(backends, createBackend(i, i*100, i*100))

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -82,7 +82,7 @@ func TestCPUBalanceOnce(t *testing.T) {
 				Value:      model.Matrix(values),
 			},
 		}
-		fc := NewFactorCPU(mmr)
+		fc := NewFactorCPU(mmr, nil)
 		updateScore(fc, backends)
 		sortedIdx := make([]int, 0, len(test.cpus))
 		for _, backend := range backends {
@@ -173,7 +173,7 @@ func TestCPUBalanceContinuously(t *testing.T) {
 	}
 
 	mmr := newMockMetricsReader()
-	fc := NewFactorCPU(mmr)
+	fc := NewFactorCPU(mmr, nil)
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
 		values := make([]*model.SampleStream, 0, len(test.cpus))
@@ -227,7 +227,7 @@ func TestNoCPUMetric(t *testing.T) {
 	}
 
 	mmr := newMockMetricsReader()
-	fc := NewFactorCPU(mmr)
+	fc := NewFactorCPU(mmr, nil)
 	backends := make([]scoredBackend, 0, 2)
 	for i := 0; i < 2; i++ {
 		backends = append(backends, createBackend(i, i*100, i*100))

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -147,8 +147,10 @@ func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) (map[uint64]Qu
 	dmr.Unlock()
 	results := make(map[uint64]QueryResult, len(copyedMap))
 	now := time.Now()
+	dmr.lg.Info("begin read exprs", zap.Any("exprs", copyedMap))
 	for id, expr := range copyedMap {
 		qr := dmr.queryMetric(ctx, promQLAPI, expr, now)
+		dmr.lg.Info("read expr", zap.Any("expr", expr), zap.Any("result", qr))
 		// Only update the result when it succeeds.
 		if qr.Err == nil {
 			qr.UpdateTime = monotime.Now()

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -189,6 +189,7 @@ func (dmr *DefaultMetricsReader) queryOnce(ctx context.Context, promQLAPI promv1
 	qr.Err = backoff.Retry(func() error {
 		var err error
 		qr.Value, _, err = promQLAPI.QueryRange(childCtx, promQL, promRange)
+		dmr.lg.Info("begin query", zap.String("query", promQL), zap.Any("range", promRange), zap.Error(err))
 		if !pnet.IsRetryableError(err) {
 			return backoff.Permanent(errors.WithStack(err))
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #530

Problem Summary:
The PromQL to query CPU is wrong and it's hard to find the reason.

What is changed and how it works:
- Fix the PromQL
- Add logs to troubleshoot
- Update retry interval

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Add E2E tests in endless and CPU-based balance works.
![image](https://github.com/pingcap/tiproxy/assets/29590578/d78ef777-36a3-4f5c-854e-7eb8ce6c850f)
![image](https://github.com/pingcap/tiproxy/assets/29590578/bcb234e6-6815-4b8c-8d39-0c1edeae0984)

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
