### PR TITLE
metricsreader: only report error once if Prometheus is not deployed

### DIFF
--- a/pkg/balance/metricsreader/metrics_reader_test.go
+++ b/pkg/balance/metricsreader/metrics_reader_test.go
@@ -208,7 +208,7 @@ func TestNoPromAddr(t *testing.T) {
 			return nil, nil
 		},
 	}
-	lg, _ := logger.CreateLoggerForTest(t)
+	lg, text := logger.CreateLoggerForTest(t)
 	cfg := newHealthCheckConfigForTest()
 	mr := NewDefaultMetricsReader(lg, mpf, cfg)
 	promInfo, err := mr.getPromAPI(context.Background())
@@ -225,6 +225,7 @@ func TestNoPromAddr(t *testing.T) {
 	time.Sleep(10 * cfg.MetricsInterval)
 	qr := mr.GetQueryResult(id)
 	require.True(t, qr.Empty())
+	require.Equal(t, 1, strings.Count(text.String(), "no prometheus info found"))
 }
 
 func setupTypicalMetricsReader(t *testing.T) (*mockHttpHandler, MetricsReader) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #576 

Problem Summary:
Start a cluster without Prometheus and TiProxy keeps reporting warnings every 5 seconds.

What is changed and how it works:
Only report the error once if there are successive errors.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
