### PR TITLE
metrics, balance: add metrics for load balance

### DIFF
--- a/lib/config/getter.go
+++ b/lib/config/getter.go
@@ -1,0 +1,8 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+type ConfigGetter interface {
+	GetConfig() *Config
+}

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -176,7 +176,7 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 // BackendsToBalance returns the busiest/unhealthy backend and the idlest backend.
 // balanceCount: the count of connections to migrate in this round. 0 indicates no need to balance.
 // reason: the debug information to be logged.
-func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount int, reason []zap.Field) {
+func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount int, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return
 	}
@@ -226,16 +226,17 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			// backend1 factor scores: 1, 0, 1
 			// backend2 factor scores: 0, 1, 0
 			// Balancing the third factor may make the second factor unbalanced, although it's in the same order with the first factor.
-			return nil, nil, 0, nil
+			return
 		}
 		leftBitNum -= bitNum
 	}
+	reason = factor.Name()
 	fields := []zap.Field{
-		zap.String("factor", factor.Name()),
+		zap.String("factor", reason),
 		zap.Uint64("from_score", maxScore),
 		zap.Uint64("to_score", minScore),
 	}
-	return busiestBackend.BackendCtx, idlestBackend.BackendCtx, balanceCount, fields
+	return busiestBackend.BackendCtx, idlestBackend.BackendCtx, balanceCount, reason, fields
 }
 
 func (fbb *FactorBasedBalance) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -136,11 +136,12 @@ func TestBalanceWithOneFactor(t *testing.T) {
 			}
 		}
 		backends := createBackends(len(test.scores))
-		from, to, count, _ := fm.BackendsToBalance(backends)
+		from, to, count, reason, _ := fm.BackendsToBalance(backends)
 		require.Equal(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)
 			require.Equal(t, backends[test.toIdx], to, "test index %d", tIdx)
+			require.Equal(t, "mock", reason, "test index %d", tIdx)
 		} else {
 			require.Nil(t, from, "test index %d", tIdx)
 			require.Nil(t, to, "test index %d", tIdx)
@@ -215,7 +216,7 @@ func TestBalanceWith2Factors(t *testing.T) {
 			}
 		}
 		backends := createBackends(len(test.scores1))
-		from, to, count, _ := fm.BackendsToBalance(backends)
+		from, to, count, _, _ := fm.BackendsToBalance(backends)
 		require.Equal(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)
@@ -266,7 +267,7 @@ func TestBalanceWith3Factors(t *testing.T) {
 			}(factorIdx, factor)
 		}
 		backends := createBackends(len(test.scores))
-		from, to, count, _ := fm.BackendsToBalance(backends)
+		from, to, count, _, _ := fm.BackendsToBalance(backends)
 		require.Equal(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)

--- a/pkg/balance/factor/factor_location_test.go
+++ b/pkg/balance/factor/factor_location_test.go
@@ -6,120 +6,33 @@ package factor
 import (
 	"testing"
 
-	"github.com/pingcap/tiproxy/lib/config"
-	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/stretchr/testify/require"
 )
 
-func TestFactorLocationOneBackend(t *testing.T) {
+func TestFactorLocationScore(t *testing.T) {
 	tests := []struct {
-		selfLocation    string
-		backendLocation string
-		expectedScore   uint64
-	}{
-		{},
-		{
-			selfLocation:  "az1",
-			expectedScore: 1,
-		},
-		{
-			backendLocation: "az1",
-		},
-		{
-			selfLocation:    "az1",
-			backendLocation: "az2",
-			expectedScore:   1,
-		},
-		{
-			selfLocation:    "az1",
-			backendLocation: "az1",
-		},
-	}
-
-	factor := NewFactorLocation()
-	for i, test := range tests {
-		var backendLabels map[string]string
-		if test.backendLocation != "" {
-			backendLabels = map[string]string{
-				locationLabelName: test.backendLocation,
-			}
-		}
-		backendCtx := &mockBackend{
-			BackendInfo: observer.BackendInfo{Labels: backendLabels},
-		}
-		// Create 2 backends so that UpdateScore won't skip calculating scores.
-		backends := []scoredBackend{
-			{
-				BackendCtx: backendCtx,
-			},
-			{
-				BackendCtx: backendCtx,
-			},
-		}
-		var selfLabels map[string]string
-		if test.selfLocation != "" {
-			selfLabels = map[string]string{
-				locationLabelName: test.selfLocation,
-			}
-		}
-		factor.SetConfig(&config.Config{
-			Labels: selfLabels,
-		})
-		factor.UpdateScore(backends)
-		for _, backend := range backends {
-			require.Equal(t, test.expectedScore, backend.score(), "test idx: %d", i)
-		}
-	}
-}
-
-func TestFactorLocationMultiBackends(t *testing.T) {
-	tests := []struct {
-		labels        map[string]string
+		local         bool
 		expectedScore uint64
 	}{
 		{
+			local:         false,
 			expectedScore: 1,
 		},
 		{
-			labels: map[string]string{
-				locationLabelName: "az1",
-			},
-			expectedScore: 0,
-		},
-		{
-			labels: map[string]string{
-				"z": "az1",
-			},
-			expectedScore: 1,
-		},
-		{
-			labels: map[string]string{
-				locationLabelName: "az2",
-				"z":               "az1",
-			},
-			expectedScore: 1,
-		},
-		{
-			labels: map[string]string{
-				locationLabelName: "az1",
-				"z":               "az2",
-			},
+			local:         true,
 			expectedScore: 0,
 		},
 	}
+
+	factor := NewFactorLocation()
 	backends := make([]scoredBackend, 0, len(tests))
 	for _, test := range tests {
-		backend := scoredBackend{
+		backends = append(backends, scoredBackend{
 			BackendCtx: &mockBackend{
-				BackendInfo: observer.BackendInfo{Labels: test.labels},
+				local: test.local,
 			},
-		}
-		backends = append(backends, backend)
+		})
 	}
-	factor := NewFactorLocation()
-	factor.SetConfig(&config.Config{
-		Labels: map[string]string{locationLabelName: "az1"},
-	})
 	factor.UpdateScore(backends)
 	for i, test := range tests {
 		require.Equal(t, test.expectedScore, backends[i].score(), "test idx: %d", i)

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -24,6 +24,7 @@ type mockBackend struct {
 	connScore int
 	connCount int
 	healthy   bool
+	local     bool
 }
 
 func newMockBackend(healthy bool, connScore int) *mockBackend {
@@ -51,6 +52,10 @@ func (mb *mockBackend) ConnCount() int {
 
 func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
 	return mb.BackendInfo
+}
+
+func (mb *mockBackend) Local() bool {
+	return mb.local
 }
 
 var _ Factor = (*mockFactor)(nil)

--- a/pkg/balance/metricsreader/mock_test.go
+++ b/pkg/balance/metricsreader/mock_test.go
@@ -118,3 +118,7 @@ func (mb *mockBackend) Addr() string {
 func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
 	return mb.BackendInfo
 }
+
+func (mb *mockBackend) Local() bool {
+	return true
+}

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -13,7 +13,7 @@ type BalancePolicy interface {
 	Init(cfg *config.Config)
 	BackendToRoute(backends []BackendCtx) BackendCtx
 	// balanceCount is the count of connections to balance per second.
-	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason []zap.Field)
+	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason string, logFields []zap.Field)
 	SetConfig(cfg *config.Config)
 }
 
@@ -24,5 +24,6 @@ type BackendCtx interface {
 	// ConnScore = current connections + incoming connections - outgoing connections.
 	ConnScore() int
 	Healthy() bool
+	Local() bool
 	GetBackendInfo() observer.BackendInfo
 }

--- a/pkg/balance/policy/mock_test.go
+++ b/pkg/balance/policy/mock_test.go
@@ -35,6 +35,10 @@ func (mb *mockBackend) Addr() string {
 	return ""
 }
 
+func (mb *mockBackend) Local() bool {
+	return true
+}
+
 func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
 	return observer.BackendInfo{}
 }

--- a/pkg/balance/policy/simple_policy.go
+++ b/pkg/balance/policy/simple_policy.go
@@ -44,24 +44,26 @@ func (sbp *SimpleBalancePolicy) BackendToRoute(backends []BackendCtx) BackendCtx
 	return nil
 }
 
-func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason []zap.Field) {
+func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return
 	}
 	sortBackends(backends)
 	from, to = backends[len(backends)-1], backends[0]
 	if !to.Healthy() || from.ConnScore() <= 0 {
-		return nil, nil, 0, nil
+		return nil, nil, 0, "", nil
 	}
 	if !from.Healthy() {
 		balanceCount = BalanceCount4Health
+		reason = "status"
 	} else {
 		if float64(from.ConnScore()) <= float64(to.ConnScore()+1)*ConnBalancedRatio {
-			return nil, nil, 0, nil
+			return nil, nil, 0, "", nil
 		}
 		balanceCount = 1
+		reason = "conn"
 	}
-	reason = []zap.Field{
+	logFields = []zap.Field{
 		zap.Bool("from_healthy", from.Healthy()),
 		zap.Bool("to_healthy", to.Healthy()),
 		zap.Int("from_score", from.ConnScore()),

--- a/pkg/balance/policy/simple_policy_test.go
+++ b/pkg/balance/policy/simple_policy_test.go
@@ -15,6 +15,7 @@ func TestSimplePolicy(t *testing.T) {
 		routeIdx int
 		fromIdx  int
 		toIdx    int
+		reason   string
 	}{
 		{
 			backends: []BackendCtx{newMockBackend(false, 0)},
@@ -45,6 +46,7 @@ func TestSimplePolicy(t *testing.T) {
 			routeIdx: 1,
 			fromIdx:  0,
 			toIdx:    1,
+			reason:   "conn",
 		},
 		{
 			backends: []BackendCtx{newMockBackend(true, 0), newMockBackend(true, 0)},
@@ -79,12 +81,13 @@ func TestSimplePolicy(t *testing.T) {
 		} else {
 			require.Nil(t, backend)
 		}
-		from, to, _, _ := sbp.BackendsToBalance(test.backends)
+		from, to, _, reason, _ := sbp.BackendsToBalance(test.backends)
 		if test.fromIdx >= 0 {
 			require.Equal(t, fromBackend.healthy, from.Healthy(), "test idx: %d", idx)
 			require.Equal(t, fromBackend.connScore, from.ConnScore(), "test idx: %d", idx)
 			require.Equal(t, toBackend.healthy, to.Healthy(), "test idx: %d", idx)
 			require.Equal(t, toBackend.connScore, to.ConnScore(), "test idx: %d", idx)
+			require.Equal(t, test.reason, reason, "test idx: %d", idx)
 		} else {
 			require.Nil(t, from, "test idx: %d", idx)
 			require.Nil(t, to, "test idx: %d", idx)

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -180,7 +180,7 @@ var _ policy.BalancePolicy = (*mockBalancePolicy)(nil)
 
 type mockBalancePolicy struct {
 	cfg               atomic.Pointer[config.Config]
-	backendsToBalance func([]policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field)
+	backendsToBalance func([]policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field)
 	backendToRoute    func([]policy.BackendCtx) policy.BackendCtx
 }
 
@@ -195,11 +195,11 @@ func (m *mockBalancePolicy) BackendToRoute(backends []policy.BackendCtx) policy.
 	return nil
 }
 
-func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field) {
+func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field) {
 	if m.backendsToBalance != nil {
 		return m.backendsToBalance(backends)
 	}
-	return nil, nil, 0, nil
+	return nil, nil, 0, "", nil
 }
 
 func (m *mockBalancePolicy) SetConfig(cfg *config.Config) {

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -73,6 +73,7 @@ type RedirectableConn interface {
 type BackendInst interface {
 	Addr() string
 	Healthy() bool
+	Local() bool
 }
 
 // backendWrapper contains the connections on the backend.
@@ -131,6 +132,13 @@ func (b *backendWrapper) ConnCount() int {
 	return b.connList.Len()
 }
 
+func (b *backendWrapper) Local() bool {
+	b.mu.RLock()
+	local := b.mu.Local
+	b.mu.RUnlock()
+	return local
+}
+
 func (b *backendWrapper) GetBackendInfo() observer.BackendInfo {
 	b.mu.RLock()
 	info := b.mu.BackendInfo
@@ -155,6 +163,8 @@ func (b *backendWrapper) String() string {
 // connWrapper wraps RedirectableConn.
 type connWrapper struct {
 	RedirectableConn
+	// The reason why the redirection happens.
+	redirectReason string
 	// Reference to the target backend if it's redirecting, otherwise nil.
 	redirectingBackend *backendWrapper
 	// Last redirect start time of this connection.

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -858,8 +858,8 @@ func TestControlSpeed(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		bp.backendsToBalance = func(bc []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason []zapcore.Field) {
-			return tester.getBackendByIndex(0), tester.getBackendByIndex(1), test.balanceCount, nil
+		bp.backendsToBalance = func(bc []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field) {
+			return tester.getBackendByIndex(0), tester.getBackendByIndex(1), test.balanceCount, "conn", nil
 		}
 		tester.router.lastRedirectTime = monotime.Time(0)
 		require.Equal(t, total, tester.getBackendByIndex(0).connScore)

--- a/pkg/balance/router/router_static.go
+++ b/pkg/balance/router/router_static.go
@@ -99,3 +99,7 @@ func (b *StaticBackend) Healthy() bool {
 func (b *StaticBackend) SetHealthy(healthy bool) {
 	b.healthy.Store(healthy)
 }
+
+func (b *StaticBackend) Local() bool {
+	return true
+}

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -52,7 +52,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	// init Router
 	rt := router.NewScoreBasedRouter(logger.Named("router"))
 	hc := observer.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
-	bo := observer.NewDefaultBackendObserver(logger.Named("observer"), healthCheckCfg, fetcher, hc)
+	bo := observer.NewDefaultBackendObserver(logger.Named("observer"), healthCheckCfg, fetcher, hc, mgr.cfgMgr)
 	bo.Start(context.Background())
 	balancePolicy := factor.NewFactorBasedBalance(logger.Named("factor"), mgr.metricsReader)
 	rt.Init(context.Background(), bo, balancePolicy, mgr.cfgMgr.GetConfig(), mgr.cfgMgr.WatchConfig())

--- a/pkg/metrics/balance.go
+++ b/pkg/metrics/balance.go
@@ -15,6 +15,7 @@ const (
 	LblBackend       = "backend"
 	LblFrom          = "from"
 	LblTo            = "to"
+	LblReason        = "reason"
 	LblMigrateResult = "migrate_res"
 )
 
@@ -33,7 +34,7 @@ var (
 			Subsystem: LabelBalance,
 			Name:      "migrate_total",
 			Help:      "Number and result of session migration.",
-		}, []string{LblFrom, LblTo, LblMigrateResult})
+		}, []string{LblFrom, LblTo, LblReason, LblMigrateResult})
 
 	MigrateDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -1602,6 +1602,92 @@
                      "show": true
                   }
                ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_TEST-CLUSTER}",
+               "description": "Reasons of session migrations per minute.",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 22,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(increase(tiproxy_balance_migrate_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (reason)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{reason}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Session Migration Reasons",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
             }
          ],
          "repeat": null,
@@ -1621,7 +1707,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 22,
+         "id": 23,
          "panels": [
             {
                "aliasColors": { },
@@ -1638,7 +1724,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 23,
+               "id": 24,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1738,7 +1824,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 24,
+               "id": 25,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1824,7 +1910,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 25,
+               "id": 26,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1913,7 +1999,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 26,
+         "id": 27,
          "panels": [
             {
                "aliasColors": { },
@@ -1930,7 +2016,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 27,
+               "id": 28,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2016,7 +2102,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 28,
+               "id": 29,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2102,7 +2188,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 29,
+               "id": 30,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2188,7 +2274,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 30,
+               "id": 31,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2227,6 +2313,92 @@
                "timeFrom": null,
                "timeShift": null,
                "title": "Packets/Second to Backends",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_TEST-CLUSTER}",
+               "description": "Bytes per second between TiProxy and cross-location backends.",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 0,
+                  "y": 0
+               },
+               "id": 32,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tiproxy_traffic_cross_location_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}[1m])) by (instance)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Cross Location Bytes/Second",
                "tooltip": {
                   "shared": true,
                   "sort": 0,

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -388,6 +388,20 @@ local bMigDurP = graphPanel.new(
   )
 );
 
+local bMigReasonP = graphPanel.new(
+  title='Session Migration Reasons',
+  datasource=myDS,
+  legend_rightSide=true,
+  description='Reasons of session migrations per minute.',
+  format='short',
+)
+.addTarget(
+  prometheus.target(
+    'sum(increase(tiproxy_balance_migrate_total{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}[1m])) by (reason)',
+    legendFormat='{{reason}}',
+  )
+);
+
 // Backend Summary
 local backendRow = row.new(collapse=true, title='Backend');
 local bGetDurP = graphPanel.new(
@@ -503,6 +517,20 @@ local outPacketsP = graphPanel.new(
   )
 );
 
+local crossBytesP = graphPanel.new(
+  title='Cross Location Bytes/Second',
+  datasource=myDS,
+  legend_rightSide=true,
+  description='Bytes per second between TiProxy and cross-location backends.',
+  format='short',
+)
+.addTarget(
+  prometheus.target(
+    'sum(rate(tiproxy_traffic_cross_location_bytes{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}[1m])) by (instance)',
+    legendFormat='{{instance}}',
+  )
+);
+
 // Merge together.
 local panelW = 12;
 local panelH = 6;
@@ -543,6 +571,7 @@ newDash
   .addPanel(bConnP, gridPos=leftPanelPos)
   .addPanel(bMigCounterP, gridPos=rightPanelPos)
   .addPanel(bMigDurP, gridPos=leftPanelPos)
+  .addPanel(bMigReasonP, gridPos=rightPanelPos)
   ,
   gridPos=rowPos
 )
@@ -560,6 +589,7 @@ newDash
   .addPanel(inPacketsP, gridPos=rightPanelPos)
   .addPanel(outBytesP, gridPos=leftPanelPos)
   .addPanel(outPacketsP, gridPos=rightPanelPos)
+  .addPanel(crossBytesP, gridPos=leftPanelPos)
   ,
   gridPos=rowPos
 )

--- a/pkg/metrics/traffic.go
+++ b/pkg/metrics/traffic.go
@@ -37,4 +37,12 @@ var (
 			Name:      "outbound_packets",
 			Help:      "Counter of packets to backends.",
 		}, []string{LblBackend})
+
+	CrossLocationBytesCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelTraffic,
+			Name:      "cross_location_bytes",
+			Help:      "Counter of bytes between TiProxy and cross-location backends.",
+		})
 )

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -400,7 +400,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 
 func (mgr *BackendConnManager) updateTraffic(backendIO *pnet.PacketIO) {
 	inBytes, inPackets, outBytes, outPackets := backendIO.InBytes(), backendIO.InPackets(), backendIO.OutBytes(), backendIO.OutPackets()
-	addTraffic(backendIO.RemoteAddr().String(), inBytes-mgr.inBytes, inPackets-mgr.inPackets, outBytes-mgr.outBytes, outPackets-mgr.outPackets)
+	addTraffic(backendIO.RemoteAddr().String(), inBytes-mgr.inBytes, inPackets-mgr.inPackets, outBytes-mgr.outBytes, outPackets-mgr.outPackets, mgr.curBackend.Local())
 	mgr.inBytes, mgr.inPackets, mgr.outBytes, mgr.outPackets = inBytes, inPackets, outBytes, outPackets
 }
 

--- a/pkg/proxy/backend/metrics.go
+++ b/pkg/proxy/backend/metrics.go
@@ -57,7 +57,10 @@ func addCmdMetrics(cmd pnet.Command, addr string, startTime monotime.Time) {
 	mc.observer.Observe(cost.Seconds())
 }
 
-func addTraffic(addr string, inBytes, inPackets, outBytes, outPackets uint64) {
+func addTraffic(addr string, inBytes, inPackets, outBytes, outPackets uint64, local bool) {
+	if !local {
+		metrics.CrossLocationBytesCounter.Add(float64(inBytes + outBytes))
+	}
 	cache.Lock()
 	defer cache.Unlock()
 	// Updating traffic per IO costs too much CPU, so update it per command.


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #555

Problem Summary:
Users may need these metrics for load balance:
- The reasons for connection migration
- Cross-zone traffic

What is changed and how it works:
- Add `ConfigGetter` to pull configs instead of pushing configs because #532 
- `BackendObserver` decides backend locality by TiProxy labels and backend labels. This is moved from `FactorLocation` so that both `FactorLocation` and `BackendConnMgr` can know backend locality by `BackendInst`
- Add cross-az traffic and connection migration metrics

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Add metrics of cross-az traffic and connection migration reasons
```
