### PR TITLE
factor: query Prometheus more frequently to update metrics timely

### DIFF
--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -32,7 +32,7 @@ const (
 	healthCheckMaxRetries    = 3
 	healthCheckRetryInterval = 1 * time.Second
 	healthCheckTimeout       = 2 * time.Second
-	readMetricsInterval      = 15 * time.Second
+	readMetricsInterval      = 5 * time.Second
 	readMetricsTimeout       = 3 * time.Second
 )
 

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -144,12 +144,12 @@ func createBackend(backendIdx, connCount, connScore int) scoredBackend {
 	}
 }
 
-func createSampleStream(values []float64, backendIdx int) *model.SampleStream {
+func createSampleStream(values []float64, backendIdx int, curTime model.Time) *model.SampleStream {
 	host := strconv.Itoa(backendIdx)
 	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(host + ":10080")}
 	pairs := make([]model.SamplePair, 0, len(values))
 	for i, cpu := range values {
-		ts := model.Time(time.Now().UnixMilli() - int64(15000*(len(values)-i)))
+		ts := curTime.Add(15 * time.Second * time.Duration(i-len(values)))
 		pairs = append(pairs, model.SamplePair{Timestamp: ts, Value: model.SampleValue(cpu)})
 	}
 	return &model.SampleStream{Metric: labelSet, Values: pairs}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #562 

Problem Summary:
The refresh interval of Prometheus is 15s and the interval for TiProxy reading Prometheus is 15s. Thus, the metric delay is at most 30s.
If TiProxy reads Prometheus every 5s, the max delay is 20s.

What is changed and how it works:
- Update the reading metrics interval to 5s
- Do not update the backend snapshot if the metric of this backend is not updated, even if the whole query result is updated.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
