### PR TITLE
factor: update migration speed for factors

### DIFF
--- a/pkg/balance/factor/factor.go
+++ b/pkg/balance/factor/factor.go
@@ -14,7 +14,7 @@ type Factor interface {
 	ScoreBitNum() int
 	// BalanceCount returns the count of connections to balance per second.
 	// 0 indicates the factor is already balanced.
-	BalanceCount(from, to scoredBackend) int
+	BalanceCount(from, to scoredBackend) float64
 	SetConfig(cfg *config.Config)
 	Close()
 }

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -176,7 +176,7 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 // BackendsToBalance returns the busiest/unhealthy backend and the idlest backend.
 // balanceCount: the count of connections to migrate in this round. 0 indicates no need to balance.
 // reason: the debug information to be logged.
-func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount int, reason string, logFields []zap.Field) {
+func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (from, to policy.BackendCtx, balanceCount float64, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return
 	}
@@ -217,7 +217,7 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			// backend2 factor scores: 0, 0
 			// Balancing the second factor won't make the first factor unbalanced.
 			balanceCount = factor.BalanceCount(*busiestBackend, *idlestBackend)
-			if balanceCount > 0 {
+			if balanceCount > 0.0001 {
 				break
 			}
 		} else if score1 < score2 {

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -258,7 +258,7 @@ func TestBalanceWith3Factors(t *testing.T) {
 	for tIdx, test := range tests {
 		for factorIdx, factor := range factors {
 			func(factorIdx int, factor *mockFactor) {
-				factor.balanceCount = test.balanceCounts[factorIdx]
+				factor.balanceCount = float64(test.balanceCounts[factorIdx])
 				factor.updateScore = func(backends []scoredBackend) {
 					for i := 0; i < len(backends); i++ {
 						backends[i].addScore(test.scores[i][factorIdx], factor.bitNum)

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -137,7 +137,7 @@ func TestBalanceWithOneFactor(t *testing.T) {
 		}
 		backends := createBackends(len(test.scores))
 		from, to, count, reason, _ := fm.BackendsToBalance(backends)
-		require.Equal(t, test.count, count, "test index %d", tIdx)
+		require.EqualValues(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)
 			require.Equal(t, backends[test.toIdx], to, "test index %d", tIdx)
@@ -217,7 +217,7 @@ func TestBalanceWith2Factors(t *testing.T) {
 		}
 		backends := createBackends(len(test.scores1))
 		from, to, count, _, _ := fm.BackendsToBalance(backends)
-		require.Equal(t, test.count, count, "test index %d", tIdx)
+		require.EqualValues(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)
 			require.Equal(t, backends[test.toIdx], to, "test index %d", tIdx)
@@ -268,7 +268,7 @@ func TestBalanceWith3Factors(t *testing.T) {
 		}
 		backends := createBackends(len(test.scores))
 		from, to, count, _, _ := fm.BackendsToBalance(backends)
-		require.Equal(t, test.count, count, "test index %d", tIdx)
+		require.EqualValues(t, test.count, count, "test index %d", tIdx)
 		if test.count > 0 {
 			require.Equal(t, backends[test.fromIdx], from, "test index %d", tIdx)
 			require.Equal(t, backends[test.toIdx], to, "test index %d", tIdx)

--- a/pkg/balance/factor/factor_conn.go
+++ b/pkg/balance/factor/factor_conn.go
@@ -40,7 +40,7 @@ func (fcc *FactorConnCount) ScoreBitNum() int {
 	return fcc.bitNum
 }
 
-func (fcc *FactorConnCount) BalanceCount(from, to scoredBackend) int {
+func (fcc *FactorConnCount) BalanceCount(from, to scoredBackend) float64 {
 	if float64(from.ConnScore()) > float64(to.ConnScore()+1)*connBalancedRatio {
 		return balanceCount4Conn
 	}

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -208,17 +208,14 @@ func (fc *FactorCPU) ScoreBitNum() int {
 	return fc.bitNum
 }
 
-func (fc *FactorCPU) BalanceCount(from, to scoredBackend) int {
+func (fc *FactorCPU) BalanceCount(from, to scoredBackend) float64 {
 	fromAvgUsage, fromLatestUsage := fc.getUsage(from)
 	toAvgUsage, toLatestUsage := fc.getUsage(to)
 	// The higher the CPU usage, the more sensitive the load balance should be.
 	// E.g. 10% vs 25% don't need rebalance, but 80% vs 95% need rebalance.
 	// Use the average usage to avoid thrash when CPU jitters too much and use the latest usage to avoid migrate too many connections.
 	if 1.3-toAvgUsage > (1.3-fromAvgUsage)*cpuBalancedRatio && 1.3-toLatestUsage > (1.3-fromLatestUsage)*cpuBalancedRatio {
-		if balanceCount := int(1 / fc.usagePerConn / balanceRatio4Cpu); balanceCount > 1 {
-			return balanceCount
-		}
-		return 1
+		return 1 / fc.usagePerConn / balanceRatio4Cpu
 	}
 	return 0
 }

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -209,8 +209,8 @@ func TestCPUBalanceContinuously(t *testing.T) {
 			if balanceCount == 0 {
 				break
 			}
-			backends[len(backends)-1].BackendCtx.(*mockBackend).connScore -= balanceCount
-			backends[0].BackendCtx.(*mockBackend).connScore += balanceCount
+			backends[len(backends)-1].BackendCtx.(*mockBackend).connScore -= int(balanceCount)
+			backends[0].BackendCtx.(*mockBackend).connScore += int(balanceCount)
 		}
 		connScores := make([]int, len(test.connScores))
 		for _, backend := range backends {

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -17,59 +17,59 @@ import (
 
 func TestCPUBalanceOnce(t *testing.T) {
 	tests := []struct {
-		cpus         [][]float64
-		scoreOrder   []int
-		balanceCount int
+		cpus       [][]float64
+		scoreOrder []int
+		balanced   bool
 	}{
 		{
-			cpus:         [][]float64{{0}, {0.2}},
-			scoreOrder:   []int{0, 1},
-			balanceCount: 0,
+			cpus:       [][]float64{{0}, {0.2}},
+			scoreOrder: []int{0, 1},
+			balanced:   true,
 		},
 		{
-			cpus:         [][]float64{{1, 0.5, 0.25}, {0, 0.25, 0.5}, {0, 0, 0}, {1, 1, 1}},
-			scoreOrder:   []int{2, 0, 1, 3},
-			balanceCount: 1,
+			cpus:       [][]float64{{1, 0.5, 0.25}, {0, 0.25, 0.5}, {0, 0, 0}, {1, 1, 1}},
+			scoreOrder: []int{2, 0, 1, 3},
+			balanced:   false,
 		},
 		{
-			cpus:         [][]float64{{0.25}, {}, {0.5}},
-			scoreOrder:   []int{0, 2, 1},
-			balanceCount: 1,
+			cpus:       [][]float64{{0.25}, {}, {0.5}},
+			scoreOrder: []int{0, 2, 1},
+			balanced:   false,
 		},
 		{
-			cpus:         [][]float64{{0.95, 0.92, 0.93, 0.94, 0.92, 0.94}, {0.81, 0.79, 0.82, 0.83, 0.76, 0.78}},
-			scoreOrder:   []int{1, 0},
-			balanceCount: 1,
+			cpus:       [][]float64{{0.95, 0.92, 0.93, 0.94, 0.92, 0.94}, {0.81, 0.79, 0.82, 0.83, 0.76, 0.78}},
+			scoreOrder: []int{1, 0},
+			balanced:   false,
 		},
 		{
-			cpus:         [][]float64{{0.35, 0.42, 0.37, 0.45, 0.42, 0.44}, {0.56, 0.62, 0.58, 0.57, 0.59, 0.63}},
-			scoreOrder:   []int{0, 1},
-			balanceCount: 1,
+			cpus:       [][]float64{{0.35, 0.42, 0.37, 0.45, 0.42, 0.44}, {0.56, 0.62, 0.58, 0.57, 0.59, 0.63}},
+			scoreOrder: []int{0, 1},
+			balanced:   false,
 		},
 		{
-			cpus:         [][]float64{{0, 0.1, 0, 0.1}, {0.15, 0.1, 0.15, 0.15}, {0.1, 0, 0.1, 0}},
-			scoreOrder:   []int{2, 0, 1},
-			balanceCount: 0,
+			cpus:       [][]float64{{0, 0.1, 0, 0.1}, {0.15, 0.1, 0.15, 0.15}, {0.1, 0, 0.1, 0}},
+			scoreOrder: []int{2, 0, 1},
+			balanced:   true,
 		},
 		{
-			cpus:         [][]float64{{0.5}, {}, {0.1, 0.3, 0.4}},
-			scoreOrder:   []int{2, 0, 1},
-			balanceCount: 1,
+			cpus:       [][]float64{{0.5}, {}, {0.1, 0.3, 0.4}},
+			scoreOrder: []int{2, 0, 1},
+			balanced:   false,
 		},
 		{
-			cpus:         [][]float64{{1.0}, {0.97}},
-			scoreOrder:   []int{1, 0},
-			balanceCount: 0,
+			cpus:       [][]float64{{1.0}, {0.97}},
+			scoreOrder: []int{1, 0},
+			balanced:   true,
 		},
 		{
-			cpus:         [][]float64{{0.8, 0.2, 0.8, 0.2}, {0.3, 0.5, 0.3, 0.5}},
-			scoreOrder:   []int{0, 1},
-			balanceCount: 0,
+			cpus:       [][]float64{{0.8, 0.2, 0.8, 0.2}, {0.3, 0.5, 0.3, 0.5}},
+			scoreOrder: []int{0, 1},
+			balanced:   true,
 		},
 		{
-			cpus:         [][]float64{{1.0}, {0.9}, {0.8}, {0.7}, {0.6}, {0.5}, {0.4}, {0.3}, {0.1}},
-			scoreOrder:   []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
-			balanceCount: 1,
+			cpus:       [][]float64{{1.0}, {0.9}, {0.8}, {0.7}, {0.6}, {0.5}, {0.4}, {0.3}, {0.1}},
+			scoreOrder: []int{8, 7, 6, 5, 4, 3, 2, 1, 0},
+			balanced:   false,
 		},
 	}
 
@@ -99,7 +99,7 @@ func TestCPUBalanceOnce(t *testing.T) {
 		require.Equal(t, test.scoreOrder, sortedIdx, "test index %d", i)
 		from, to := backends[len(backends)-1], backends[0]
 		balanceCount := fc.BalanceCount(from, to)
-		require.Equal(t, test.balanceCount, balanceCount, "test index %d", i)
+		require.Equal(t, test.balanced, balanceCount < 0.0001, "test index %d", i)
 	}
 }
 
@@ -209,8 +209,9 @@ func TestCPUBalanceContinuously(t *testing.T) {
 			if balanceCount == 0 {
 				break
 			}
-			backends[len(backends)-1].BackendCtx.(*mockBackend).connScore -= int(balanceCount)
-			backends[0].BackendCtx.(*mockBackend).connScore += int(balanceCount)
+			count := int(balanceCount + 0.9999)
+			backends[len(backends)-1].BackendCtx.(*mockBackend).connScore -= count
+			backends[0].BackendCtx.(*mockBackend).connScore += count
 		}
 		connScores := make([]int, len(test.connScores))
 		for _, backend := range backends {

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -16,7 +16,7 @@ import (
 const (
 	errMetricExpDuration = 1 * time.Minute
 	// balanceSeconds4Health indicates the time (in seconds) to migrate all the connections.
-	balanceSeconds4Health = 10
+	balanceSeconds4Health = 5
 )
 
 type valueRange int

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -239,22 +239,22 @@ func TestHealthBalanceCount(t *testing.T) {
 		{
 			conns:    []int{100, 10},
 			minCount: 5,
-			maxCount: 20,
+			maxCount: 40,
 		},
 		{
 			conns:    []int{1000, 100},
-			minCount: 50,
-			maxCount: 300,
+			minCount: 100,
+			maxCount: 400,
 		},
 		{
 			conns:    []int{100, 1000},
-			minCount: 50,
-			maxCount: 200,
+			minCount: 100,
+			maxCount: 400,
 		},
 		{
 			conns:    []int{10000, 10000},
-			minCount: 500,
-			maxCount: 2000,
+			minCount: 1000,
+			maxCount: 4000,
 		},
 	}
 

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -244,17 +244,17 @@ func TestHealthBalanceCount(t *testing.T) {
 		{
 			conns:    []int{1000, 100},
 			minCount: 50,
-			maxCount: 100,
+			maxCount: 300,
 		},
 		{
 			conns:    []int{100, 1000},
 			minCount: 50,
-			maxCount: 100,
+			maxCount: 200,
 		},
 		{
 			conns:    []int{10000, 10000},
 			minCount: 500,
-			maxCount: 1000,
+			maxCount: 2000,
 		},
 	}
 

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -217,72 +217,63 @@ func TestNoHealthMetrics(t *testing.T) {
 
 func TestHealthBalanceCount(t *testing.T) {
 	tests := []struct {
-		conns    []int
-		minCount int
-		maxCount int
+		conn    int
+		healthy bool
+		count   float64
 	}{
 		{
-			conns:    []int{1, 0},
-			minCount: 1,
-			maxCount: 1,
+			conn:    100,
+			healthy: false,
+			count:   100 / balanceSeconds4Health,
 		},
 		{
-			conns:    []int{10, 0},
-			minCount: 1,
-			maxCount: 4,
+			conn:    50,
+			healthy: false,
+			count:   100 / balanceSeconds4Health,
 		},
 		{
-			conns:    []int{10, 10},
-			minCount: 1,
-			maxCount: 4,
+			conn:    100,
+			healthy: true,
+			count:   0,
 		},
 		{
-			conns:    []int{100, 10},
-			minCount: 5,
-			maxCount: 40,
-		},
-		{
-			conns:    []int{1000, 100},
-			minCount: 100,
-			maxCount: 400,
-		},
-		{
-			conns:    []int{100, 1000},
-			minCount: 100,
-			maxCount: 400,
-		},
-		{
-			conns:    []int{10000, 10000},
-			minCount: 1000,
-			maxCount: 4000,
+			conn:    50,
+			healthy: false,
+			count:   50 / balanceSeconds4Health,
 		},
 	}
 
-	values := []*model.Sample{
-		createSample(99999999, 0),
-		createSample(0, 1),
-	}
+	backends := make([]scoredBackend, 0, 2)
+	backends = append(backends, createBackend(0, 0, 0))
+	backends = append(backends, createBackend(1, 0, 0))
+	unhealthyBackend := backends[0].BackendCtx.(*mockBackend)
 	mmr := &mockMetricsReader{
-		qrs: map[uint64]metricsreader.QueryResult{
-			1: {
-				UpdateTime: monotime.Now(),
-				Value:      model.Vector(values),
-			},
-			2: {
-				UpdateTime: monotime.Now(),
-				Value:      model.Vector(values),
-			},
-		},
+		qrs: map[uint64]metricsreader.QueryResult{},
 	}
 	fh := NewFactorHealth(mmr)
-	for i, test := range tests {
-		backends := []scoredBackend{
-			createBackend(0, test.conns[0], test.conns[0]),
-			createBackend(1, test.conns[1], test.conns[1]),
+	updateMmr := func(healthy bool) {
+		number := 0.0
+		if !healthy {
+			number = 99999999.0
 		}
+		values := []*model.Sample{
+			createSample(number, 0),
+			createSample(0, 1),
+		}
+		mmr.qrs[1] = metricsreader.QueryResult{
+			UpdateTime: monotime.Now(),
+			Value:      model.Vector(values),
+		}
+		mmr.qrs[2] = mmr.qrs[1]
+	}
+	for i, test := range tests {
+		updateMmr(test.healthy)
+		unhealthyBackend.connScore = test.conn
 		fh.UpdateScore(backends)
+		if test.count == 0 {
+			continue
+		}
 		count := fh.BalanceCount(backends[0], backends[1])
-		require.GreaterOrEqual(t, count, test.minCount, "test idx: %d", i)
-		require.LessOrEqual(t, count, test.maxCount, "test idx: %d", i)
+		require.Equal(t, test.count, count, "test idx: %d", i)
 	}
 }

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -82,44 +82,49 @@ func TestHealthScore(t *testing.T) {
 
 func TestHealthBalance(t *testing.T) {
 	tests := []struct {
-		errCounts    [][]float64
-		scores       []uint64
-		balanceCount int
+		errCounts [][]float64
+		scores    []uint64
+		balanced  bool
 	}{
 		{
 			errCounts: [][]float64{{math.NaN(), math.NaN()}, {math.NaN(), math.NaN()}},
 			scores:    []uint64{0, 0},
+			balanced:  true,
 		},
 		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].recoverThreshold + 1), float64(errDefinitions[1].recoverThreshold - 1)},
 				{math.NaN(), math.NaN()}},
-			scores: []uint64{1, 0},
+			scores:   []uint64{1, 0},
+			balanced: true,
 		},
 		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].recoverThreshold + 1), float64(errDefinitions[1].recoverThreshold - 1)},
 				{float64(errDefinitions[0].recoverThreshold + 1), float64(errDefinitions[1].recoverThreshold - 1)}},
-			scores: []uint64{1, 1},
+			scores:   []uint64{1, 1},
+			balanced: true,
 		},
 		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].recoverThreshold - 1), float64(errDefinitions[1].recoverThreshold - 1)},
 				{float64(errDefinitions[0].recoverThreshold + 1), float64(errDefinitions[1].recoverThreshold - 1)}},
-			scores: []uint64{0, 1},
+			scores:   []uint64{0, 1},
+			balanced: true,
 		},
 		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].failThreshold + 1), float64(errDefinitions[1].recoverThreshold + 1)},
 				{float64(errDefinitions[0].recoverThreshold + 1), float64(errDefinitions[1].recoverThreshold - 1)}},
-			scores: []uint64{2, 1},
+			scores:   []uint64{2, 1},
+			balanced: true,
 		},
 		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].failThreshold + 1), float64(errDefinitions[1].recoverThreshold + 1)},
 				{float64(errDefinitions[0].recoverThreshold - 1), float64(errDefinitions[1].recoverThreshold - 1)}},
-			scores:       []uint64{2, 0},
-			balanceCount: 1,
+			scores:   []uint64{2, 0},
+			balanced: false,
 		},
 	}
 
@@ -128,7 +133,7 @@ func TestHealthBalance(t *testing.T) {
 		values1 := make([]*model.Sample, 0, len(test.errCounts))
 		values2 := make([]*model.Sample, 0, len(test.errCounts))
 		for j := 0; j < len(test.errCounts); j++ {
-			backends = append(backends, createBackend(j, 0, 0))
+			backends = append(backends, createBackend(j, 100, 100))
 			values1 = append(values1, createSample(test.errCounts[j][0], j))
 			values2 = append(values2, createSample(test.errCounts[j][1], j))
 		}
@@ -156,7 +161,7 @@ func TestHealthBalance(t *testing.T) {
 		})
 		from, to := backends[len(backends)-1], backends[0]
 		balanceCount := fh.BalanceCount(from, to)
-		require.Equal(t, test.balanceCount, balanceCount, "test index %d", i)
+		require.Equal(t, test.balanced, balanceCount < 0.0001, "test index %d", i)
 	}
 }
 

--- a/pkg/balance/factor/factor_label.go
+++ b/pkg/balance/factor/factor_label.go
@@ -49,7 +49,7 @@ func (fl *FactorLabel) ScoreBitNum() int {
 	return fl.bitNum
 }
 
-func (fl *FactorLabel) BalanceCount(from, to scoredBackend) int {
+func (fl *FactorLabel) BalanceCount(from, to scoredBackend) float64 {
 	return balanceCount4Label
 }
 

--- a/pkg/balance/factor/factor_location.go
+++ b/pkg/balance/factor/factor_location.go
@@ -43,7 +43,7 @@ func (fl *FactorLocation) ScoreBitNum() int {
 	return fl.bitNum
 }
 
-func (fl *FactorLocation) BalanceCount(from, to scoredBackend) int {
+func (fl *FactorLocation) BalanceCount(from, to scoredBackend) float64 {
 	return balanceCount4Location
 }
 

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -21,7 +21,7 @@ const (
 	// balanceSeconds4HighMemory indicates the time (in seconds) to migrate all the connections when memory is high.
 	balanceSeconds4HighMemory = 60
 	// balanceSeconds4OOMRisk indicates the time (in seconds) to migrate all the connections when there's an OOM risk.
-	balanceSeconds4OOMRisk = 10
+	balanceSeconds4OOMRisk = 5
 )
 
 var _ Factor = (*FactorCPU)(nil)

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -19,9 +19,9 @@ const (
 	// If some metrics are missing, we use the old one temporarily for no longer than memMetricExpDuration.
 	memMetricExpDuration = 1 * time.Minute
 	// balanceSeconds4HighMemory indicates the time (in seconds) to migrate all the connections when memory is high.
-	balanceSeconds4HighMemory = 60
+	balanceSeconds4HighMemory = 60.0
 	// balanceSeconds4OOMRisk indicates the time (in seconds) to migrate all the connections when there's an OOM risk.
-	balanceSeconds4OOMRisk = 5
+	balanceSeconds4OOMRisk = 5.0
 )
 
 var _ Factor = (*FactorCPU)(nil)
@@ -50,10 +50,28 @@ var (
 	}
 )
 
+// 2: high risk
+// 1: low risk
+// 0: no risk
+func getRiskLevel(usage float64, timeToOOM time.Duration) (int, bool) {
+	level := 0
+	for j := 0; j < len(oomRiskLevels); j++ {
+		if timeToOOM < oomRiskLevels[j].timeToOOM {
+			return len(oomRiskLevels) - j, true
+		}
+		if usage > oomRiskLevels[j].memUsage {
+			return len(oomRiskLevels) - j, false
+		}
+	}
+	return level, false
+}
+
 type memBackendSnapshot struct {
 	updatedTime time.Time
 	memUsage    float64
 	timeToOOM   time.Duration
+	// Record the balance count when the backend has OOM risk so that it won't be smaller in the next rounds.
+	balanceCount float64
 }
 
 type FactorMemory struct {
@@ -120,27 +138,27 @@ func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []
 		// If a backend exists in metrics but not in the backend list, ignore it for this round.
 		// The backend will be in the next round if it's healthy.
 		pairs := qr.GetSamplePair4Backend(backend)
+		snapshot, existsSnapshot := fm.snapshot[addr]
 		if len(pairs) > 0 {
 			updateTime := time.UnixMilli(int64(pairs[len(pairs)-1].Timestamp))
 			// If this backend is not updated, ignore it.
-			if snapshot, ok := fm.snapshot[addr]; !ok || snapshot.updatedTime.Before(updateTime) {
+			if !existsSnapshot || snapshot.updatedTime.Before(updateTime) {
 				latestUsage, timeToOOM := calcMemUsage(pairs)
 				if latestUsage >= 0 {
 					snapshots[addr] = memBackendSnapshot{
-						updatedTime: updateTime,
-						memUsage:    latestUsage,
-						timeToOOM:   timeToOOM,
+						updatedTime:  updateTime,
+						memUsage:     latestUsage,
+						timeToOOM:    timeToOOM,
+						balanceCount: fm.calcBalanceCount(backend, latestUsage, timeToOOM),
 					}
 					valid = true
 				}
 			}
 		}
 		// Merge the old snapshot just in case some metrics have missed for a short period.
-		if !valid {
-			if snapshot, ok := fm.snapshot[addr]; ok {
-				if time.Since(snapshot.updatedTime) < memMetricExpDuration {
-					snapshots[addr] = snapshot
-				}
+		if !valid && existsSnapshot {
+			if time.Since(snapshot.updatedTime) < memMetricExpDuration {
+				snapshots[addr] = snapshot
 			}
 		}
 	}
@@ -190,29 +208,12 @@ func (fm *FactorMemory) calcMemScore(addr string) (int, bool) {
 	if !ok || usage < 0 {
 		return 0, false
 	}
-	score := 0
-	for j := 0; j < len(oomRiskLevels); j++ {
-		if timeToOOM < oomRiskLevels[j].timeToOOM {
-			return len(oomRiskLevels) - j, true
-		}
-		if usage > oomRiskLevels[j].memUsage {
-			return len(oomRiskLevels) - j, false
-		}
-	}
-	return score, false
+	return getRiskLevel(usage, timeToOOM)
 }
 
-func (fm *FactorMemory) ScoreBitNum() int {
-	return fm.bitNum
-}
-
-func (fm *FactorMemory) BalanceCount(from, to scoredBackend) int {
-	// The risk level may change frequently, e.g. last time timeToOOM was 30s and connections were migrated away,
-	// then this time it becomes 60s and the connections are migrated back.
-	// So we only rebalance when the difference of risk levels of 2 backends is big enough.
-	fromScore, isOOM := fm.calcMemScore(from.Addr())
-	toScore, _ := fm.calcMemScore(to.Addr())
-	if fromScore-toScore <= 1 {
+func (fm *FactorMemory) calcBalanceCount(backend scoredBackend, usage float64, timeToOOM time.Duration) float64 {
+	score, isOOM := getRiskLevel(usage, timeToOOM)
+	if score < 2 {
 		return 0
 	}
 	// Assuming all backends have high memory and the user scales out a new backend, we don't want all the connections
@@ -221,13 +222,28 @@ func (fm *FactorMemory) BalanceCount(from, to scoredBackend) int {
 	if isOOM {
 		seconds = balanceSeconds4OOMRisk
 	}
-	// We wish the connections to be migrated in time but only a few are migrated in each round.
-	// The formula is the same as FactorStatus.
-	connCount := from.ConnScore()
-	if to.ConnScore() > connCount {
-		connCount = to.ConnScore()
+	balanceCount := float64(backend.ConnScore()) / seconds
+	// If the migration started eariler, reuse the balance count.
+	if snapshot := fm.snapshot[backend.Addr()]; snapshot.balanceCount > balanceCount {
+		return snapshot.balanceCount
 	}
-	return connCount/seconds + 1
+	return balanceCount
+}
+
+func (fm *FactorMemory) ScoreBitNum() int {
+	return fm.bitNum
+}
+
+func (fm *FactorMemory) BalanceCount(from, to scoredBackend) float64 {
+	// The risk level may change frequently, e.g. last time timeToOOM was 30s and connections were migrated away,
+	// then this time it becomes 60s and the connections are migrated back.
+	// So we only rebalance when the difference of risk levels of 2 backends is big enough.
+	fromScore, _ := fm.calcMemScore(from.Addr())
+	toScore, _ := fm.calcMemScore(to.Addr())
+	if fromScore-toScore <= 1 {
+		return 0
+	}
+	return fm.snapshot[from.Addr()].balanceCount
 }
 
 func (fm *FactorMemory) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -221,14 +221,13 @@ func (fm *FactorMemory) BalanceCount(from, to scoredBackend) int {
 	if isOOM {
 		seconds = balanceSeconds4OOMRisk
 	}
-	// Assuming that the source and target backends have similar connections at first.
-	// We wish the connections to be migrated in 10 seconds but only a few are migrated in each round.
-	// If we use from.ConnScore() / 10, the migration will be slower and slower.
-	conns := (from.ConnScore() + to.ConnScore()) / (seconds * 2)
-	if conns > 0 {
-		return conns
+	// We wish the connections to be migrated in time but only a few are migrated in each round.
+	// The formula is the same as FactorStatus.
+	connCount := from.ConnScore()
+	if to.ConnScore() > connCount {
+		connCount = to.ConnScore()
 	}
-	return 1
+	return connCount/seconds + 1
 }
 
 func (fm *FactorMemory) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -109,44 +109,44 @@ func TestMemoryScore(t *testing.T) {
 
 func TestMemoryBalance(t *testing.T) {
 	tests := []struct {
-		memory       [][]float64
-		scores       []uint64
-		balanceCount int
+		memory   [][]float64
+		scores   []uint64
+		balanced bool
 	}{
 		{
-			memory:       [][]float64{{0.2, 0.3}, {0.3, 0.4}},
-			scores:       []uint64{1, 1},
-			balanceCount: 0,
+			memory:   [][]float64{{0.2, 0.3}, {0.3, 0.4}},
+			scores:   []uint64{1, 1},
+			balanced: true,
 		},
 		{
-			memory:       [][]float64{{0.21, 0.22}, {0.5, 0.55}},
-			scores:       []uint64{0, 1},
-			balanceCount: 0,
+			memory:   [][]float64{{0.21, 0.22}, {0.5, 0.55}},
+			scores:   []uint64{0, 1},
+			balanced: true,
 		},
 		{
-			memory:       [][]float64{{0.5, 0.7}, {0.71, 0.74}},
-			scores:       []uint64{2, 1},
-			balanceCount: 0,
+			memory:   [][]float64{{0.5, 0.7}, {0.71, 0.74}},
+			scores:   []uint64{2, 1},
+			balanced: true,
 		},
 		{
-			memory:       [][]float64{{0.85, 0.75}, {0.85, 0.85}},
-			scores:       []uint64{1, 2},
-			balanceCount: 0,
+			memory:   [][]float64{{0.85, 0.75}, {0.85, 0.85}},
+			scores:   []uint64{1, 2},
+			balanced: true,
 		},
 		{
-			memory:       [][]float64{{0.6, 0.75}, {0.81, 0.82}},
-			scores:       []uint64{2, 2},
-			balanceCount: 0,
+			memory:   [][]float64{{0.6, 0.75}, {0.81, 0.82}},
+			scores:   []uint64{2, 2},
+			balanced: true,
 		},
 		{
-			memory:       [][]float64{{0.2, 0.15}, {0.81, 0.82}},
-			scores:       []uint64{0, 2},
-			balanceCount: 1,
+			memory:   [][]float64{{0.2, 0.15}, {0.81, 0.82}},
+			scores:   []uint64{0, 2},
+			balanced: false,
 		},
 		{
-			memory:       [][]float64{{0.2, 0.15}, {0.81, 0.82}, {0.65, 0.65}},
-			scores:       []uint64{0, 2, 1},
-			balanceCount: 1,
+			memory:   [][]float64{{0.2, 0.15}, {0.81, 0.82}, {0.65, 0.65}},
+			scores:   []uint64{0, 2, 1},
+			balanced: false,
 		},
 	}
 
@@ -154,7 +154,7 @@ func TestMemoryBalance(t *testing.T) {
 		backends := make([]scoredBackend, 0, len(test.memory))
 		values := make([]*model.SampleStream, 0, len(test.memory))
 		for j := 0; j < len(test.memory); j++ {
-			backends = append(backends, createBackend(j, 0, 0))
+			backends = append(backends, createBackend(j, 100, 100))
 			values = append(values, createSampleStream(test.memory[j], j, model.Now()))
 		}
 		mmr := &mockMetricsReader{
@@ -177,7 +177,7 @@ func TestMemoryBalance(t *testing.T) {
 		})
 		from, to := backends[len(backends)-1], backends[0]
 		balanceCount := fm.BalanceCount(from, to)
-		require.Equal(t, test.balanceCount, balanceCount, "test index %d", i)
+		require.EqualValues(t, test.balanced, balanceCount < 0.0001, "test index %d", i)
 	}
 }
 

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -249,17 +249,17 @@ func TestMemoryBalanceCount(t *testing.T) {
 		},
 		{
 			conns:                []int{1000, 100},
-			oomCountRange:        []int{50, 100},
+			oomCountRange:        []int{50, 200},
 			highMemoryCountRange: []int{5, 50},
 		},
 		{
 			conns:                []int{100, 1000},
-			oomCountRange:        []int{50, 100},
+			oomCountRange:        []int{50, 200},
 			highMemoryCountRange: []int{5, 50},
 		},
 		{
 			conns:                []int{10000, 10000},
-			oomCountRange:        []int{500, 1000},
+			oomCountRange:        []int{500, 2000},
 			highMemoryCountRange: []int{50, 500},
 		},
 	}

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -244,22 +244,22 @@ func TestMemoryBalanceCount(t *testing.T) {
 		},
 		{
 			conns:                []int{100, 10},
-			oomCountRange:        []int{5, 20},
+			oomCountRange:        []int{10, 40},
 			highMemoryCountRange: []int{1, 5},
 		},
 		{
 			conns:                []int{1000, 100},
-			oomCountRange:        []int{50, 200},
+			oomCountRange:        []int{100, 400},
 			highMemoryCountRange: []int{5, 50},
 		},
 		{
 			conns:                []int{100, 1000},
-			oomCountRange:        []int{50, 200},
+			oomCountRange:        []int{100, 400},
 			highMemoryCountRange: []int{5, 50},
 		},
 		{
 			conns:                []int{10000, 10000},
-			oomCountRange:        []int{500, 2000},
+			oomCountRange:        []int{1000, 4000},
 			highMemoryCountRange: []int{50, 500},
 		},
 	}

--- a/pkg/balance/factor/factor_status.go
+++ b/pkg/balance/factor/factor_status.go
@@ -7,19 +7,29 @@ import "github.com/pingcap/tiproxy/lib/config"
 
 const (
 	// balanceSeconds4Status indicates the time (in seconds) to migrate all the connections.
-	// A typical TiDB graceful shutdown time is 15s. The health check delay is 3s and we have at most 12s.
-	balanceSeconds4Status = 5
+	// A typical TiDB graceful shutdown time is 15s. The health check delay is 3s and the max transaction duration may be seconds.
+	// We need to migrate connections in time but it can't be too fast because the table statistics of the target backend
+	// may be loaded slowly.
+	balanceSeconds4Status = 5.0
 )
+
+// The snapshot of backend data of the last round.
+type statusBackendSnapshot struct {
+	// Record the balance count when the backend becomes unhealthy so that it won't be smaller in the next rounds.
+	balanceCount float64
+}
 
 var _ Factor = (*FactorStatus)(nil)
 
 type FactorStatus struct {
-	bitNum int
+	snapshot map[string]statusBackendSnapshot
+	bitNum   int
 }
 
 func NewFactorStatus() *FactorStatus {
 	return &FactorStatus{
-		bitNum: 1,
+		bitNum:   1,
+		snapshot: make(map[string]statusBackendSnapshot),
 	}
 }
 
@@ -28,6 +38,7 @@ func (fs *FactorStatus) Name() string {
 }
 
 func (fs *FactorStatus) UpdateScore(backends []scoredBackend) {
+	fs.updateSnapshot(backends)
 	for i := 0; i < len(backends); i++ {
 		score := 0
 		if !backends[i].Healthy() {
@@ -37,26 +48,32 @@ func (fs *FactorStatus) UpdateScore(backends []scoredBackend) {
 	}
 }
 
+func (fs *FactorStatus) updateSnapshot(backends []scoredBackend) {
+	snapshots := make(map[string]statusBackendSnapshot, len(backends))
+	for i := 0; i < len(backends); i++ {
+		var balanceCount float64
+		addr := backends[i].Addr()
+		if !backends[i].Healthy() {
+			snapshot, existSnapshot := fs.snapshot[addr]
+			if existSnapshot && snapshot.balanceCount > 0.0001 {
+				balanceCount = snapshot.balanceCount
+			} else {
+				balanceCount = float64(backends[i].ConnScore()) / balanceSeconds4Status
+			}
+		}
+		snapshots[addr] = statusBackendSnapshot{
+			balanceCount: balanceCount,
+		}
+	}
+	fs.snapshot = snapshots
+}
+
 func (fs *FactorStatus) ScoreBitNum() int {
 	return fs.bitNum
 }
 
-func (fs *FactorStatus) BalanceCount(from, to scoredBackend) int {
-	// We wish the connections to be migrated in 5 seconds but only a few are migrated in each round.
-	// Recording the balance count at the first migration will make the factor stateful and complicated.
-	// We wish to calcuate the balance count only based on the parameters passed in.
-	//
-	// Assuming A has 28 connections and B has 0 connection. We're migrating all connections from A to B in 5s.
-	// If we use from / 5 + 1, each migration will be 6, 5, 4, 3, 3, 2, 2, 1, 1, 1. It takes 10 seconds.
-	// If we use (from+to) / 10 + 1, each migration will be 3, 3, 3, 3, 3, 3, 3, 3, 3, 1. It takes 10 seconds.
-	// If we use the max value of the 2 formula, each migration will be 6, 5, 4, 3, 3, 3, 3, 1. It takes 8 seconds.
-	// If we use max(from, to) / 5 + 1, each migration will be 6, 5, 4, 4, 4, 5. It takes 6 seconds.
-	// If we use (from+to) / 5 + 1, the migration is too fast if A and B has similar connection counts at first.
-	connCount := from.ConnScore()
-	if to.ConnScore() > connCount {
-		connCount = to.ConnScore()
-	}
-	return connCount/balanceSeconds4Status + 1
+func (fs *FactorStatus) BalanceCount(from, to scoredBackend) float64 {
+	return fs.snapshot[from.Addr()].balanceCount
 }
 
 func (fs *FactorStatus) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_status.go
+++ b/pkg/balance/factor/factor_status.go
@@ -51,6 +51,7 @@ func (fs *FactorStatus) BalanceCount(from, to scoredBackend) int {
 	// If we use (from+to) / 10 + 1, each migration will be 3, 3, 3, 3, 3, 3, 3, 3, 3, 1. It takes 10 seconds.
 	// If we use the max value of the 2 formula, each migration will be 6, 5, 4, 3, 3, 3, 3, 1. It takes 8 seconds.
 	// If we use max(from, to) / 5 + 1, each migration will be 6, 5, 4, 4, 4, 5. It takes 6 seconds.
+	// If we use (from+to) / 5 + 1, the migration is too fast if A and B has similar connection counts at first.
 	connCount := from.ConnScore()
 	if to.ConnScore() > connCount {
 		connCount = to.ConnScore()

--- a/pkg/balance/factor/factor_status_test.go
+++ b/pkg/balance/factor/factor_status_test.go
@@ -69,17 +69,17 @@ func TestStatusBalanceCount(t *testing.T) {
 		{
 			conns:    []int{1000, 100},
 			minCount: 100,
-			maxCount: 200,
+			maxCount: 300,
 		},
 		{
 			conns:    []int{100, 1000},
 			minCount: 100,
-			maxCount: 200,
+			maxCount: 300,
 		},
 		{
 			conns:    []int{10000, 10000},
 			minCount: 1000,
-			maxCount: 2000,
+			maxCount: 3000,
 		},
 	}
 

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -62,7 +62,7 @@ var _ Factor = (*mockFactor)(nil)
 
 type mockFactor struct {
 	bitNum       int
-	balanceCount int
+	balanceCount float64
 	updateScore  func(backends []scoredBackend)
 	cfg          *config.Config
 }
@@ -79,7 +79,7 @@ func (mf *mockFactor) ScoreBitNum() int {
 	return mf.bitNum
 }
 
-func (mf *mockFactor) BalanceCount(from, to scoredBackend) int {
+func (mf *mockFactor) BalanceCount(from, to scoredBackend) float64 {
 	return mf.balanceCount
 }
 

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -13,7 +13,7 @@ type BalancePolicy interface {
 	Init(cfg *config.Config)
 	BackendToRoute(backends []BackendCtx) BackendCtx
 	// balanceCount is the count of connections to balance per second.
-	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason string, logFields []zap.Field)
+	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field)
 	SetConfig(cfg *config.Config)
 }
 

--- a/pkg/balance/policy/simple_policy.go
+++ b/pkg/balance/policy/simple_policy.go
@@ -44,7 +44,7 @@ func (sbp *SimpleBalancePolicy) BackendToRoute(backends []BackendCtx) BackendCtx
 	return nil
 }
 
-func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount int, reason string, logFields []zap.Field) {
+func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return
 	}

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -180,7 +180,7 @@ var _ policy.BalancePolicy = (*mockBalancePolicy)(nil)
 
 type mockBalancePolicy struct {
 	cfg               atomic.Pointer[config.Config]
-	backendsToBalance func([]policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field)
+	backendsToBalance func([]policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount float64, reason string, logFields []zapcore.Field)
 	backendToRoute    func([]policy.BackendCtx) policy.BackendCtx
 }
 
@@ -195,7 +195,7 @@ func (m *mockBalancePolicy) BackendToRoute(backends []policy.BackendCtx) policy.
 	return nil
 }
 
-func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field) {
+func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount float64, reason string, logFields []zapcore.Field) {
 	if m.backendsToBalance != nil {
 		return m.backendsToBalance(backends)
 	}

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -815,7 +815,7 @@ func TestControlSpeed(t *testing.T) {
 	tester.addConnections(total)
 
 	tests := []struct {
-		balanceCount     int
+		balanceCount     float64
 		rounds           int
 		interval         time.Duration
 		expectedCountMin int
@@ -867,10 +867,38 @@ func TestControlSpeed(t *testing.T) {
 			expectedCountMin: 100,
 			expectedCountMax: 100,
 		},
+		{
+			balanceCount:     1.1,
+			rounds:           1000,
+			interval:         10 * time.Millisecond,
+			expectedCountMin: 10,
+			expectedCountMax: 20,
+		},
+		{
+			balanceCount:     0.9,
+			rounds:           1000,
+			interval:         10 * time.Millisecond,
+			expectedCountMin: 5,
+			expectedCountMax: 20,
+		},
+		{
+			balanceCount:     0.5,
+			rounds:           1000,
+			interval:         10 * time.Millisecond,
+			expectedCountMin: 5,
+			expectedCountMax: 5,
+		},
+		{
+			balanceCount:     0.1,
+			rounds:           1000,
+			interval:         10 * time.Millisecond,
+			expectedCountMin: 1,
+			expectedCountMax: 2,
+		},
 	}
 
 	for _, test := range tests {
-		bp.backendsToBalance = func(bc []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount int, reason string, logFields []zapcore.Field) {
+		bp.backendsToBalance = func(bc []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount float64, reason string, logFields []zapcore.Field) {
 			return tester.getBackendByIndex(0), tester.getBackendByIndex(1), test.balanceCount, "conn", nil
 		}
 		tester.router.lastRedirectTime = monotime.Time(0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #570 

Problem Summary:
In testing I found the migration is not quick enough because:
- Some migrations may fail and retry. This possibility was not considered for migration speed.
- In the rolling upgrade scenario, the target backend had 0 connection at first because it had just started. But my assumption was that the source and target backends have similar connections at first.

Besides, CPU-based balance is too fast because when balanceCount < 1, it is set to 1. So there's at least 15 connections migrated for each metric collection cycle.

What is changed and how it works:
- Change the return type of `BalanceCount` from int to float64. E.g. 0.5 means migrating 1 connection every 2 seconds.
- Record the balance count at the beginning of migration for urgent factors, including status, health, and memory. Thus, the balance count won't change during the migration.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
