### PR TITLE
router, factor: fix the speed control of session migration

### DIFF
--- a/pkg/balance/factor/factor.go
+++ b/pkg/balance/factor/factor.go
@@ -12,8 +12,8 @@ type Factor interface {
 	UpdateScore(backends []scoredBackend)
 	// ScoreBitNum returns the bit number of the score.
 	ScoreBitNum() int
-	// BalanceCount returns the count of connections to balance in this round.
-	// 0 indicates balanced (within the threshold) or the migration speed is limited.
+	// BalanceCount returns the count of connections to balance per second.
+	// 0 indicates the factor is already balanced.
 	BalanceCount(from, to scoredBackend) int
 	SetConfig(cfg *config.Config)
 }

--- a/pkg/balance/factor/factor_conn.go
+++ b/pkg/balance/factor/factor_conn.go
@@ -9,8 +9,8 @@ const (
 	// connBalancedRatio is the threshold of ratio of the most connection count and least count.
 	// If the ratio exceeds the threshold, we migrate connections.
 	connBalancedRatio = 1.2
-	// balanceCount4Conn indicates how many connections to balance in each round.
-	// Always migrate 1 connection because we don't know the CPU usage here and we may migrate too many connections.
+	// balanceCount4Conn indicates how many connections to balance per second.
+	// Migrate slowly because we don't know the CPU usage here and we may migrate too many connections.
 	balanceCount4Conn = 1
 )
 

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -20,7 +20,7 @@ const (
 	// 0.001 represents for 0.1%
 	minCpuPerConn    = 0.001
 	cpuBalancedRatio = 1.2
-	// If the CPU difference of 2 backends is 30% and we're narrowing it to 20% in 30 seconds(rounds),
+	// If the CPU difference of 2 backends is 30% and we're narrowing it to 20% in 30 seconds,
 	// then in each round, we migrate ((30% - 20%) / 2) / usagePerConn / 30 = 1 / usagePerConn / 600 connections.
 	balanceRatio4Cpu = 600
 )

--- a/pkg/balance/factor/factor_label.go
+++ b/pkg/balance/factor/factor_label.go
@@ -6,7 +6,7 @@ package factor
 import "github.com/pingcap/tiproxy/lib/config"
 
 const (
-	// balanceCount4Label indicates how many connections to balance in each round.
+	// balanceCount4Label indicates how many connections to balance per second.
 	balanceCount4Label = 1
 )
 

--- a/pkg/balance/factor/factor_location.go
+++ b/pkg/balance/factor/factor_location.go
@@ -9,7 +9,7 @@ const (
 	// locationLabelName indicates the label name that location-based balance should be based on.
 	// We use `zone` because the follower read in TiDB also uses `zone` to decide location.
 	locationLabelName = "zone"
-	// balanceCount4Location indicates how many connections to balance in each round.
+	// balanceCount4Location indicates how many connections to balance per second.
 	balanceCount4Location = 1
 )
 

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -12,6 +12,7 @@ import (
 type BalancePolicy interface {
 	Init(cfg *config.Config)
 	BackendToRoute(backends []BackendCtx) BackendCtx
+	// balanceCount is the count of connections to balance per second.
 	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason []zap.Field)
 	SetConfig(cfg *config.Config)
 }

--- a/pkg/balance/policy/simple_policy.go
+++ b/pkg/balance/policy/simple_policy.go
@@ -14,9 +14,9 @@ const (
 	// ConnBalancedRatio is the threshold of ratio of the most connection count and least count.
 	// If the ratio exceeds the threshold, we migrate connections.
 	ConnBalancedRatio = 1.2
-	// BalanceCount4Health indicates how many connections to balance in each round.
+	// BalanceCount4Health indicates how many connections to balance per second.
 	// If some backends are unhealthy, migrate fast but do not put too much pressure on TiDB.
-	BalanceCount4Health = 10
+	BalanceCount4Health = 1000
 )
 
 var _ BalancePolicy = (*SimpleBalancePolicy)(nil)

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -102,9 +102,10 @@ func (conn *mockRedirectableConn) redirectFail() {
 }
 
 type mockBackendObserver struct {
-	sync.Mutex
-	healths     map[string]*observer.BackendHealth
-	subscribers map[string]chan observer.HealthResult
+	healthLock     sync.Mutex
+	healths        map[string]*observer.BackendHealth
+	subscriberLock sync.Mutex
+	subscribers    map[string]chan observer.HealthResult
 }
 
 func newMockBackendObserver() *mockBackendObserver {
@@ -115,15 +116,15 @@ func newMockBackendObserver() *mockBackendObserver {
 }
 
 func (mbo *mockBackendObserver) toggleBackendHealth(addr string) {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.healthLock.Lock()
+	defer mbo.healthLock.Unlock()
 	health := mbo.healths[addr]
 	health.Healthy = !health.Healthy
 }
 
 func (mbo *mockBackendObserver) addBackend(addr string) {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.healthLock.Lock()
+	defer mbo.healthLock.Unlock()
 	mbo.healths[addr] = &observer.BackendHealth{
 		Healthy: true,
 	}
@@ -133,16 +134,16 @@ func (mbo *mockBackendObserver) Start(ctx context.Context) {
 }
 
 func (mbo *mockBackendObserver) Subscribe(name string) <-chan observer.HealthResult {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.subscriberLock.Lock()
+	defer mbo.subscriberLock.Unlock()
 	subscriber := make(chan observer.HealthResult)
 	mbo.subscribers[name] = subscriber
 	return subscriber
 }
 
 func (mbo *mockBackendObserver) Unsubscribe(name string) {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.subscriberLock.Lock()
+	defer mbo.subscriberLock.Unlock()
 	if subscriber, ok := mbo.subscribers[name]; ok {
 		close(subscriber)
 		delete(mbo.subscribers, name)
@@ -154,20 +155,22 @@ func (mbo *mockBackendObserver) Refresh() {
 }
 
 func (mbo *mockBackendObserver) notify(err error) {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.healthLock.Lock()
 	healths := make(map[string]*observer.BackendHealth, len(mbo.healths))
 	for addr, health := range mbo.healths {
 		healths[addr] = health
 	}
+	mbo.healthLock.Unlock()
+	mbo.subscriberLock.Lock()
 	for _, subscriber := range mbo.subscribers {
 		subscriber <- observer.NewHealthResult(healths, err)
 	}
+	mbo.subscriberLock.Unlock()
 }
 
 func (mbo *mockBackendObserver) Close() {
-	mbo.Lock()
-	defer mbo.Unlock()
+	mbo.subscriberLock.Lock()
+	defer mbo.subscriberLock.Unlock()
 	for _, subscriber := range mbo.subscribers {
 		close(subscriber)
 	}

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -176,7 +176,9 @@ func (mbo *mockBackendObserver) Close() {
 var _ policy.BalancePolicy = (*mockBalancePolicy)(nil)
 
 type mockBalancePolicy struct {
-	cfg atomic.Pointer[config.Config]
+	cfg               atomic.Pointer[config.Config]
+	backendsToBalance func([]policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field)
+	backendToRoute    func([]policy.BackendCtx) policy.BackendCtx
 }
 
 func (m *mockBalancePolicy) Init(cfg *config.Config) {
@@ -184,10 +186,16 @@ func (m *mockBalancePolicy) Init(cfg *config.Config) {
 }
 
 func (m *mockBalancePolicy) BackendToRoute(backends []policy.BackendCtx) policy.BackendCtx {
+	if m.backendToRoute != nil {
+		return m.backendToRoute(backends)
+	}
 	return nil
 }
 
 func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field) {
+	if m.backendsToBalance != nil {
+		return m.backendsToBalance(backends)
+	}
 	return nil, nil, 0, nil
 }
 

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -53,7 +53,7 @@ const (
 
 const (
 	// The interval to rebalance connections.
-	rebalanceInterval = time.Second
+	rebalanceInterval = 10 * time.Millisecond
 	// After a connection fails to redirect, it may contain some unmigratable status.
 	// Limit its redirection interval to avoid unnecessary retrial to reduce latency jitter.
 	redirectFailMinInterval = 3 * time.Second

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/pingcap/tiproxy/pkg/metrics"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 type routerTester struct {
@@ -31,11 +33,15 @@ type routerTester struct {
 	conns     map[uint64]*mockRedirectableConn
 }
 
-func newRouterTester(t *testing.T) *routerTester {
+func newRouterTester(t *testing.T, bp policy.BalancePolicy) *routerTester {
 	lg, _ := logger.CreateLoggerForTest(t)
 	router := NewScoreBasedRouter(lg)
-	router.policy = policy.NewSimpleBalancePolicy()
-	router.policy.Init(nil)
+	if bp == nil {
+		router.policy = policy.NewSimpleBalancePolicy()
+		router.policy.Init(nil)
+	} else {
+		router.policy = bp
+	}
 	t.Cleanup(router.Close)
 	return &routerTester{
 		t:        t,
@@ -161,6 +167,7 @@ func (tester *routerTester) closeConnections(num int, redirecting bool) {
 
 func (tester *routerTester) rebalance(num int) {
 	for i := 0; i < num; i++ {
+		tester.router.lastRedirectTime = monotime.Time(0)
 		tester.router.rebalance(context.Background())
 	}
 }
@@ -243,7 +250,7 @@ func (tester *routerTester) clear() {
 }
 
 func TestRebalance(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(3)
 	tester.killBackends(2)
 	tester.addConnections(100)
@@ -272,7 +279,7 @@ func TestRebalance(t *testing.T) {
 
 // Test that the connections are always balanced after rebalance and routing.
 func TestConnBalanced(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(3)
 
 	// balanced after routing
@@ -305,7 +312,7 @@ func TestConnBalanced(t *testing.T) {
 
 // Test that routing fails when there's no healthy backends.
 func TestNoBackends(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	conn := tester.createConn()
 	backend := tester.simpleRoute(conn)
 	require.True(t, backend == nil || reflect.ValueOf(backend).IsNil())
@@ -318,7 +325,7 @@ func TestNoBackends(t *testing.T) {
 
 // Test that the backends returned by the BackendSelector are complete and different.
 func TestSelectorReturnOrder(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(3)
 	selector := tester.router.GetBackendSelector()
 	for i := 0; i < 3; i++ {
@@ -351,7 +358,7 @@ func TestSelectorReturnOrder(t *testing.T) {
 
 // Test that the backends are balanced even when routing are concurrent.
 func TestRouteConcurrently(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(3)
 	addrs := make(map[string]int, 3)
 	selectors := make([]BackendSelector, 0, 30)
@@ -382,7 +389,7 @@ func TestRouteConcurrently(t *testing.T) {
 
 // Test that the backends are balanced during rolling restart.
 func TestRollingRestart(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	backendNum := 3
 	tester.addBackends(backendNum)
 	tester.addConnections(100)
@@ -411,7 +418,7 @@ func TestRollingRestart(t *testing.T) {
 
 // Test the corner cases of rebalance.
 func TestRebalanceCornerCase(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tests := []func(){
 		func() {
 			// Balancer won't work when there's no backend.
@@ -445,53 +452,53 @@ func TestRebalanceCornerCase(t *testing.T) {
 		func() {
 			// The parameter limits the redirecting num.
 			tester.addBackends(2)
-			tester.addConnections(5 * policy.BalanceCount4Health)
+			tester.addConnections(50)
 			tester.killBackends(1)
 			tester.rebalance(1)
-			tester.checkRedirectingNum(policy.BalanceCount4Health)
+			tester.checkRedirectingNum(10)
 		},
 		func() {
 			// All the connections are redirected to the new healthy one and the unhealthy backends are removed.
 			tester.addBackends(1)
-			tester.addConnections(policy.BalanceCount4Health)
+			tester.addConnections(10)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
-			tester.checkRedirectingNum(policy.BalanceCount4Health)
+			tester.checkRedirectingNum(10)
 			tester.checkBackendNum(2)
 			backend := tester.getBackendByIndex(1)
-			require.Equal(t, policy.BalanceCount4Health, backend.connScore)
-			tester.redirectFinish(policy.BalanceCount4Health, true)
+			require.Equal(t, 10, backend.connScore)
+			tester.redirectFinish(10, true)
 			tester.checkBackendNum(1)
 		},
 		func() {
 			// Connections won't be redirected again before redirection finishes.
 			tester.addBackends(1)
-			tester.addConnections(policy.BalanceCount4Health)
+			tester.addConnections(10)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
-			tester.checkRedirectingNum(policy.BalanceCount4Health)
+			tester.checkRedirectingNum(10)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
-			tester.checkRedirectingNum(policy.BalanceCount4Health)
+			tester.checkRedirectingNum(10)
 			backend := tester.getBackendByIndex(0)
 			require.Equal(t, 0, backend.connScore)
-			require.Equal(t, policy.BalanceCount4Health, backend.connList.Len())
+			require.Equal(t, 10, backend.connList.Len())
 			backend = tester.getBackendByIndex(1)
-			require.Equal(t, policy.BalanceCount4Health, backend.connScore)
+			require.Equal(t, 10, backend.connScore)
 			require.Equal(t, 0, backend.connList.Len())
 		},
 		func() {
 			// After redirection fails, the connections are moved back to the unhealthy backends.
 			tester.addBackends(1)
-			tester.addConnections(policy.BalanceCount4Health)
+			tester.addConnections(10)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
 			tester.checkBackendNum(2)
-			tester.redirectFinish(policy.BalanceCount4Health, false)
+			tester.redirectFinish(10, false)
 			tester.checkBackendNum(2)
 		},
 		func() {
@@ -521,11 +528,11 @@ func TestRebalanceCornerCase(t *testing.T) {
 		func() {
 			// Connections will be redirected again immediately after failure.
 			tester.addBackends(1)
-			tester.addConnections(policy.BalanceCount4Health)
+			tester.addConnections(10)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
-			tester.redirectFinish(policy.BalanceCount4Health, false)
+			tester.redirectFinish(10, false)
 			tester.killBackends(1)
 			tester.addBackends(1)
 			tester.rebalance(1)
@@ -678,7 +685,7 @@ func TestObserveError(t *testing.T) {
 }
 
 func TestSetBackendStatus(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(1)
 	tester.addConnections(10)
 	tester.killBackends(1)
@@ -713,7 +720,7 @@ func TestGetServerVersion(t *testing.T) {
 
 func TestBackendHealthy(t *testing.T) {
 	// Make the connection redirect.
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(1)
 	tester.addConnections(1)
 	tester.killBackends(1)
@@ -730,7 +737,7 @@ func TestBackendHealthy(t *testing.T) {
 
 func TestCloseRedirectingConns(t *testing.T) {
 	// Make the connection redirect.
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(1)
 	tester.addConnections(1)
 	require.Equal(t, 1, tester.getBackendByIndex(0).connScore)
@@ -749,7 +756,7 @@ func TestCloseRedirectingConns(t *testing.T) {
 }
 
 func TestUpdateBackendHealth(t *testing.T) {
-	tester := newRouterTester(t)
+	tester := newRouterTester(t, nil)
 	tester.addBackends(3)
 	// Test some backends are not in the list anymore.
 	tester.removeBackends(1)
@@ -783,4 +790,64 @@ func TestWatchConfig(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return policy.getConfig().Labels["k1"] == "v2"
 	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestControlSpeed(t *testing.T) {
+	bp := &mockBalancePolicy{}
+	tester := newRouterTester(t, bp)
+	tester.addBackends(2)
+	bp.backendToRoute = func(bc []policy.BackendCtx) policy.BackendCtx {
+		return tester.getBackendByIndex(0)
+	}
+	total := 2000
+	tester.addConnections(total)
+
+	tests := []struct {
+		balanceCount     int
+		expectedCountMin int
+		expectedCountMax int
+	}{
+		{
+			balanceCount:     0,
+			expectedCountMin: 0,
+			expectedCountMax: 0,
+		},
+		{
+			balanceCount:     1,
+			expectedCountMin: 1,
+			expectedCountMax: 2,
+		},
+		{
+			balanceCount:     10,
+			expectedCountMin: 1,
+			expectedCountMax: 10,
+		},
+		{
+			balanceCount:     100,
+			expectedCountMin: 10,
+			expectedCountMax: 10,
+		},
+		{
+			balanceCount:     1000,
+			expectedCountMin: 100,
+			expectedCountMax: 100,
+		},
+	}
+
+	for _, test := range tests {
+		bp.backendsToBalance = func(bc []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field) {
+			return tester.getBackendByIndex(0), tester.getBackendByIndex(1), test.balanceCount, nil
+		}
+		tester.router.lastRedirectTime = monotime.Time(0)
+		require.Equal(t, total, tester.getBackendByIndex(0).connScore)
+		for j := 0; j < 10; j++ {
+			tester.router.rebalance(context.Background())
+			tester.router.lastRedirectTime -= monotime.Time(rebalanceInterval)
+		}
+		redirectingNum := total - tester.getBackendByIndex(0).connScore
+		// Define a bound because the test may be slow.
+		require.LessOrEqual(t, test.expectedCountMin, redirectingNum)
+		require.GreaterOrEqual(t, test.expectedCountMax, redirectingNum)
+		tester.redirectFinish(redirectingNum, false)
+	}
 }

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -804,31 +804,54 @@ func TestControlSpeed(t *testing.T) {
 
 	tests := []struct {
 		balanceCount     int
+		rounds           int
+		interval         time.Duration
 		expectedCountMin int
 		expectedCountMax int
 	}{
 		{
 			balanceCount:     0,
+			rounds:           2,
+			interval:         time.Second,
 			expectedCountMin: 0,
 			expectedCountMax: 0,
 		},
 		{
 			balanceCount:     1,
+			rounds:           1,
+			interval:         10 * time.Millisecond,
 			expectedCountMin: 1,
 			expectedCountMax: 2,
 		},
 		{
+			balanceCount:     1,
+			rounds:           100,
+			interval:         100 * time.Millisecond,
+			expectedCountMin: 9,
+			expectedCountMax: 11,
+		},
+		{
 			balanceCount:     10,
-			expectedCountMin: 1,
-			expectedCountMax: 10,
+			rounds:           10,
+			interval:         100 * time.Millisecond,
+			expectedCountMin: 9,
+			expectedCountMax: 20,
 		},
 		{
 			balanceCount:     100,
+			rounds:           10,
 			expectedCountMin: 10,
 			expectedCountMax: 10,
 		},
 		{
 			balanceCount:     1000,
+			rounds:           1,
+			expectedCountMin: 10,
+			expectedCountMax: 10,
+		},
+		{
+			balanceCount:     1000,
+			rounds:           10,
 			expectedCountMin: 100,
 			expectedCountMax: 100,
 		},
@@ -840,9 +863,9 @@ func TestControlSpeed(t *testing.T) {
 		}
 		tester.router.lastRedirectTime = monotime.Time(0)
 		require.Equal(t, total, tester.getBackendByIndex(0).connScore)
-		for j := 0; j < 10; j++ {
+		for j := 0; j < test.rounds; j++ {
 			tester.router.rebalance(context.Background())
-			tester.router.lastRedirectTime -= monotime.Time(rebalanceInterval)
+			tester.router.lastRedirectTime -= monotime.Time(test.interval)
 		}
 		redirectingNum := total - tester.getBackendByIndex(0).connScore
 		// Define a bound because the test may be slow.


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #549 

Problem Summary:
There are some problems with the current session migration:
- When a backend has something wrong, all the connections are migrated to the same target backend. The target backend may be overloaded
- There is a sleep in the rebalance, which may cause the problem that the lock is held too long

What is changed and how it works:
- Rebalance every a short time and migrate only a few connections in each round
- Control the speed in the router, considering both slow migration(like CPU-based) and fast migration(like health-based)
- `BalanceCount()` returns the count per second, instead of per round
- Factors calculate the balance count by the current connection counts
- Fix a deadlock bug in `TestConcurrency`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
