### PR TITLE
factor: support location-based balance

### DIFF
--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -41,10 +41,11 @@ func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsReader) *Fact
 func (fbb *FactorBasedBalance) Init(cfg *config.Config) {
 	fbb.factors = []Factor{
 		NewFactorHealth(),
+		NewFactorLabel(),
 		NewFactorError(fbb.mr),
 		NewFactorMemory(fbb.mr),
 		NewFactorCPU(fbb.mr),
-		NewFactorLabel(),
+		NewFactorLocation(),
 		NewFactorConnCount(),
 	}
 	err := fbb.updateBitNum()

--- a/pkg/balance/factor/factor_location.go
+++ b/pkg/balance/factor/factor_location.go
@@ -1,0 +1,60 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package factor
+
+import "github.com/pingcap/tiproxy/lib/config"
+
+const (
+	// locationLabelName indicates the label name that location-based balance should be based on.
+	// We use `zone` because the follower read in TiDB also uses `zone` to decide location.
+	locationLabelName = "zone"
+	// balanceCount4Location indicates how many connections to balance in each round.
+	balanceCount4Location = 1
+)
+
+var _ Factor = (*FactorLabel)(nil)
+
+type FactorLocation struct {
+	// The location of this tiproxy instance.
+	selfLocation string
+	bitNum       int
+}
+
+func NewFactorLocation() *FactorLocation {
+	return &FactorLocation{
+		bitNum: 1,
+	}
+}
+
+func (fl *FactorLocation) Name() string {
+	return "location"
+}
+
+func (fl *FactorLocation) UpdateScore(backends []scoredBackend) {
+	if len(fl.selfLocation) == 0 || len(backends) <= 1 {
+		return
+	}
+	for i := 0; i < len(backends); i++ {
+		score := 1
+		backendLabels := backends[i].GetBackendInfo().Labels
+		if backendLabels != nil && backendLabels[locationLabelName] == fl.selfLocation {
+			score = 0
+		}
+		backends[i].addScore(score, fl.bitNum)
+	}
+}
+
+func (fl *FactorLocation) ScoreBitNum() int {
+	return fl.bitNum
+}
+
+func (fl *FactorLocation) BalanceCount(from, to scoredBackend) int {
+	return balanceCount4Location
+}
+
+func (fl *FactorLocation) SetConfig(cfg *config.Config) {
+	if cfg.Labels != nil {
+		fl.selfLocation = cfg.Labels[locationLabelName]
+	}
+}

--- a/pkg/balance/factor/factor_location_test.go
+++ b/pkg/balance/factor/factor_location_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package factor
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFactorLocationOneBackend(t *testing.T) {
+	tests := []struct {
+		selfLocation    string
+		backendLocation string
+		expectedScore   uint64
+	}{
+		{},
+		{
+			selfLocation:  "az1",
+			expectedScore: 1,
+		},
+		{
+			backendLocation: "az1",
+		},
+		{
+			selfLocation:    "az1",
+			backendLocation: "az2",
+			expectedScore:   1,
+		},
+		{
+			selfLocation:    "az1",
+			backendLocation: "az1",
+		},
+	}
+
+	factor := NewFactorLocation()
+	for i, test := range tests {
+		var backendLabels map[string]string
+		if test.backendLocation != "" {
+			backendLabels = map[string]string{
+				locationLabelName: test.backendLocation,
+			}
+		}
+		backendCtx := &mockBackend{
+			BackendInfo: observer.BackendInfo{Labels: backendLabels},
+		}
+		// Create 2 backends so that UpdateScore won't skip calculating scores.
+		backends := []scoredBackend{
+			{
+				BackendCtx: backendCtx,
+			},
+			{
+				BackendCtx: backendCtx,
+			},
+		}
+		var selfLabels map[string]string
+		if test.selfLocation != "" {
+			selfLabels = map[string]string{
+				locationLabelName: test.selfLocation,
+			}
+		}
+		factor.SetConfig(&config.Config{
+			Labels: selfLabels,
+		})
+		factor.UpdateScore(backends)
+		for _, backend := range backends {
+			require.Equal(t, test.expectedScore, backend.score(), "test idx: %d", i)
+		}
+	}
+}
+
+func TestFactorLocationMultiBackends(t *testing.T) {
+	tests := []struct {
+		labels        map[string]string
+		expectedScore uint64
+	}{
+		{
+			expectedScore: 1,
+		},
+		{
+			labels: map[string]string{
+				locationLabelName: "az1",
+			},
+			expectedScore: 0,
+		},
+		{
+			labels: map[string]string{
+				"z": "az1",
+			},
+			expectedScore: 1,
+		},
+		{
+			labels: map[string]string{
+				locationLabelName: "az2",
+				"z":               "az1",
+			},
+			expectedScore: 1,
+		},
+		{
+			labels: map[string]string{
+				locationLabelName: "az1",
+				"z":               "az2",
+			},
+			expectedScore: 0,
+		},
+	}
+	backends := make([]scoredBackend, 0, len(tests))
+	for _, test := range tests {
+		backend := scoredBackend{
+			BackendCtx: &mockBackend{
+				BackendInfo: observer.BackendInfo{Labels: test.labels},
+			},
+		}
+		backends = append(backends, backend)
+	}
+	factor := NewFactorLocation()
+	factor.SetConfig(&config.Config{
+		Labels: map[string]string{locationLabelName: "az1"},
+	})
+	factor.UpdateScore(backends)
+	for i, test := range tests {
+		require.Equal(t, test.expectedScore, backends[i].score(), "test idx: %d", i)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #545

Problem Summary:
I planned to use the label-based balance to implement the location-based balance, but I found 2 things:
- TiDB follower read uses a predefined label `zone` to decide the location, and TiDB-operator only sets TiDB/TiProxy labels that are in `replication.location-labels` in PD.
- To be compatible with the Elastic Group on TiDBCloud, we need both label-based and location-based balance. The priority of label-based balance should be the highest.

Thus, I plan to add another location-based balance and it is based on a predefined label `zone`.

What is changed and how it works:
Add factor `FactorLocation` and it is based on a predefined label `zone`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support location-based balance
```
