### PR TITLE
factor: update migration speed

### DIFF
--- a/pkg/balance/factor/factor_conn.go
+++ b/pkg/balance/factor/factor_conn.go
@@ -10,7 +10,7 @@ const (
 	// If the ratio exceeds the threshold, we migrate connections.
 	connBalancedRatio = 1.2
 	// balanceCount4Conn indicates how many connections to balance in each round.
-	// This is not urgent, so migrate slowly.
+	// Always migrate 1 connection because we don't know the CPU usage here and we may migrate too many connections.
 	balanceCount4Conn = 1
 )
 

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -14,30 +14,30 @@ import (
 )
 
 const (
-	cpuEwmaAlpha = 0.5
 	// If some metrics are missing, we use the old one temporarily for no longer than cpuMetricExpDuration.
 	cpuMetricExpDuration = 2 * time.Minute
 	cpuScoreStep         = 5
 	// 0.001 represents for 0.1%
 	minCpuPerConn    = 0.001
-	cpuBalancedRatio = 1.3
-	balanceCount4Cpu = 1
+	cpuBalancedRatio = 1.2
+	// If the CPU difference of 2 backends is 30% and we're narrowing it to 20% in 30 seconds(rounds),
+	// then in each round, we migrate ((30% - 20%) / 2) / usagePerConn / 30 = 1 / usagePerConn / 600 connections.
+	balanceRatio4Cpu = 600
 )
 
 var _ Factor = (*FactorCPU)(nil)
 
 var (
 	cpuQueryExpr = metricsreader.QueryExpr{
-		PromQL:   `rate(process_cpu_seconds_total{%s="tidb"}[30s])/tidb_server_maxprocs`,
+		// The CPU usage is smoothed by rate[1m].
+		PromQL:   `rate(process_cpu_seconds_total{%s="tidb"}[1m])/tidb_server_maxprocs`,
 		HasLabel: true,
-		Range:    3 * time.Minute,
 	}
 )
 
 type cpuBackendSnapshot struct {
 	updatedTime monotime.Time
 	avgUsage    float64
-	latestUsage float64
 	connCount   int
 }
 
@@ -106,6 +106,9 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 		if avgUsage < 0 || avgUsage > 1 {
 			avgUsage = 1
 		}
+		if avgUsage < 0.1 {
+			avgUsage = 0
+		}
 		backends[i].addScore(int(avgUsage*100)/cpuScoreStep, fc.bitNum)
 	}
 }
@@ -117,13 +120,12 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 		valid := false
 		// If a backend exists in metrics but not in the backend list, ignore it for this round.
 		// The backend will be in the next round if it's healthy.
-		pairs := qr.GetSamplePair4Backend(backend)
-		if len(pairs) > 0 {
-			avgUsage, latestUsage := calcAvgUsage(pairs)
+		sample := qr.GetSample4Backend(backend)
+		if sample != nil {
+			avgUsage := calcAvgUsage(sample)
 			if avgUsage >= 0 {
 				snapshots[addr] = cpuBackendSnapshot{
 					avgUsage:    avgUsage,
-					latestUsage: latestUsage,
 					connCount:   backend.ConnCount(),
 					updatedTime: qr.UpdateTime,
 				}
@@ -142,28 +144,12 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 	fc.snapshot = snapshots
 }
 
-func calcAvgUsage(usageHistory []model.SamplePair) (avgUsage, latestUsage float64) {
-	avgUsage, latestUsage = -1, -1
-	if len(usageHistory) == 0 {
-		return
-	}
-	// The CPU usage jitters too much, so use the EWMA algorithm to make it smooth.
-	for _, usage := range usageHistory {
-		value := float64(usage.Value)
-		if math.IsNaN(value) {
-			continue
-		}
-		latestUsage = value
-		if avgUsage < 0 {
-			avgUsage = value
-		} else {
-			avgUsage = avgUsage*(1-cpuEwmaAlpha) + value*cpuEwmaAlpha
-		}
-	}
-	if avgUsage > 1 {
+func calcAvgUsage(sample *model.Sample) float64 {
+	avgUsage := float64(sample.Value)
+	if math.IsNaN(avgUsage) || avgUsage > 1 {
 		avgUsage = 1
 	}
-	return
+	return avgUsage
 }
 
 // Estimate the average CPU usage used by one connection.
@@ -173,8 +159,8 @@ func calcAvgUsage(usageHistory []model.SamplePair) (avgUsage, latestUsage float6
 func (fc *FactorCPU) updateCpuPerConn() {
 	totalUsage, totalConns := 0.0, 0
 	for _, backend := range fc.snapshot {
-		if backend.latestUsage > 0 && backend.connCount > 0 {
-			totalUsage += backend.latestUsage
+		if backend.avgUsage > 0 && backend.connCount > 0 {
+			totalUsage += backend.avgUsage
 			totalConns += backend.connCount
 		}
 	}
@@ -223,8 +209,11 @@ func (fc *FactorCPU) BalanceCount(from, to scoredBackend) int {
 	}
 	// The higher the CPU usage, the more sensitive the load balance should be.
 	// E.g. 10% vs 25% don't need rebalance, but 80% vs 95% need rebalance.
-	if 1.1-toUsage > (1.1-fromUsage)*cpuBalancedRatio {
-		return balanceCount4Cpu
+	if 1.3-toUsage > (1.3-fromUsage)*cpuBalancedRatio {
+		if balanceCount := int(1 / fc.usagePerConn / balanceRatio4Cpu); balanceCount > 1 {
+			return balanceCount
+		}
+		return 1
 	}
 	return 0
 }

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -106,9 +106,6 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 		if avgUsage < 0 || avgUsage > 1 {
 			avgUsage = 1
 		}
-		if avgUsage < 0.1 {
-			avgUsage = 0
-		}
 		backends[i].addScore(int(avgUsage*100)/cpuScoreStep, fc.bitNum)
 	}
 }

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -16,69 +16,69 @@ import (
 
 func TestCPUBalanceOnce(t *testing.T) {
 	tests := []struct {
-		cpus         [][]float64
+		cpus         []float64
 		scoreOrder   []int
 		balanceCount int
 	}{
 		{
-			cpus:         [][]float64{{0}, {0.2}},
+			cpus:         []float64{0, 0.2},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         [][]float64{{1, 0.5, 0.25, 0}, {0, 0.25, 0.5, 1}, {0, 0, 0, 0}, {1, 1, 1, 1}},
+			cpus:         []float64{0.25, 0.5, 0, 1},
 			scoreOrder:   []int{2, 0, 1, 3},
-			balanceCount: balanceCount4Cpu,
+			balanceCount: 1,
 		},
 		{
-			cpus:         [][]float64{{0.25}, {}, {0.5}},
+			cpus:         []float64{0.25, math.NaN(), 0.5},
 			scoreOrder:   []int{0, 2, 1},
-			balanceCount: balanceCount4Cpu,
+			balanceCount: 1,
 		},
 		{
-			cpus:         [][]float64{{0.95, 0.92, 0.93, 0.94, 0.92, 0.94}, {0.81, 0.79, 0.82, 0.83, 0.76, 0.78}},
+			cpus:         []float64{0.92, 0.76},
 			scoreOrder:   []int{1, 0},
-			balanceCount: balanceCount4Cpu,
+			balanceCount: 1,
 		},
 		{
-			cpus:         [][]float64{{0.35, 0.42, 0.37, 0.45, 0.42, 0.44}, {0.56, 0.62, 0.58, 0.57, 0.59, 0.63}},
+			cpus:         []float64{0.42, 0.59},
 			scoreOrder:   []int{0, 1},
-			balanceCount: balanceCount4Cpu,
+			balanceCount: 1,
 		},
 		{
-			cpus:         [][]float64{{0, 0.1, 0, 0.1}, {0.15, 0.1, 0.15, 0.1}, {0.1, 0, 0.1, 0}},
-			scoreOrder:   []int{2, 0, 1},
+			cpus:         []float64{0.1, 0.25},
+			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         [][]float64{{0.5}, {}, {0.1, 0.3, 0.5}},
-			scoreOrder:   []int{2, 0, 1},
-			balanceCount: balanceCount4Cpu,
+			cpus:         []float64{0.1, 0.35},
+			scoreOrder:   []int{0, 1},
+			balanceCount: 1,
 		},
 		{
-			cpus:         [][]float64{{1.0}, {0.97}},
-			scoreOrder:   []int{1, 0},
+			cpus:         []float64{0.95, math.NaN()},
+			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         [][]float64{{1.0}, {0.9}, {0.8}, {0.7}, {0.6}, {0.5}, {0.4}, {0.3}, {0.1}},
+			cpus:         []float64{1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.1},
 			scoreOrder:   []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
-			balanceCount: balanceCount4Cpu,
+			balanceCount: 1,
 		},
 	}
 
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
-		values := make([]*model.SampleStream, 0, len(test.cpus))
+		values := make([]*model.Sample, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
 			backends = append(backends, createBackend(j, 0, 0))
-			values = append(values, createSampleStream(test.cpus[j], j))
+			values = append(values, createSample(test.cpus[j], j))
 		}
 		mmr := &mockMetricsReader{
 			qrs: map[uint64]metricsreader.QueryResult{
 				1: {
 					UpdateTime: monotime.Now(),
-					Value:      model.Matrix(values),
+					Value:      model.Vector(values),
 				},
 			},
 		}
@@ -99,76 +99,64 @@ func TestCPUBalanceOnce(t *testing.T) {
 
 func TestCPUBalanceContinuously(t *testing.T) {
 	tests := []struct {
-		cpus          [][]float64
+		cpus          []float64
 		connCounts    []int
 		connScores    []int
 		newConnScores []int
 	}{
 		{
-			cpus:          [][]float64{{}, {}},
+			cpus:          []float64{math.NaN(), math.NaN()},
 			connCounts:    []int{0, 0},
 			connScores:    []int{0, 0},
 			newConnScores: []int{0, 0},
 		},
 		{
-			cpus:          [][]float64{{0.01}, {0.02}},
+			cpus:          []float64{0.01, 0.02},
 			connCounts:    []int{100, 200},
 			connScores:    []int{100, 200},
 			newConnScores: []int{100, 200},
 		},
 		{
-			cpus:          [][]float64{{0.1, 0.1, 0.1, 0.1, 0.1}, {0.05, 0.07, 0.05, 0.04, 0.03}},
+			cpus:          []float64{0.5, 0.2},
 			connCounts:    []int{200, 100},
 			connScores:    []int{200, 100},
-			newConnScores: []int{200, 100},
+			newConnScores: []int{172, 128},
 		},
 		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
-			connCounts:    []int{200, 100},
-			connScores:    []int{200, 100},
-			newConnScores: []int{170, 130},
-		},
-		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			cpus:          []float64{0.5, 0.2},
 			connCounts:    []int{170, 130},
 			connScores:    []int{170, 130},
-			newConnScores: []int{140, 160},
+			newConnScores: []int{142, 158},
 		},
 		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			cpus:          []float64{0.5, 0.2},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
-			newConnScores: []int{170, 130},
+			newConnScores: []int{172, 128},
 		},
 		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			cpus:          []float64{0.5, 0.2},
 			connCounts:    []int{200, 100},
 			connScores:    []int{0, 300},
-			newConnScores: []int{86, 214},
+			newConnScores: []int{99, 201},
 		},
 		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {}},
+			cpus:          []float64{0.5, math.NaN()},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
-			newConnScores: []int{170, 130},
+			newConnScores: []int{241, 59},
 		},
 		{
-			cpus:          [][]float64{{}, {}},
+			cpus:          []float64{math.NaN(), 0.2},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
-			newConnScores: []int{170, 130},
+			newConnScores: []int{115, 185},
 		},
 		{
-			cpus:          [][]float64{{}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			cpus:          []float64{0.5, 0.2},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
-			newConnScores: []int{170, 130},
-		},
-		{
-			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
-			connCounts:    []int{200, 100},
-			connScores:    []int{180, 120},
-			newConnScores: []int{170, 130},
+			newConnScores: []int{172, 128},
 		},
 	}
 
@@ -176,14 +164,14 @@ func TestCPUBalanceContinuously(t *testing.T) {
 	fc := NewFactorCPU(mmr)
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
-		values := make([]*model.SampleStream, 0, len(test.cpus))
+		values := make([]*model.Sample, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
 			backends = append(backends, createBackend(j, test.connCounts[j], test.connScores[j]))
-			values = append(values, createSampleStream(test.cpus[j], j))
+			values = append(values, createSample(test.cpus[j], j))
 		}
 		mmr.qrs[1] = metricsreader.QueryResult{
 			UpdateTime: monotime.Now(),
-			Value:      model.Matrix(values),
+			Value:      model.Vector(values),
 		}
 		// Rebalance until it stops. The final scores should be newConnScores.
 		for k := 0; ; k++ {
@@ -210,18 +198,18 @@ func TestCPUBalanceContinuously(t *testing.T) {
 
 func TestNoCPUMetric(t *testing.T) {
 	tests := []struct {
-		cpus       [][]float64
+		cpus       []float64
 		updateTime monotime.Time
 	}{
 		{
 			cpus: nil,
 		},
 		{
-			cpus:       [][]float64{{1.0}, {0.0}},
+			cpus:       []float64{1.0, 0.0},
 			updateTime: monotime.Now().Sub(cpuMetricExpDuration * 2),
 		},
 		{
-			cpus:       [][]float64{{math.NaN()}, {math.NaN()}},
+			cpus:       []float64{math.NaN(), math.NaN()},
 			updateTime: monotime.Now(),
 		},
 	}
@@ -233,13 +221,13 @@ func TestNoCPUMetric(t *testing.T) {
 		backends = append(backends, createBackend(i, i*100, i*100))
 	}
 	for i, test := range tests {
-		values := make([]*model.SampleStream, 0, len(test.cpus))
+		values := make([]*model.Sample, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
-			values = append(values, createSampleStream(test.cpus[j], j))
+			values = append(values, createSample(test.cpus[j], j))
 		}
 		mmr.qrs[1] = metricsreader.QueryResult{
 			UpdateTime: test.updateTime,
-			Value:      model.Matrix(values),
+			Value:      model.Vector(values),
 		}
 		updateScore(fc, backends)
 		require.Equal(t, backends[0].score(), backends[1].score(), "test index %d", i)

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -17,53 +17,69 @@ import (
 func TestCPUBalanceOnce(t *testing.T) {
 	tests := []struct {
 		cpus         []float64
+		connCounts   []int
 		scoreOrder   []int
 		balanceCount int
 	}{
 		{
 			cpus:         []float64{0, 0.2},
+			connCounts:   []int{0, 0},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
 			cpus:         []float64{0.25, 0.5, 0, 1},
+			connCounts:   []int{10, 10, 10, 10},
 			scoreOrder:   []int{2, 0, 1, 3},
 			balanceCount: 1,
 		},
 		{
 			cpus:         []float64{0.25, math.NaN(), 0.5},
+			connCounts:   []int{10, 10, 10},
 			scoreOrder:   []int{0, 2, 1},
 			balanceCount: 1,
 		},
 		{
 			cpus:         []float64{0.92, 0.76},
+			connCounts:   []int{10, 10},
 			scoreOrder:   []int{1, 0},
 			balanceCount: 1,
 		},
 		{
 			cpus:         []float64{0.42, 0.59},
+			connCounts:   []int{10, 10},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 1,
 		},
 		{
 			cpus:         []float64{0.1, 0.25},
+			connCounts:   []int{0, 0},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
 			cpus:         []float64{0.1, 0.35},
+			connCounts:   []int{10, 10},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 1,
 		},
 		{
 			cpus:         []float64{0.95, math.NaN()},
+			connCounts:   []int{0, 0},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
 			cpus:         []float64{1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.1},
+			connCounts:   []int{0, 0, 0, 0, 0, 0, 0, 0, 0},
 			scoreOrder:   []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
 			balanceCount: 1,
+		},
+		{
+			cpus:         []float64{0.4, 0.8},
+			connCounts:   []int{2000, 4000},
+			scoreOrder:   []int{0, 1},
+			balanceCount: 8,
 		},
 	}
 
@@ -71,7 +87,7 @@ func TestCPUBalanceOnce(t *testing.T) {
 		backends := make([]scoredBackend, 0, len(test.cpus))
 		values := make([]*model.Sample, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
-			backends = append(backends, createBackend(j, 0, 0))
+			backends = append(backends, createBackend(j, test.connCounts[j], test.connCounts[j]))
 			values = append(values, createSample(test.cpus[j], j))
 		}
 		mmr := &mockMetricsReader{

--- a/pkg/balance/factor/factor_error.go
+++ b/pkg/balance/factor/factor_error.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	errMetricExpDuration = 1 * time.Minute
-	balanceCount4Err     = 10
+	balanceCount4Err     = 1000
 )
 
 type valueRange int

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -8,7 +8,7 @@ import "github.com/pingcap/tiproxy/lib/config"
 const (
 	// balanceCount4Health indicates how many connections to balance in each round.
 	// If some backends are unhealthy, migrate fast but do not put too much pressure on TiDB.
-	balanceCount4Health = 10
+	balanceCount4Health = 1000
 )
 
 var _ Factor = (*FactorHealth)(nil)

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -17,7 +17,7 @@ const (
 	// If some metrics are missing, we use the old one temporarily for no longer than memMetricExpDuration.
 	memMetricExpDuration = 1 * time.Minute
 	// balanceCount4Mem indicates how many connections to balance in each round.
-	balanceCount4Mem = 10
+	balanceCount4Mem = 1000
 )
 
 var _ Factor = (*FactorCPU)(nil)

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -136,12 +136,12 @@ func createBackend(backendIdx, connCount, connScore int) scoredBackend {
 	}
 }
 
-func createSampleStream(cpus []float64, backendIdx int) *model.SampleStream {
+func createSampleStream(values []float64, backendIdx int) *model.SampleStream {
 	host := strconv.Itoa(backendIdx)
 	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(host + ":10080")}
-	pairs := make([]model.SamplePair, 0, len(cpus))
-	for i, cpu := range cpus {
-		ts := model.Time(time.Now().UnixMilli() - int64(15000*(len(cpus)-i)))
+	pairs := make([]model.SamplePair, 0, len(values))
+	for i, cpu := range values {
+		ts := model.Time(time.Now().UnixMilli() - int64(15000*(len(values)-i)))
 		pairs = append(pairs, model.SamplePair{Timestamp: ts, Value: model.SampleValue(cpu)})
 	}
 	return &model.SampleStream{Metric: labelSet, Values: pairs}

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -161,7 +161,7 @@ func (tester *routerTester) closeConnections(num int, redirecting bool) {
 
 func (tester *routerTester) rebalance(num int) {
 	for i := 0; i < num; i++ {
-		tester.router.rebalance()
+		tester.router.rebalance(context.Background())
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #547 

Problem Summary:
Currently the migration speed has some problems:
- For CPU-based balance, 1 connection per second may be too low if there are many connections
- For health, memory, and error based balance, 10 connections per second is too low.

What is changed and how it works:
- For CPU-based balance, the migration speed depends on the overall connection count.
- For health, memory, and error based balance, change it to 1000 connections per second and add a sleep between migrations.
- For CPU-based balance, use `rate[1m]` instead of EMWA algorithm to make it simpler.
- Update some constants.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
