### PR TITLE
observer, net: read packet from SQL port in health check

### DIFF
--- a/pkg/balance/observer/health_check.go
+++ b/pkg/balance/observer/health_check.go
@@ -86,6 +86,9 @@ func (dhc *DefaultHealthCheck) checkSqlPort(ctx context.Context, addr string, bh
 		if err = conn.SetReadDeadline(time.Now().Add(dhc.cfg.DialTimeout)); err != nil {
 			return err
 		}
+		if err = pnet.CheckSqlPort(conn); err != nil {
+			return err
+		}
 		if ignoredErr := conn.Close(); ignoredErr != nil && !pnet.IsDisconnectError(ignoredErr) {
 			dhc.logger.Warn("close connection in health check failed", zap.Error(ignoredErr))
 		}

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -358,32 +358,17 @@ func ParseChangeUser(data []byte, capability Capability) (*ChangeUserReq, error)
 	return req, err
 }
 
-// ReadServerVersion only reads server version.
-func ReadServerVersion(conn net.Conn) (string, error) {
+// CheckSqlPort checks whether the SQL port is available.
+func CheckSqlPort(conn net.Conn) error {
 	c := packet.NewConn(conn)
 	data, err := c.ReadPacket()
 	if err != nil {
-		return "", err
+		return err
 	}
 	if data[0] == ErrHeader.Byte() {
-		return "", errors.New("read initial handshake error")
+		return errors.New("read initial handshake error")
 	}
-	pos := 1
-	version := data[pos : pos+bytes.IndexByte(data[pos:], 0x00)]
-	return string(version), nil
-}
-
-// WriteServerVersion only writes server version. It's only used for testing.
-func WriteServerVersion(conn net.Conn, serverVersion string) error {
-	data := make([]byte, 0, 128)
-	data = append(data, []byte{0, 0, 0, 0}...)
-	// min version 10
-	data = append(data, 10)
-	// server version[NUL]
-	data = append(data, serverVersion...)
-	data = append(data, 0)
-	c := packet.NewConn(conn)
-	return c.WritePacket(data)
+	return nil
 }
 
 // ParseOKPacket parses an OK packet and only returns server status.


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #577 

Problem Summary:
#510 removes reading one packet from the SQL port, but some TiDB versions don't respond after establishing the TCP connection before finishing loading statistics.

Handshake until TLS is complicated. It needs to consider capabilities like proxy-protocol and TLS. So maybe I'll use another way to detect the validity of TLS certs.

What is changed and how it works:
Read one packet from the SQL port in health checking.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
