### PR TITLE
factor: use both average usage and latest usage in CPU-based balance

### DIFF
--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	cpuEwmaAlpha = 0.5
 	// If some metrics are missing, we use the old one temporarily for no longer than cpuMetricExpDuration.
 	cpuMetricExpDuration = 2 * time.Minute
 	cpuScoreStep         = 5
@@ -29,15 +30,18 @@ var _ Factor = (*FactorCPU)(nil)
 
 var (
 	cpuQueryExpr = metricsreader.QueryExpr{
-		// The CPU usage is smoothed by rate[1m].
-		PromQL:   `rate(process_cpu_seconds_total{%s="tidb"}[1m])/tidb_server_maxprocs`,
+		PromQL:   `irate(process_cpu_seconds_total{%s="tidb"}[30s])/tidb_server_maxprocs`,
 		HasLabel: true,
+		Range:    1 * time.Minute,
 	}
 )
 
 type cpuBackendSnapshot struct {
 	updatedTime monotime.Time
-	avgUsage    float64
+	// smoothed CPU usage, used to decide whether to migrate
+	avgUsage float64
+	// timely CPU usage, used to score and decide the balance count
+	latestUsage float64
 	connCount   int
 }
 
@@ -87,26 +91,8 @@ func (fc *FactorCPU) UpdateScore(backends []scoredBackend) {
 	}
 
 	for i := 0; i < len(backends); i++ {
-		// Negative indicates missing metric.
-		avgUsage := -1.0
-		addr := backends[i].Addr()
-		// Estimate the current cpu usage by the latest CPU usage, the latest connection count, and the current connection count.
-		if snapshot, ok := fc.snapshot[addr]; ok {
-			histConnCount := snapshot.connCount
-			curConnCount := backends[i].ConnScore()
-			if snapshot.avgUsage >= 0 {
-				avgUsage = snapshot.avgUsage + float64(curConnCount-histConnCount)*fc.usagePerConn
-				if avgUsage < 0 {
-					avgUsage = 0
-				}
-			}
-		}
-		// If the metric of one backend is missing, treat it as unhealthy.
-		// If the metrics of all backends are missing, give them the same scores.
-		if avgUsage < 0 || avgUsage > 1 {
-			avgUsage = 1
-		}
-		backends[i].addScore(int(avgUsage*100)/cpuScoreStep, fc.bitNum)
+		_, latestUsage := fc.getUsage(backends[i])
+		backends[i].addScore(int(latestUsage*100)/cpuScoreStep, fc.bitNum)
 	}
 }
 
@@ -117,12 +103,13 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 		valid := false
 		// If a backend exists in metrics but not in the backend list, ignore it for this round.
 		// The backend will be in the next round if it's healthy.
-		sample := qr.GetSample4Backend(backend)
-		if sample != nil {
-			avgUsage := calcAvgUsage(sample)
+		pairs := qr.GetSamplePair4Backend(backend)
+		if len(pairs) > 0 {
+			avgUsage, latestUsage := calcAvgUsage(pairs)
 			if avgUsage >= 0 {
 				snapshots[addr] = cpuBackendSnapshot{
 					avgUsage:    avgUsage,
+					latestUsage: latestUsage,
 					connCount:   backend.ConnCount(),
 					updatedTime: qr.UpdateTime,
 				}
@@ -141,12 +128,28 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 	fc.snapshot = snapshots
 }
 
-func calcAvgUsage(sample *model.Sample) float64 {
-	avgUsage := float64(sample.Value)
-	if math.IsNaN(avgUsage) || avgUsage > 1 {
+func calcAvgUsage(usageHistory []model.SamplePair) (avgUsage, latestUsage float64) {
+	avgUsage, latestUsage = -1, -1
+	if len(usageHistory) == 0 {
+		return
+	}
+	// The CPU usage may jitter, so use the EWMA algorithm to make it smooth.
+	for _, usage := range usageHistory {
+		value := float64(usage.Value)
+		if math.IsNaN(value) {
+			continue
+		}
+		latestUsage = value
+		if avgUsage < 0 {
+			avgUsage = value
+		} else {
+			avgUsage = avgUsage*(1-cpuEwmaAlpha) + value*cpuEwmaAlpha
+		}
+	}
+	if avgUsage > 1 {
 		avgUsage = 1
 	}
-	return avgUsage
+	return
 }
 
 // Estimate the average CPU usage used by one connection.
@@ -156,8 +159,8 @@ func calcAvgUsage(sample *model.Sample) float64 {
 func (fc *FactorCPU) updateCpuPerConn() {
 	totalUsage, totalConns := 0.0, 0
 	for _, backend := range fc.snapshot {
-		if backend.avgUsage > 0 && backend.connCount > 0 {
-			totalUsage += backend.avgUsage
+		if backend.latestUsage > 0 && backend.connCount > 0 {
+			totalUsage += backend.latestUsage
 			totalConns += backend.connCount
 		}
 	}
@@ -180,33 +183,32 @@ func (fc *FactorCPU) updateCpuPerConn() {
 	}
 }
 
+// Estimate the current cpu usage by the latest CPU usage, the latest connection count, and the current connection count.
+func (fc *FactorCPU) getUsage(backend scoredBackend) (avgUsage, latestUsage float64) {
+	snapshot, ok := fc.snapshot[backend.Addr()]
+	if !ok || snapshot.avgUsage < 0 || latestUsage < 0 {
+		// The metric has missed for minutes.
+		return 1, 1
+	}
+	avgUsage = snapshot.avgUsage
+	latestUsage = snapshot.latestUsage + float64(backend.ConnScore()-snapshot.connCount)*fc.usagePerConn
+	if latestUsage > 1 {
+		latestUsage = 1
+	}
+	return
+}
+
 func (fc *FactorCPU) ScoreBitNum() int {
 	return fc.bitNum
 }
 
 func (fc *FactorCPU) BalanceCount(from, to scoredBackend) int {
-	var fromUsage, toUsage float64
-	if fromSnapshot, ok := fc.snapshot[from.Addr()]; !ok || fromSnapshot.avgUsage < 0 {
-		// The metric has missed for minutes.
-		fromUsage = 1
-	} else {
-		fromUsage = fromSnapshot.avgUsage + float64(from.ConnScore()-fromSnapshot.connCount)*fc.usagePerConn
-		if fromUsage > 1 {
-			fromUsage = 1
-		}
-	}
-	if toSnapshot, ok := fc.snapshot[to.Addr()]; !ok || toSnapshot.avgUsage < 0 {
-		// impossible
-		return 0
-	} else {
-		toUsage = toSnapshot.avgUsage + float64(to.ConnScore()-toSnapshot.connCount)*fc.usagePerConn
-		if toUsage > 1 {
-			toUsage = 1
-		}
-	}
+	fromAvgUsage, fromLatestUsage := fc.getUsage(from)
+	toAvgUsage, toLatestUsage := fc.getUsage(to)
 	// The higher the CPU usage, the more sensitive the load balance should be.
 	// E.g. 10% vs 25% don't need rebalance, but 80% vs 95% need rebalance.
-	if 1.3-toUsage > (1.3-fromUsage)*cpuBalancedRatio {
+	// Use the average usage to avoid thrash when CPU jitters too much and use the latest usage to avoid migrate too many connections.
+	if 1.3-toAvgUsage > (1.3-fromAvgUsage)*cpuBalancedRatio && 1.3-toLatestUsage > (1.3-fromLatestUsage)*cpuBalancedRatio {
 		if balanceCount := int(1 / fc.usagePerConn / balanceRatio4Cpu); balanceCount > 1 {
 			return balanceCount
 		}

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -16,85 +16,74 @@ import (
 
 func TestCPUBalanceOnce(t *testing.T) {
 	tests := []struct {
-		cpus         []float64
-		connCounts   []int
+		cpus         [][]float64
 		scoreOrder   []int
 		balanceCount int
 	}{
 		{
-			cpus:         []float64{0, 0.2},
-			connCounts:   []int{0, 0},
+			cpus:         [][]float64{{0}, {0.2}},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         []float64{0.25, 0.5, 0, 1},
-			connCounts:   []int{10, 10, 10, 10},
+			cpus:         [][]float64{{1, 0.5, 0.25}, {0, 0.25, 0.5}, {0, 0, 0}, {1, 1, 1}},
 			scoreOrder:   []int{2, 0, 1, 3},
 			balanceCount: 1,
 		},
 		{
-			cpus:         []float64{0.25, math.NaN(), 0.5},
-			connCounts:   []int{10, 10, 10},
+			cpus:         [][]float64{{0.25}, {}, {0.5}},
 			scoreOrder:   []int{0, 2, 1},
 			balanceCount: 1,
 		},
 		{
-			cpus:         []float64{0.92, 0.76},
-			connCounts:   []int{10, 10},
+			cpus:         [][]float64{{0.95, 0.92, 0.93, 0.94, 0.92, 0.94}, {0.81, 0.79, 0.82, 0.83, 0.76, 0.78}},
 			scoreOrder:   []int{1, 0},
 			balanceCount: 1,
 		},
 		{
-			cpus:         []float64{0.42, 0.59},
-			connCounts:   []int{10, 10},
+			cpus:         [][]float64{{0.35, 0.42, 0.37, 0.45, 0.42, 0.44}, {0.56, 0.62, 0.58, 0.57, 0.59, 0.63}},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 1,
 		},
 		{
-			cpus:         []float64{0.1, 0.25},
-			connCounts:   []int{0, 0},
-			scoreOrder:   []int{0, 1},
+			cpus:         [][]float64{{0, 0.1, 0, 0.1}, {0.15, 0.1, 0.15, 0.15}, {0.1, 0, 0.1, 0}},
+			scoreOrder:   []int{2, 0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         []float64{0.1, 0.35},
-			connCounts:   []int{10, 10},
-			scoreOrder:   []int{0, 1},
+			cpus:         [][]float64{{0.5}, {}, {0.1, 0.3, 0.4}},
+			scoreOrder:   []int{2, 0, 1},
 			balanceCount: 1,
 		},
 		{
-			cpus:         []float64{0.95, math.NaN()},
-			connCounts:   []int{0, 0},
+			cpus:         [][]float64{{1.0}, {0.97}},
+			scoreOrder:   []int{1, 0},
+			balanceCount: 0,
+		},
+		{
+			cpus:         [][]float64{{0.8, 0.2, 0.8, 0.2}, {0.3, 0.5, 0.3, 0.5}},
 			scoreOrder:   []int{0, 1},
 			balanceCount: 0,
 		},
 		{
-			cpus:         []float64{1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.1},
-			connCounts:   []int{0, 0, 0, 0, 0, 0, 0, 0, 0},
+			cpus:         [][]float64{{1.0}, {0.9}, {0.8}, {0.7}, {0.6}, {0.5}, {0.4}, {0.3}, {0.1}},
 			scoreOrder:   []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
 			balanceCount: 1,
-		},
-		{
-			cpus:         []float64{0.4, 0.8},
-			connCounts:   []int{2000, 4000},
-			scoreOrder:   []int{0, 1},
-			balanceCount: 8,
 		},
 	}
 
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
-		values := make([]*model.Sample, 0, len(test.cpus))
+		values := make([]*model.SampleStream, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
-			backends = append(backends, createBackend(j, test.connCounts[j], test.connCounts[j]))
-			values = append(values, createSample(test.cpus[j], j))
+			backends = append(backends, createBackend(j, 0, 0))
+			values = append(values, createSampleStream(test.cpus[j], j))
 		}
 		mmr := &mockMetricsReader{
 			qrs: map[uint64]metricsreader.QueryResult{
 				1: {
 					UpdateTime: monotime.Now(),
-					Value:      model.Vector(values),
+					Value:      model.Matrix(values),
 				},
 			},
 		}
@@ -115,64 +104,82 @@ func TestCPUBalanceOnce(t *testing.T) {
 
 func TestCPUBalanceContinuously(t *testing.T) {
 	tests := []struct {
-		cpus          []float64
+		cpus          [][]float64
 		connCounts    []int
 		connScores    []int
 		newConnScores []int
 	}{
 		{
-			cpus:          []float64{math.NaN(), math.NaN()},
+			cpus:          [][]float64{{}, {}},
 			connCounts:    []int{0, 0},
 			connScores:    []int{0, 0},
 			newConnScores: []int{0, 0},
 		},
 		{
-			cpus:          []float64{0.01, 0.02},
+			cpus:          [][]float64{{0.01}, {0.02}},
 			connCounts:    []int{100, 200},
 			connScores:    []int{100, 200},
 			newConnScores: []int{100, 200},
 		},
 		{
-			cpus:          []float64{0.5, 0.2},
+			cpus:          [][]float64{{0.1, 0.1, 0.1, 0.1, 0.1}, {0.05, 0.07, 0.05, 0.04, 0.03}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{200, 100},
+			newConnScores: []int{200, 100},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
 			connCounts:    []int{200, 100},
 			connScores:    []int{200, 100},
 			newConnScores: []int{172, 128},
 		},
 		{
-			cpus:          []float64{0.5, 0.2},
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
 			connCounts:    []int{170, 130},
 			connScores:    []int{170, 130},
 			newConnScores: []int{142, 158},
 		},
 		{
-			cpus:          []float64{0.5, 0.2},
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
 			newConnScores: []int{172, 128},
 		},
 		{
-			cpus:          []float64{0.5, 0.2},
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
 			connCounts:    []int{200, 100},
 			connScores:    []int{0, 300},
-			newConnScores: []int{99, 201},
+			newConnScores: []int{0, 300},
 		},
 		{
-			cpus:          []float64{0.5, math.NaN()},
-			connCounts:    []int{200, 100},
-			connScores:    []int{180, 120},
-			newConnScores: []int{241, 59},
-		},
-		{
-			cpus:          []float64{math.NaN(), 0.2},
-			connCounts:    []int{200, 100},
-			connScores:    []int{180, 120},
-			newConnScores: []int{115, 185},
-		},
-		{
-			cpus:          []float64{0.5, 0.2},
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {}},
 			connCounts:    []int{200, 100},
 			connScores:    []int{180, 120},
 			newConnScores: []int{172, 128},
+		},
+		{
+			cpus:          [][]float64{{}, {}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{172, 128},
+		},
+		{
+			cpus:          [][]float64{{}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{172, 128},
+		},
+		{
+			cpus:          [][]float64{{0.5, 0.4, 0.6, 0.5, 0.5}, {0.2, 0.1, 0.2, 0.1, 0.2}},
+			connCounts:    []int{200, 100},
+			connScores:    []int{180, 120},
+			newConnScores: []int{172, 128},
+		},
+		{
+			cpus:          [][]float64{{0.8, 0.2, 0.8, 0.2}, {0.3, 0.5, 0.3, 0.5}},
+			connCounts:    []int{100, 200},
+			connScores:    []int{100, 200},
+			newConnScores: []int{100, 200},
 		},
 	}
 
@@ -180,14 +187,14 @@ func TestCPUBalanceContinuously(t *testing.T) {
 	fc := NewFactorCPU(mmr)
 	for i, test := range tests {
 		backends := make([]scoredBackend, 0, len(test.cpus))
-		values := make([]*model.Sample, 0, len(test.cpus))
+		values := make([]*model.SampleStream, 0, len(test.cpus))
 		for j := 0; j < len(test.cpus); j++ {
 			backends = append(backends, createBackend(j, test.connCounts[j], test.connScores[j]))
-			values = append(values, createSample(test.cpus[j], j))
+			values = append(values, createSampleStream(test.cpus[j], j))
 		}
 		mmr.qrs[1] = metricsreader.QueryResult{
 			UpdateTime: monotime.Now(),
-			Value:      model.Vector(values),
+			Value:      model.Matrix(values),
 		}
 		// Rebalance until it stops. The final scores should be newConnScores.
 		for k := 0; ; k++ {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #559

Problem Summary:
After replacing the EWMA algorithm with `rate[1m]`, the CPU usage is always stale. When migrating connections from A to B, the smoothed CPU usage of A is higher than B, even if the actual CPU usage of A is lower than B.

What is changed and how it works:
- Replace `rate[1m]` to `irate[30s]` to get the latest CPU usage
- Calculate the score and balance count based on the latest CPU usage
- Use the EWMA algorithm to get the smoothed average CPU usage
- When deciding whether to balance, also consider the average CPU usage to avoid CPU jittering too much

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
