### PR TITLE
elect, infosync: create Election to elect owner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/btree v1.5.2
+	go.etcd.io/etcd/api/v3 v3.5.6
 	go.etcd.io/etcd/client/pkg/v3 v3.5.6
 	go.etcd.io/etcd/client/v3 v3.5.6
 	go.etcd.io/etcd/server/v3 v3.5.6
@@ -92,7 +93,6 @@ require (
 	github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	go.etcd.io/etcd/api/v3 v3.5.6 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.6 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.5.6 // indirect
 	go.etcd.io/etcd/raft/v3 v3.5.6 // indirect

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -1,0 +1,238 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package owner
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/lib/util/retry"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.uber.org/zap"
+)
+
+const (
+	logInterval = 10
+)
+
+type Member interface {
+	OnElected()
+	OnRetired()
+}
+
+// Election is used to campaign the owner and manage the owner information.
+type Election interface {
+	// Start starts compaining the owner.
+	Start(context.Context)
+	// IsOwner returns whether the member is the owner.
+	IsOwner() bool
+	// GetOwnerID gets the owner ID.
+	GetOwnerID(ctx context.Context) (string, error)
+	// Close stops compaining the owner.
+	Close()
+}
+
+type electionConfig struct {
+	timeout    time.Duration
+	retryIntvl time.Duration
+	retryCnt   uint64
+	sessionTTL int
+}
+
+var _ Election = (*election)(nil)
+
+// election is used for electing owner.
+type election struct {
+	cfg electionConfig
+	// id is typically the instance address
+	id      string
+	key     string
+	lg      *zap.Logger
+	etcdCli *clientv3.Client
+	elec    atomic.Pointer[concurrency.Election]
+	wg      waitgroup.WaitGroup
+	cancel  context.CancelFunc
+	member  Member
+}
+
+// NewElection creates an Election.
+func NewElection(lg *zap.Logger, etcdCli *clientv3.Client, cfg electionConfig, id, key string, member Member) *election {
+	lg = lg.With(zap.String("key", key), zap.String("id", id))
+	return &election{
+		lg:      lg,
+		etcdCli: etcdCli,
+		cfg:     cfg,
+		id:      id,
+		key:     key,
+		member:  member,
+	}
+}
+
+func (m *election) Start(ctx context.Context) {
+	clientCtx, cancelFunc := context.WithCancel(ctx)
+	m.cancel = cancelFunc
+	// Don't recover because we don't know what will happen after recovery.
+	m.wg.Run(func() {
+		m.campaignLoop(clientCtx)
+	})
+}
+
+func (m *election) initSession(ctx context.Context) (*concurrency.Session, error) {
+	var session *concurrency.Session
+	// If the network breaks for sometime, the session will fail but it still needs to compaign after recovery.
+	// So retry it infinitely.
+	err := retry.RetryNotify(func() error {
+		var err error
+		// Do not use context.WithTimeout, otherwise the session will be cancelled after timeout, even if it is created successfully.
+		session, err = concurrency.NewSession(m.etcdCli, concurrency.WithTTL(m.cfg.sessionTTL), concurrency.WithContext(ctx))
+		return err
+	}, ctx, m.cfg.retryIntvl, retry.InfiniteCnt,
+		func(err error, duration time.Duration) {
+			m.lg.Warn("failed to init election session, retrying", zap.Error(err))
+		}, logInterval)
+	if err == nil {
+		m.lg.Info("election session is initialized")
+	} else {
+		m.lg.Error("failed to init election session, quit", zap.Error(err))
+	}
+	return session, err
+}
+
+func (m *election) IsOwner() bool {
+	return m.elec.Load() != nil
+}
+
+func (m *election) campaignLoop(ctx context.Context) {
+	session, err := m.initSession(ctx)
+	if err != nil {
+		return
+	}
+	for {
+		select {
+		case <-session.Done():
+			m.lg.Info("etcd session is done, creates a new one")
+			leaseID := session.Lease()
+			if session, err = m.initSession(ctx); err != nil {
+				m.lg.Error("new session failed, break campaign loop", zap.Error(err))
+				m.revokeLease(leaseID)
+				return
+			}
+		case <-ctx.Done():
+			m.revokeLease(session.Lease())
+			return
+		default:
+		}
+		// If the etcd server turns clocks forward, the following case may occur.
+		// The etcd server deletes this session's lease ID, but etcd session doesn't find it.
+		// In this case if we do the campaign operation, the etcd server will return ErrLeaseNotFound.
+		if errors.Is(err, rpctypes.ErrLeaseNotFound) {
+			if session != nil {
+				err = session.Close()
+				m.lg.Warn("etcd session encounters ErrLeaseNotFound, close it", zap.Error(err))
+			}
+			continue
+		}
+
+		elec := concurrency.NewElection(session, m.key)
+		if err = elec.Campaign(ctx, m.id); err != nil {
+			m.lg.Info("failed to campaign", zap.Error(err))
+			continue
+		}
+
+		ownerID, err := m.GetOwnerID(ctx)
+		if err != nil || ownerID != m.id {
+			continue
+		}
+
+		m.onElected(elec)
+		// NOTICE: watchOwner won't revoke the lease.
+		m.watchOwner(ctx, session, ownerID)
+		m.onRetired()
+	}
+}
+
+func (m *election) onElected(elec *concurrency.Election) {
+	m.member.OnElected()
+	m.elec.Store(elec)
+	m.lg.Info("elected as the owner")
+}
+
+func (m *election) onRetired() {
+	m.member.OnRetired()
+	m.elec.Store(nil)
+	m.lg.Info("the owner retires")
+}
+
+// revokeLease revokes the session lease so that other members can compaign immediately.
+func (m *election) revokeLease(leaseID clientv3.LeaseID) {
+	// If revoke takes longer than the ttl, lease is expired anyway.
+	// Don't use the context of the caller because it may be already done.
+	cancelCtx, cancel := context.WithTimeout(context.Background(), time.Duration(m.cfg.sessionTTL)*time.Second)
+	if _, err := m.etcdCli.Revoke(cancelCtx, leaseID); err != nil {
+		m.lg.Warn("revoke session failed", zap.Error(errors.WithStack(err)))
+	}
+	cancel()
+}
+
+// GetOwnerID is similar to concurrency.Election.Leader() but it doesn't need an concurrency.Election.
+func (m *election) GetOwnerID(ctx context.Context) (string, error) {
+	var resp *clientv3.GetResponse
+	err := retry.Retry(func() error {
+		childCtx, cancel := context.WithTimeout(ctx, m.cfg.timeout)
+		var err error
+		resp, err = m.etcdCli.Get(childCtx, m.key, clientv3.WithFirstCreate()...)
+		cancel()
+		return errors.WithStack(err)
+	}, ctx, m.cfg.retryIntvl, m.cfg.retryCnt)
+
+	if err != nil {
+		m.lg.Error("failed to get owner info, quit", zap.Error(err))
+		return "", err
+	}
+	if len(resp.Kvs) == 0 {
+		return "", concurrency.ErrElectionNoLeader
+	}
+	return string(resp.Kvs[0].Value), nil
+}
+
+func (m *election) watchOwner(ctx context.Context, session *concurrency.Session, key string) {
+	watchCh := m.etcdCli.Watch(ctx, key)
+	for {
+		select {
+		case resp, ok := <-watchCh:
+			if !ok {
+				m.lg.Info("watcher is closed, no owner")
+				return
+			}
+			if resp.Canceled {
+				m.lg.Info("watch canceled, no owner")
+				return
+			}
+
+			for _, ev := range resp.Events {
+				if ev.Type == mvccpb.DELETE {
+					m.lg.Info("watch failed, owner is deleted")
+					return
+				}
+			}
+		case <-session.Done():
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Close is called before the instance is going to shutdown.
+// It should hand over the owner to someone else.
+func (m *election) Close() {
+	m.cancel()
+	m.wg.Wait()
+}

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -1,7 +1,7 @@
 // Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package owner
+package elect
 
 import (
 	"context"

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -66,7 +66,6 @@ func TestEtcdServerDown(t *testing.T) {
 
 	// server is down and the owner retires
 	addr := ts.shutdownServer()
-	ts.expectEvent("1", eventTypeRetired)
 	_, err := elec1.GetOwnerID(context.Background())
 	require.Error(t, err)
 
@@ -77,6 +76,7 @@ func TestEtcdServerDown(t *testing.T) {
 	// start the server again and the elections recover
 	ts.startServer(addr)
 	ownerID := ts.getOwnerID()
+	ts.expectEvent("1", eventTypeRetired)
 	ts.expectEvent(ownerID, eventTypeElected)
 }
 

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -1,0 +1,102 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package owner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestElectOwner(t *testing.T) {
+	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	t.Cleanup(ts.close)
+
+	// 2 nodes start and 1 node is the owner
+	{
+		elec1 := ts.newElection("1")
+		elec2 := ts.newElection("2")
+		elec1.Start(context.Background())
+		elec2.Start(context.Background())
+		ownerID := ts.getOwnerID()
+		ts.expectEvent(ownerID, eventTypeElected)
+	}
+	// stop the owner and the other becomes the owner
+	{
+		ownerID := ts.getOwnerID()
+		elec := ts.getElection(ownerID)
+		elec.Close()
+		ts.expectEvent(ownerID, eventTypeRetired)
+		ownerID2 := ts.getOwnerID()
+		require.NotEqual(t, ownerID, ownerID2)
+		ts.expectEvent(ownerID2, eventTypeElected)
+	}
+	// start a new node and the owner doesn't change
+	{
+		ownerID := ts.getOwnerID()
+		elec := ts.newElection("3")
+		elec.Start(context.Background())
+		time.Sleep(300 * time.Millisecond)
+		ownerID2 := ts.getOwnerID()
+		require.Equal(t, ownerID, ownerID2)
+	}
+	// stop all the nodes and there's no owner
+	{
+		elec := ts.getElection("3")
+		elec.Close()
+		ownerID := ts.getOwnerID()
+		elec = ts.getElection(ownerID)
+		elec.Close()
+		ts.expectEvent(ownerID, eventTypeRetired)
+		_, err := elec.GetOwnerID(context.Background())
+		require.Error(t, err)
+	}
+}
+
+func TestEtcdServerDown(t *testing.T) {
+	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	t.Cleanup(ts.close)
+
+	elec1 := ts.newElection("1")
+	elec1.Start(context.Background())
+	ts.expectEvent("1", eventTypeElected)
+
+	// server is down and the owner retires
+	addr := ts.shutdownServer()
+	ts.expectEvent("1", eventTypeRetired)
+	_, err := elec1.GetOwnerID(context.Background())
+	require.Error(t, err)
+
+	// start another member, it should not panic
+	elec2 := ts.newElection("2")
+	elec2.Start(context.Background())
+
+	// start the server again and the elections recover
+	ts.startServer(addr)
+	ownerID := ts.getOwnerID()
+	ts.expectEvent(ownerID, eventTypeElected)
+}
+
+func TestOwnerHang(t *testing.T) {
+	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	t.Cleanup(ts.close)
+
+	// make the owner hang at loop
+	elec1 := ts.newElection("1")
+	ts.hang("1", true)
+	defer ts.hang("1", false)
+	elec1.Start(context.Background())
+	ownerID := ts.getOwnerID()
+	require.Equal(t, "1", ownerID)
+
+	// start another member
+	elec2 := ts.newElection("2")
+	elec2.Start(context.Background())
+	// even if the owner hangs, it's keeping alive at background
+	time.Sleep(time.Second)
+	ownerID = ts.getOwnerID()
+	require.Equal(t, "1", ownerID)
+}

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package owner
+package elect
 
 import (
 	"context"

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -41,12 +41,14 @@ func (mo *mockMember) OnRetired() {
 	mo.ch <- eventTypeRetired
 }
 
-func (mo *mockMember) expectEvent(t *testing.T, expected int) {
-	select {
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout")
-	case event := <-mo.ch:
-		require.Equal(t, expected, event)
+func (mo *mockMember) expectEvent(t *testing.T, expected ...int) {
+	for _, exp := range expected {
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout")
+		case event := <-mo.ch:
+			require.Equal(t, exp, event)
+		}
 	}
 }
 
@@ -147,9 +149,9 @@ func (ts *etcdTestSuite) getOwnerID() string {
 	return ownerID
 }
 
-func (ts *etcdTestSuite) expectEvent(id string, event int) {
+func (ts *etcdTestSuite) expectEvent(id string, event ...int) {
 	elec := ts.getElection(id)
-	elec.member.(*mockMember).expectEvent(ts.t, event)
+	elec.member.(*mockMember).expectEvent(ts.t, event...)
 }
 
 func (ts *etcdTestSuite) hang(id string, hang bool) {

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -1,0 +1,207 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package owner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/manager/cert"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
+)
+
+const (
+	eventTypeElected = iota
+	eventTypeRetired
+)
+
+var _ Member = (*mockMember)(nil)
+
+type mockMember struct {
+	ch chan int
+}
+
+func newMockMember() *mockMember {
+	return &mockMember{ch: make(chan int, 2)}
+}
+
+func (mo *mockMember) OnElected() {
+	mo.ch <- eventTypeElected
+}
+
+func (mo *mockMember) OnRetired() {
+	mo.ch <- eventTypeRetired
+}
+
+func (mo *mockMember) expectEvent(t *testing.T, expected int) {
+	select {
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	case event := <-mo.ch:
+		require.Equal(t, expected, event)
+	}
+}
+
+func (mo *mockMember) hang(hang bool) {
+	contn := true
+	for contn {
+		if hang {
+			// fill the channel
+			select {
+			case mo.ch <- eventTypeElected:
+			default:
+				contn = false
+			}
+		} else {
+			// clear the channel
+			select {
+			case <-mo.ch:
+			default:
+				contn = false
+			}
+		}
+	}
+}
+
+type etcdTestSuite struct {
+	elecCfg electionConfig
+	key     string
+	elecs   []*election
+	t       *testing.T
+	lg      *zap.Logger
+	server  *embed.Etcd
+	client  *clientv3.Client
+	kv      clientv3.KV
+}
+
+func newEtcdTestSuite(t *testing.T, elecCfg electionConfig, key string) *etcdTestSuite {
+	lg, _ := logger.CreateLoggerForTest(t)
+	ts := &etcdTestSuite{
+		t:       t,
+		lg:      lg,
+		elecCfg: elecCfg,
+		key:     key,
+	}
+
+	ts.startServer("0.0.0.0:0")
+	endpoint := ts.server.Clients[0].Addr().String()
+	cfg := newConfig(endpoint)
+
+	certMgr := cert.NewCertManager()
+	err := certMgr.Init(cfg, lg, nil)
+	require.NoError(t, err)
+
+	ts.client, err = infosync.InitEtcdClient(ts.lg, cfg, certMgr)
+	require.NoError(t, err)
+	ts.kv = clientv3.NewKV(ts.client)
+	return ts
+}
+
+func (ts *etcdTestSuite) newElection(id string) *election {
+	cfg := electionConfig{
+		sessionTTL: 1,
+		timeout:    100 * time.Millisecond,
+		retryIntvl: 10 * time.Millisecond,
+		retryCnt:   2,
+	}
+	member := newMockMember()
+	elec := NewElection(ts.lg, ts.client, cfg, id, ts.key, member)
+	ts.elecs = append(ts.elecs, elec)
+	return elec
+}
+
+func (ts *etcdTestSuite) getElection(id string) *election {
+	for _, elec := range ts.elecs {
+		if elec.id == id {
+			return elec
+		}
+	}
+	ts.t.Fatalf("election not found, id %s", id)
+	return nil
+}
+
+func (ts *etcdTestSuite) getOwnerID() string {
+	var ownerID string
+	for _, elec := range ts.elecs {
+		var id string
+		require.Eventually(ts.t, func() bool {
+			var err error
+			id, err = elec.GetOwnerID(context.Background())
+			return err == nil
+		}, 3*time.Second, 10*time.Millisecond)
+		require.NotEmpty(ts.t, id)
+		if len(ownerID) == 0 {
+			ownerID = id
+		} else {
+			require.Equal(ts.t, ownerID, id)
+		}
+	}
+	return ownerID
+}
+
+func (ts *etcdTestSuite) expectEvent(id string, event int) {
+	elec := ts.getElection(id)
+	elec.member.(*mockMember).expectEvent(ts.t, event)
+}
+
+func (ts *etcdTestSuite) hang(id string, hang bool) {
+	elec := ts.getElection(id)
+	elec.member.(*mockMember).hang(hang)
+}
+
+func (ts *etcdTestSuite) close() {
+	for _, elec := range ts.elecs {
+		elec.Close()
+	}
+	if ts.client != nil {
+		require.NoError(ts.t, ts.client.Close())
+		ts.client = nil
+	}
+	if ts.server != nil {
+		ts.server.Close()
+		ts.server = nil
+	}
+}
+
+func (ts *etcdTestSuite) startServer(addr string) {
+	etcd, err := infosync.CreateEtcdServer(addr, ts.t.TempDir(), ts.lg)
+	require.NoError(ts.t, err)
+	ts.server = etcd
+}
+
+func (ts *etcdTestSuite) shutdownServer() string {
+	require.NotNil(ts.t, ts.server)
+	addr := ts.server.Clients[0].Addr().String()
+	ts.server.Close()
+	ts.server = nil
+	return addr
+}
+
+func newConfig(endpoint string) *config.Config {
+	return &config.Config{
+		Proxy: config.ProxyServer{
+			Addr:    "0.0.0.0:6000",
+			PDAddrs: endpoint,
+		},
+		API: config.API{
+			Addr: "0.0.0.0:3080",
+		},
+	}
+}
+
+func electionConfigForTest(ttl int) electionConfig {
+	return electionConfig{
+		sessionTTL: ttl,
+		timeout:    100 * time.Millisecond,
+		retryIntvl: 10 * time.Millisecond,
+		retryCnt:   2,
+	}
+}

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package owner
+package elect
 
 import (
 	"context"

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -175,7 +175,7 @@ func (is *InfoSyncer) initTopologySession(ctx context.Context) error {
 		topologySession, err := concurrency.NewSession(is.etcdCli, concurrency.WithTTL(is.syncConfig.sessionTTL), concurrency.WithContext(ctx))
 		if err == nil {
 			is.topologySession = topologySession
-			is.lg.Info("topology session is initialized", zap.Error(err))
+			is.lg.Info("topology session is initialized")
 		}
 		return err
 	}, ctx, is.syncConfig.putRetryIntvl, retry.InfiniteCnt,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #587 

Problem Summary:
`elect.Election` is a general election based on etcd election. It's used for electing VIP later.

What is changed and how it works:
- Create `elect.Election`
- Move `CreateEtcdServer` from test file to `etcd.go`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
