### PR TITLE
router, backend: pause session when last backend become unhealthy

### DIFF
--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -39,7 +39,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt := router.NewScoreBasedRouter(logger.Named("router"), true)
+	rt := router.NewScoreBasedRouter(logger.Named("router"), false)
 	healthCheckCfg := config.NewDefaultHealthCheckConfig()
 	hc := router.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	if err := rt.Init(fetcher, hc, healthCheckCfg); err != nil {

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -39,7 +39,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt := router.NewScoreBasedRouter(logger.Named("router"))
+	rt := router.NewScoreBasedRouter(logger.Named("router"), true)
 	healthCheckCfg := config.NewDefaultHealthCheckConfig()
 	hc := router.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	if err := rt.Init(fetcher, hc, healthCheckCfg); err != nil {

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -39,7 +39,7 @@ func (mgr *NamespaceManager) buildNamespace(cfg *config.Namespace) (*Namespace, 
 	} else {
 		fetcher = router.NewStaticFetcher(cfg.Backend.Instances)
 	}
-	rt := router.NewScoreBasedRouter(logger.Named("router"), false)
+	rt := router.NewScoreBasedRouter(logger.Named("router"))
 	healthCheckCfg := config.NewDefaultHealthCheckConfig()
 	hc := router.NewDefaultHealthCheck(mgr.httpCli, healthCheckCfg, logger.Named("hc"))
 	if err := rt.Init(fetcher, hc, healthCheckCfg); err != nil {

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -18,7 +18,6 @@ var _ BackendFetcher = (*StaticFetcher)(nil)
 
 // BackendFetcher is an interface to fetch the backend list.
 type BackendFetcher interface {
-	// refresh is used to force flush backend list in zero backend mode
 	GetBackendList(ctx context.Context, refresh bool) (map[string]*BackendInfo, error)
 }
 

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -18,7 +18,8 @@ var _ BackendFetcher = (*StaticFetcher)(nil)
 
 // BackendFetcher is an interface to fetch the backend list.
 type BackendFetcher interface {
-	GetBackendList(context.Context) (map[string]*BackendInfo, error)
+	// refresh is used to force flush backend list in zero backend mode
+	GetBackendList(ctx context.Context, refresh bool) (map[string]*BackendInfo, error)
 }
 
 // TopologyFetcher is an interface to fetch the tidb topology from ETCD.
@@ -42,7 +43,7 @@ func NewPDFetcher(tpFetcher TopologyFetcher, logger *zap.Logger, config *config.
 	}
 }
 
-func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInfo, error) {
+func (pf *PDFetcher) GetBackendList(ctx context.Context, _ bool) (map[string]*BackendInfo, error) {
 	backends := pf.fetchBackendList(ctx)
 	infos := make(map[string]*BackendInfo, len(backends))
 	for addr, backend := range backends {
@@ -96,7 +97,7 @@ func NewStaticFetcher(staticAddrs []string) *StaticFetcher {
 	}
 }
 
-func (sf *StaticFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+func (sf *StaticFetcher) GetBackendList(context.Context, bool) (map[string]*BackendInfo, error) {
 	return sf.backends, nil
 }
 

--- a/pkg/manager/router/backend_fetcher.go
+++ b/pkg/manager/router/backend_fetcher.go
@@ -18,6 +18,7 @@ var _ BackendFetcher = (*StaticFetcher)(nil)
 
 // BackendFetcher is an interface to fetch the backend list.
 type BackendFetcher interface {
+	// If refresh is true, it indicates their are no available backends
 	GetBackendList(ctx context.Context, refresh bool) (map[string]*BackendInfo, error)
 }
 

--- a/pkg/manager/router/backend_fetcher_test.go
+++ b/pkg/manager/router/backend_fetcher_test.go
@@ -111,7 +111,7 @@ func TestPDFetcher(t *testing.T) {
 		if test.ctx == nil {
 			test.ctx = context.Background()
 		}
-		info, err := pf.GetBackendList(test.ctx)
+		info, err := pf.GetBackendList(test.ctx, false)
 		test.check(info)
 		require.NoError(t, err)
 	}

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -144,7 +144,6 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 		startTime := monotime.Now()
 		backendInfo, err := bo.fetcher.GetBackendList(ctx, refresh)
 		refresh = false
-		// bo.logger.Info("debug GetBackendList", zap.Any("backendInfo", backendInfo))
 		if err != nil {
 			bo.logger.Error("fetching backends encounters error", zap.Error(err))
 			bo.eventReceiver.OnBackendChanged(nil, err)

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -139,9 +139,12 @@ func (bo *BackendObserver) Refresh() {
 }
 
 func (bo *BackendObserver) observe(ctx context.Context) {
+	refresh := false
 	for ctx.Err() == nil {
 		startTime := monotime.Now()
-		backendInfo, err := bo.fetcher.GetBackendList(ctx)
+		backendInfo, err := bo.fetcher.GetBackendList(ctx, refresh)
+		refresh = false
+		// bo.logger.Info("debug GetBackendList", zap.Any("backendInfo", backendInfo))
 		if err != nil {
 			bo.logger.Error("fetching backends encounters error", zap.Error(err))
 			bo.eventReceiver.OnBackendChanged(nil, err)
@@ -160,6 +163,7 @@ func (bo *BackendObserver) observe(ctx context.Context) {
 			select {
 			case <-time.After(wait):
 			case <-bo.refreshChan:
+				refresh = true
 			case <-ctx.Done():
 				return
 			}

--- a/pkg/manager/router/backend_observer.go
+++ b/pkg/manager/router/backend_observer.go
@@ -139,6 +139,8 @@ func (bo *BackendObserver) Refresh() {
 }
 
 func (bo *BackendObserver) observe(ctx context.Context) {
+	// refresh means the fetcher request is triggerd by calling Refresh() actively.
+	// It typically indicates their are no available backends.
 	refresh := false
 	for ctx.Err() == nil {
 		startTime := monotime.Now()

--- a/pkg/manager/router/backend_observer_test.go
+++ b/pkg/manager/router/backend_observer_test.go
@@ -76,7 +76,7 @@ func TestCancelObserver(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		ts.addBackend()
 	}
-	info, err := ts.fetcher.GetBackendList(context.Background())
+	info, err := ts.fetcher.GetBackendList(context.Background(), false)
 	require.NoError(t, err)
 	require.Len(t, info, 10)
 
@@ -185,7 +185,7 @@ func newMockBackendFetcher() *mockBackendFetcher {
 	}
 }
 
-func (mbf *mockBackendFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+func (mbf *mockBackendFetcher) GetBackendList(context.Context, bool) (map[string]*BackendInfo, error) {
 	mbf.Lock()
 	defer mbf.Unlock()
 	backends := make(map[string]*BackendInfo, len(mbf.backends))
@@ -218,7 +218,7 @@ func NewExternalFetcher(backendGetter func() ([]string, error)) *ExternalFetcher
 	}
 }
 
-func (ef *ExternalFetcher) GetBackendList(context.Context) (map[string]*BackendInfo, error) {
+func (ef *ExternalFetcher) GetBackendList(context.Context, bool) (map[string]*BackendInfo, error) {
 	addrs, err := ef.backendGetter()
 	return backendListToMap(addrs), err
 }

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -34,6 +34,8 @@ type Router interface {
 	ConnCount() int
 	// ServerVersion returns the TiDB version.
 	ServerVersion() string
+	// InZeroBackendMode indicates all backends unhealthy, and we have kept client connections
+	InZeroBackendMode() bool
 	Close()
 }
 
@@ -72,6 +74,7 @@ type RedirectableConn interface {
 	// Redirect returns false if the current conn is not redirectable.
 	Redirect(backend BackendInst) bool
 	ConnectionID() uint64
+	SaveSession() bool
 }
 
 // BackendInst defines a backend that a connection is redirecting to.

--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -20,6 +20,8 @@ var (
 type ConnEventReceiver interface {
 	OnRedirectSucceed(from, to string, conn RedirectableConn) error
 	OnRedirectFail(from, to string, conn RedirectableConn) error
+	OnPauseSucceed(addr string, conn RedirectableConn) error
+	OnPauseFail(addr string, conn RedirectableConn) error
 	OnConnClosed(addr string, conn RedirectableConn) error
 }
 
@@ -34,8 +36,6 @@ type Router interface {
 	ConnCount() int
 	// ServerVersion returns the TiDB version.
 	ServerVersion() string
-	// InZeroBackendMode indicates all backends unhealthy, and we have kept client connections
-	InZeroBackendMode() bool
 	Close()
 }
 
@@ -43,13 +43,15 @@ type connPhase int
 
 const (
 	// The session is never redirected.
-	phaseNotRedirected connPhase = iota
+	phaseNone connPhase = iota
 	// The session is redirecting.
 	phaseRedirectNotify
-	// The session redirected successfully last time.
-	phaseRedirectEnd
 	// The session failed to redirect last time.
 	phaseRedirectFail
+	// The session is pausing.
+	phasePauseNotify
+	// The session failed to pause last time.
+	phasePauseFail
 )
 
 const (
@@ -74,7 +76,7 @@ type RedirectableConn interface {
 	// Redirect returns false if the current conn is not redirectable.
 	Redirect(backend BackendInst) bool
 	ConnectionID() uint64
-	SaveSession() bool
+	Pause() bool
 }
 
 // BackendInst defines a backend that a connection is redirecting to.

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -33,14 +33,17 @@ type ScoreBasedRouter struct {
 	backends     *glist.List[*backendWrapper]
 	observeError error
 	// Only store the version of a random backend, so the client may see a wrong version when backends are upgrading.
-	serverVersion string
+	serverVersion     string
+	enableZeroBackend bool
+	inZeroBackendMode bool
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
-func NewScoreBasedRouter(logger *zap.Logger) *ScoreBasedRouter {
+func NewScoreBasedRouter(logger *zap.Logger, enableZeroBackend bool) *ScoreBasedRouter {
 	return &ScoreBasedRouter{
-		logger:   logger,
-		backends: glist.New[*backendWrapper](),
+		logger:            logger,
+		backends:          glist.New[*backendWrapper](),
+		enableZeroBackend: enableZeroBackend,
 	}
 }
 
@@ -314,9 +317,39 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 			backend.setHealth(*health)
 			router.adjustBackendList(be, true)
 		}
+		if health.Status == StatusHealthy {
+			router.inZeroBackendMode = false
+		}
 	}
+	// router.logger.Info(
+	// 	"debug backend change",
+	// 	zap.Int("len", router.backends.Len()),
+	// 	zap.Bool("zero_backend", router.inZeroBackendMode),
+	// 	zap.Any("backends", router.backends),
+	// )
 	if len(backends) > 0 {
 		router.updateServerVersion()
+	}
+	if router.enableZeroBackend && len(backends) > 0 {
+		inZeroBackendMode := true
+		for be := router.backends.Front(); be != nil; be = be.Next() {
+			backend := be.Value
+			if backend.Healthy() {
+				inZeroBackendMode = false
+				break
+			}
+		}
+		router.inZeroBackendMode = inZeroBackendMode
+		if inZeroBackendMode {
+			router.logger.Info("last backend become unhealthy, notify connections to save session")
+			for be := router.backends.Front(); be != nil; be = be.Next() {
+				backend := be.Value
+				for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
+					conn := ele.Value
+					conn.SaveSession()
+				}
+			}
+		}
 	}
 }
 
@@ -430,6 +463,10 @@ func (router *ScoreBasedRouter) ServerVersion() string {
 	version := router.serverVersion
 	router.Unlock()
 	return version
+}
+
+func (router *ScoreBasedRouter) InZeroBackendMode() bool {
+	return router.inZeroBackendMode
 }
 
 // Close implements Router.Close interface.

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -414,7 +414,9 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 					case phasePauseNotify:
 						continue
 					case phaseRedirectNotify:
-						router.logger.Debug("connection is redirecting, maybe a new backend is alive. skip pause")
+						// When the connection is redirecting, it won't be paused
+						router.logger.Debug("connection is redirecting, maybe a new backend is alive. skip pause",
+							zap.Uint64("connID", conn.ConnectionID()))
 						continue
 					}
 					backend.connScore--

--- a/pkg/manager/router/router_score.go
+++ b/pkg/manager/router/router_score.go
@@ -409,16 +409,15 @@ func (router *ScoreBasedRouter) OnBackendChanged(backends map[string]*BackendHea
 			for be := router.backends.Front(); be != nil; be = be.Next() {
 				backend := be.Value
 				for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
-					backend.connScore--
 					conn := ele.Value
 					switch conn.phase {
 					case phasePauseNotify:
 						continue
 					case phaseRedirectNotify:
-						router.logger.Info("connection is redirecting, maybe a new backend is alive. skip pause")
-						backend.connScore++
+						router.logger.Debug("connection is redirecting, maybe a new backend is alive. skip pause")
 						continue
 					}
+					backend.connScore--
 					conn.phase = phasePauseNotify
 					conn.Pause()
 				}

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -59,6 +59,10 @@ func (r *StaticRouter) ServerVersion() string {
 	return ""
 }
 
+func (r *StaticRouter) InZeroBackendMode() bool {
+	return false
+}
+
 func (r *StaticRouter) Close() {
 }
 

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -59,10 +59,6 @@ func (r *StaticRouter) ServerVersion() string {
 	return ""
 }
 
-func (r *StaticRouter) InZeroBackendMode() bool {
-	return false
-}
-
 func (r *StaticRouter) Close() {
 }
 
@@ -71,6 +67,14 @@ func (r *StaticRouter) OnRedirectSucceed(from, to string, conn RedirectableConn)
 }
 
 func (r *StaticRouter) OnRedirectFail(from, to string, conn RedirectableConn) error {
+	return nil
+}
+
+func (r *StaticRouter) OnPauseSucceed(addr string, conn RedirectableConn) error {
+	return nil
+}
+
+func (r *StaticRouter) OnPauseFail(addr string, conn RedirectableConn) error {
 	return nil
 }
 

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -527,27 +527,28 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 		rs.err = ErrTargetUnhealthy
 		return
 	}
+
 	backendIO := mgr.backendIO.Load()
-	var sessionStates, sessionToken string
 	if backendIO == nil {
 		mgr.logger.Info("session paused, skip redirect")
 		return
-	} else {
-		if sessionStates, sessionToken, rs.err = mgr.querySessionStates(backendIO); rs.err != nil {
-			// If the backend connection is closed, also close the client connection.
-			// Otherwise, if the client is idle, the mgr will keep retrying.
-			if errors.Is(rs.err, net.ErrClosed) || pnet.IsDisconnectError(rs.err) || errors.Is(rs.err, os.ErrDeadlineExceeded) {
-				mgr.quitSource = SrcBackendNetwork
-				if ignoredErr := mgr.clientIO.GracefulClose(); ignoredErr != nil {
-					mgr.logger.Warn("graceful close client IO error", zap.Stringer("client_addr", mgr.clientIO.RemoteAddr()), zap.Error(ignoredErr))
-				}
+	}
+
+	var sessionStates, sessionToken string
+	if sessionStates, sessionToken, rs.err = mgr.querySessionStates(backendIO); rs.err != nil {
+		// If the backend connection is closed, also close the client connection.
+		// Otherwise, if the client is idle, the mgr will keep retrying.
+		if errors.Is(rs.err, net.ErrClosed) || pnet.IsDisconnectError(rs.err) || errors.Is(rs.err, os.ErrDeadlineExceeded) {
+			mgr.quitSource = SrcBackendNetwork
+			if ignoredErr := mgr.clientIO.GracefulClose(); ignoredErr != nil {
+				mgr.logger.Warn("graceful close client IO error", zap.Stringer("client_addr", mgr.clientIO.RemoteAddr()), zap.Error(ignoredErr))
 			}
-			return
 		}
-		if ctx.Err() != nil {
-			rs.err = ctx.Err()
-			return
-		}
+		return
+	}
+	if ctx.Err() != nil {
+		rs.err = ctx.Err()
+		return
 	}
 	if rs.err = mgr.updateAuthInfoFromSessionStates(hack.Slice(sessionStates)); rs.err != nil {
 		return

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -914,13 +914,13 @@ func (mgr *BackendConnManager) resume(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	mgr.logger.Info("start to handshakeSecondTime")
+	mgr.logger.Debug("start to handshakeSecondTime")
 	if err = mgr.authenticator.handshakeSecondTime(mgr.logger, mgr.clientIO, newBackendIO, mgr.backendTLS, state.sessionToken); err == nil {
 		err = mgr.initSessionStates(newBackendIO, state.sessionStates)
 	} else {
 		mgr.handshakeHandler.OnHandshake(mgr, newBackendIO.RemoteAddr().String(), err, Error2Source(err))
 	}
-	mgr.logger.Info("finish to handshakeSecondTime")
+	mgr.logger.Debug("finish to handshakeSecondTime")
 	if err != nil {
 		if ignoredErr := newBackendIO.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
 			mgr.logger.Error("close new backend connection failed", zap.Error(ignoredErr))

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -884,7 +884,7 @@ func (mgr *BackendConnManager) notifyPauseResult(addr string, pauseErr error) {
 	if pauseErr != nil {
 		err := eventReceiver.OnPauseFail(addr, mgr)
 		mgr.logger.Warn("pause connection failed", zap.String("addr", addr),
-			zap.NamedError("redirect_err", pauseErr), zap.NamedError("notify_err", err))
+			zap.NamedError("pause_err", pauseErr), zap.NamedError("notify_err", err))
 	} else {
 		err := eventReceiver.OnPauseSucceed(addr, mgr)
 		mgr.logger.Debug("pause connection succeeds", zap.String("from", addr),

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -351,7 +351,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 	if mgr.backendIO.Load() == nil {
 		err = mgr.resume(ctx)
 		if err != nil {
-			mgr.logger.Info("resume failed", zap.Error(err))
+			mgr.logger.Error("resume failed", zap.Error(err))
 			return
 		}
 	}

--- a/pkg/proxy/backend/mock_backend_test.go
+++ b/pkg/proxy/backend/mock_backend_test.go
@@ -399,7 +399,7 @@ func (mb *mockBackend) respondSessionStates(packetIO *pnet.PacketIO) error {
 	names := []string{sessionStatesCol, sessionTokenCol}
 	values := [][]any{
 		{
-			mb.sessionStates, mockCmdStr,
+			mb.sessionStates, mockSessionToken,
 		},
 	}
 	return mb.writeResultSet(packetIO, names, values)

--- a/pkg/proxy/backend/session_states.go
+++ b/pkg/proxy/backend/session_states.go
@@ -1,0 +1,10 @@
+package backend
+
+type SessionState struct {
+	sessionStates string
+	sessionToken  string
+}
+
+type SessionToken struct {
+	Username string `json:"username"`
+}

--- a/pkg/proxy/backend/testsuite_test.go
+++ b/pkg/proxy/backend/testsuite_test.go
@@ -41,6 +41,7 @@ var (
 	mockCmdInt        = 100
 	mockCmdBytes      = []byte("01234567890123456789")
 	mockSessionStates = "{\"current-db\":\"test_db\"}"
+	mockSessionToken  = "{\"username\": \"str\"}"
 )
 
 type testConfig struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->
Problem Summary: 
- Introduce a new feature that TiProxy can pause session.

What is changed and how it works:
-  TiProxy store session states when last backend become unhealthy. 
- When the session is saved, tiproxy won't closed client connection when backend connection is closed.
- The session can be restored when client become active again to a new backend.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
