### PR TITLE
observer: fix TiProxy reports unmarshal body in healthy check failed" when TiDB is graceful shutdown

### DIFF
--- a/pkg/balance/observer/health_check_test.go
+++ b/pkg/balance/observer/health_check_test.go
@@ -23,11 +23,9 @@ func TestReadServerVersion(t *testing.T) {
 	hc := NewDefaultHealthCheck(nil, newHealthCheckConfigForTest(), lg)
 	backend, info := newBackendServer(t)
 	backend.setServerVersion("1.0")
-	//backend.serverVersion.Store("1.0")
 	health := hc.Check(context.Background(), backend.sqlAddr, info)
 	require.Equal(t, "1.0", health.ServerVersion)
 	backend.stopSQLServer()
-	//backend.serverVersion.Store("2.0")
 	backend.setServerVersion("2.0")
 	backend.startSQLServer()
 	health = hc.Check(context.Background(), backend.sqlAddr, info)
@@ -47,7 +45,7 @@ func TestReadServerVersion(t *testing.T) {
 
 // Test that the backend status is correct when the backend starts or shuts down.
 func TestHealthCheck(t *testing.T) {
-	lg, _ := logger.CreateLoggerForTest(t)
+	lg, text := logger.CreateLoggerForTest(t)
 	cfg := newHealthCheckConfigForTest()
 	hc := NewDefaultHealthCheck(nil, cfg, lg)
 	backend, info := newBackendServer(t)
@@ -65,6 +63,7 @@ func TestHealthCheck(t *testing.T) {
 	backend.setHTTPResp(false)
 	health = hc.Check(context.Background(), backend.sqlAddr, info)
 	require.False(t, health.Healthy)
+	require.NotContains(t, text.String(), "unmarshal body")
 	backend.setHTTPResp(true)
 	health = hc.Check(context.Background(), backend.sqlAddr, info)
 	require.True(t, health.Healthy)
@@ -113,6 +112,7 @@ func (srv *backendServer) setServerVersion(version string) {
 	body, _ := json.Marshal(resp)
 	srv.mockHttpHandler.setHTTPRespBody(string(body))
 }
+
 func (srv *backendServer) startHTTPServer() {
 	if srv.mockHttpHandler == nil {
 		srv.mockHttpHandler = &mockHttpHandler{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #567 

Problem Summary:
TiProxy reports unmarshal body in healthy check failed" when TiDB is graceful shutdown. It's introduced in #510 because it didn't check error correctly.

What is changed and how it works:
Return when there's an error.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
