### PR TITLE
metrics, observer: purge backend metrics when backend is down for too long

### DIFF
--- a/pkg/balance/observer/backend_health.go
+++ b/pkg/balance/observer/backend_health.go
@@ -48,7 +48,10 @@ func (bh *BackendHealth) Equals(health BackendHealth) bool {
 }
 
 func (bh *BackendHealth) String() string {
-	str := getHealthLabel(bh.Healthy)
+	str := "down"
+	if bh.Healthy {
+		str = "healthy"
+	}
 	if bh.PingErr != nil {
 		str += fmt.Sprintf(", err: %s", bh.PingErr.Error())
 	}

--- a/pkg/metrics/backend.go
+++ b/pkg/metrics/backend.go
@@ -6,8 +6,7 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 const (
-	LblRes    = "res"
-	LblStatus = "status"
+	LblRes = "res"
 )
 
 var (
@@ -17,7 +16,7 @@ var (
 			Subsystem: LabelBackend,
 			Name:      "b_status",
 			Help:      "Gauge of backend status.",
-		}, []string{LblBackend, LblStatus})
+		}, []string{LblBackend})
 
 	GetBackendHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -5,9 +5,15 @@ package metrics
 
 import (
 	"context"
+	"slices"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStartMetricsManager(t *testing.T) {
@@ -15,4 +21,80 @@ func TestStartMetricsManager(t *testing.T) {
 	mm := NewMetricsManager()
 	mm.Init(context.Background(), log)
 	mm.Close()
+}
+
+func TestDelLabelValues(t *testing.T) {
+	tests := []struct {
+		init     func()
+		coll     prometheus.Collector
+		allAddrs []string
+		delAddr  string
+	}{
+		{
+			// test LblBackend + Gauge
+			init: func() {
+				BackendConnGauge.WithLabelValues("addr0").Add(1)
+				BackendConnGauge.WithLabelValues("addr1").Add(1)
+			},
+			coll:     BackendConnGauge,
+			allAddrs: []string{"addr0", "addr1"},
+			delAddr:  "addr0",
+		},
+		{
+			// test LblFrom + LblTo + other labels + Histogram
+			init: func() {
+				MigrateDurationHistogram.WithLabelValues("addr0", "addr1", "succeed").Observe(1.0)
+				MigrateDurationHistogram.WithLabelValues("addr1", "addr2", "fail").Observe(1.0)
+				MigrateDurationHistogram.WithLabelValues("addr0", "addr2", "succeed").Observe(1.0)
+			},
+			coll:     MigrateDurationHistogram,
+			allAddrs: []string{"addr0", "addr1", "addr2"},
+			delAddr:  "addr1",
+		},
+		{
+			// test LblBackend + other labels + Counter
+			init: func() {
+				QueryTotalCounter.WithLabelValues("addr0", "query").Add(1)
+				QueryTotalCounter.WithLabelValues("addr0", "prepare").Add(1)
+				QueryTotalCounter.WithLabelValues("addr1", "query").Add(1)
+			},
+			coll:     QueryTotalCounter,
+			allAddrs: []string{"addr0", "addr1"},
+			delAddr:  "addr0",
+		},
+	}
+
+	getAddrs := func(coll prometheus.Collector) []string {
+		ch := make(chan prometheus.Metric)
+		go func() {
+			coll.Collect(ch)
+			close(ch)
+		}()
+		addrs := make([]string, 0, 3)
+		for m := range ch {
+			var metric dto.Metric
+			require.NoError(t, m.Write(&metric))
+			for _, l := range metric.Label {
+				if strings.HasPrefix(*l.Value, "addr") && !slices.Contains(addrs, *l.Value) {
+					addrs = append(addrs, *l.Value)
+				}
+			}
+		}
+		sort.Slice(addrs, func(i, j int) bool {
+			return addrs[i] < addrs[j]
+		})
+		return addrs
+	}
+	for i, test := range tests {
+		test.init()
+		require.Equal(t, test.allAddrs, getAddrs(test.coll), "%dth test failed", i)
+		DelBackend(test.delAddr)
+		newAddrs := make([]string, 0, 3)
+		for _, addr := range test.allAddrs {
+			if addr != test.delAddr {
+				newAddrs = append(newAddrs, addr)
+			}
+		}
+		require.Equal(t, newAddrs, getAddrs(test.coll), "%dth test failed", i)
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #582 

Problem Summary:
The backend metric is never cleared after the backend is down. In auto-scaling workload, the backends change frequently and then the metrics keep growing.

What is changed and how it works:
- Purge the backend metrics after it's down for over 2 hours
- Remove the `status` label for `BackendStatusGauge`. `BackendStatusGauge` is not used in Grafana so it's fine.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Steps:
1. Update the threshold from 2 hours to 2 minutes and build TiProxy
2. Create a cluster with `tiup playground v8.1.0 --db=2 --tiproxy=1 --tiproxy.version=v1.1.0 --tiflash=0`
3. Run sysbench to create metrics
4. Scale-in the TiDB `127.0.0.1:4001`
5. Check the metrics immediately and `127.0.0.1:4001` existed

```shell
curl -L 127.1:3080/metrics | grep -c 127.0.0.1:4001
204
```

6. Check the metrics after a few minutes and `127.0.0.1:4001` disappeared:

```shell
curl -L 127.1:3080/metrics | grep -c 127.0.0.1:4001
0
```

7. Check the Grafana, the metrics of `127.0.0.1:4001` existed when it was up but disappeared after it was down:

![image](https://github.com/pingcap/tiproxy/assets/29590578/18397388-1570-4969-a4bc-7d2dc3f22774)


Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Purge backend metrics when the backend is down for too long
```
