### PR TITLE
factor: adjust threshold for health-based balance

### DIFF
--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -58,15 +58,17 @@ var (
 	errDefinitions = []errDefinition{
 		{
 			// may be caused by disconnection to PD
-			// test with no connection: around 80
-			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type="pdRPC"}[1m])) by (instance)`,
-			failThreshold:    100,
+			// test with no connection in no network: around 80/m
+			// test with 100 connections in unstable network: [50, 135]/2m
+			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type="pdRPC"}[2m])) by (instance)`,
+			failThreshold:    50,
 			recoverThreshold: 10,
 		},
 		{
 			// may be caused by disconnection to TiKV
-			// test with no connection: regionMiss is around 1300, tikvRPC is around 40
-			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type=~"regionMiss|tikvRPC"}[1m])) by (instance)`,
+			// test with no connection in no network: regionMiss is around 1300/m, tikvRPC is around 40/m
+			// test with 100 connections in unstable network: [1000, 3300]/2m
+			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type=~"regionMiss|tikvRPC"}[2m])) by (instance)`,
 			failThreshold:    1000,
 			recoverThreshold: 100,
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #575 

Problem Summary:
I tested health-based balance with chaos mesh and the connections thrash:
- The network loss between TiDB and PD is set to 50% and lasts for 20s every 10s. The real value range of [1m] is [9, 120] and the range of [2m] is [50, 135]
- The network loss between TiDB and TiKV is set to 50% and lasts for 20s every 10s. The real value range of [1m] is [38, 3325] and the range of [2m] is [995, 3295]

So it's better to set the error threshold of a longer time range to make it stable.

What is changed and how it works:
Adjust time range and threshold for health-based balance

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
