### PR TITLE
metrics: set the Y axis of some metrics to logBase=2

### DIFF
--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -288,7 +288,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -766,7 +766,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -852,7 +852,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -938,7 +938,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1024,7 +1024,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1110,7 +1110,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1196,7 +1196,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1296,7 +1296,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1488,7 +1488,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1588,7 +1588,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1674,7 +1674,7 @@
                   {
                      "format": "short",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1794,7 +1794,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1880,7 +1880,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true
@@ -1966,7 +1966,7 @@
                   {
                      "format": "s",
                      "label": null,
-                     "logBase": 1,
+                     "logBase": 2,
                      "max": null,
                      "min": null,
                      "show": true

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -199,6 +199,7 @@ local uptimeP = graphPanel.new(
   datasource=myDS,
   legend_rightSide=true,
   format='s',
+  logBase1Y=2,
   description='TiProxy uptime since the last restart.',
 )
 .addTarget(
@@ -214,8 +215,9 @@ local durationP = graphPanel.new(
   title='Duration',
   datasource=myDS,
   legend_rightSide=true,
-  description='TiProxy query durations by histogram buckets with different percents.',
   format='s',
+  logBase1Y=2,
+  description='TiProxy query durations by histogram buckets with different percents.',
 )
 .addTarget(
   prometheus.target(
@@ -242,6 +244,7 @@ local durByInstP = graphPanel.new(
   legend_rightSide=true,
   description='TiProxy P99 query durations by TiProxy instances.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -256,6 +259,7 @@ local durByBackP = graphPanel.new(
   legend_rightSide=true,
   description='TiProxy P99 query durations by backends.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -270,6 +274,7 @@ local cpsByInstP = graphPanel.new(
   legend_rightSide=true,
   description='TiProxy query total statistics including both successful and failed ones.',
   format='short',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -284,6 +289,7 @@ local cpsByBackP = graphPanel.new(
   legend_rightSide=true,
   description='MySQL command statistics by backends.',
   format='short',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -298,6 +304,7 @@ local cpsByCMDP = graphPanel.new(
   legend_rightSide=true,
   description='MySQL command statistics by command type',
   format='short',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -312,6 +319,7 @@ local hsDurP= graphPanel.new(
   legend_rightSide=true,
   description='TiProxy handshake durations by different percents.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -354,6 +362,7 @@ local bMigCounterP = graphPanel.new(
   legend_rightSide=true,
   description='OPM of session migrations on all backends.',
   format='short',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -368,6 +377,7 @@ local bMigDurP = graphPanel.new(
   legend_rightSide=true,
   description='Duration of session migrations.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -394,6 +404,7 @@ local bMigReasonP = graphPanel.new(
   legend_rightSide=true,
   description='Reasons of session migrations per minute.',
   format='short',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -410,6 +421,7 @@ local bGetDurP = graphPanel.new(
   legend_rightSide=true,
   description='Duration of getting an available backend.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -436,6 +448,7 @@ local bPingBeP = graphPanel.new(
   legend_rightSide=true,
   description='Duration of Pinging backends.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(
@@ -451,6 +464,7 @@ graphPanel.new(
   legend_rightSide=true,
   description='Duration of each health check cycle.',
   format='s',
+  logBase1Y=2,
 )
 .addTarget(
   prometheus.target(


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #542 

Problem Summary:
Using log2 on the Y axis of some metrics is clearer, especially duration and CPS.

What is changed and how it works:
Update metrics json to add `logBase=2`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
