### PR TITLE
server, etcd: integrate vip manager into the server

### DIFF
--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -76,8 +76,8 @@ func NewElection(lg *zap.Logger, etcdCli *clientv3.Client, cfg electionConfig, i
 	lg = lg.With(zap.String("key", key), zap.String("id", id))
 	return &election{
 		lg:      lg,
-		cfg:     cfg,
 		etcdCli: etcdCli,
+		cfg:     cfg,
 		id:      id,
 		key:     key,
 		member:  member,

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -76,8 +76,8 @@ func NewElection(lg *zap.Logger, etcdCli *clientv3.Client, cfg electionConfig, i
 	lg = lg.With(zap.String("key", key), zap.String("id", id))
 	return &election{
 		lg:      lg,
-		etcdCli: etcdCli,
 		cfg:     cfg,
+		etcdCli: etcdCli,
 		id:      id,
 		key:     key,
 		member:  member,

--- a/pkg/manager/vip/network_test.go
+++ b/pkg/manager/vip/network_test.go
@@ -6,6 +6,7 @@
 package vip
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -13,6 +14,10 @@ import (
 )
 
 func TestAddDelIP(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("unsupported on %s", runtime.GOOS)
+	}
+
 	tests := []struct {
 		virtualIP string
 		link      string

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/sctx"
+	"github.com/pingcap/tiproxy/pkg/util/etcd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	etcdServer, err := etcd.CreateEtcdServer("0.0.0.0:0", t.TempDir(), lg)
+	require.NoError(t, err)
+	endpoint := etcdServer.Clients[0].Addr().String()
+	cfg := etcd.ConfigForEtcdTest(endpoint)
+
+	server, err := NewServer(context.Background(), &sctx.Context{Overlay: *cfg})
+	require.NoError(t, err)
+	require.NoError(t, server.Close())
+}

--- a/pkg/util/etcd/etcd.go
+++ b/pkg/util/etcd/etcd.go
@@ -1,7 +1,7 @@
 // Copyright 2023 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package infosync
+package etcd
 
 import (
 	"fmt"
@@ -78,4 +78,16 @@ func CreateEtcdServer(addr, dir string, lg *zap.Logger) (*embed.Etcd, error) {
 	}
 	<-etcd.Server.ReadyNotify()
 	return etcd, err
+}
+
+func ConfigForEtcdTest(endpoint string) *config.Config {
+	return &config.Config{
+		Proxy: config.ProxyServer{
+			Addr:    "0.0.0.0:6000",
+			PDAddrs: endpoint,
+		},
+		API: config.API{
+			Addr: "0.0.0.0:3080",
+		},
+	}
 }

--- a/pkg/util/etcd/etcd_test.go
+++ b/pkg/util/etcd/etcd_test.go
@@ -25,7 +25,8 @@ func TestEtcdClient(t *testing.T) {
 	client, err := InitEtcdClient(lg, cfg, certMgr)
 	require.NoError(t, err)
 
-	client.Put(context.Background(), "key", "value")
+	_, err = client.Put(context.Background(), "key", "value")
+	require.NoError(t, err)
 	resp, err := client.Get(context.Background(), "key")
 	require.NoError(t, err)
 	require.Equal(t, "value", string(resp.Kvs[0].Value))

--- a/pkg/util/etcd/etcd_test.go
+++ b/pkg/util/etcd/etcd_test.go
@@ -1,0 +1,35 @@
+// Copyright 2023 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package etcd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/manager/cert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEtcdClient(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	server, err := CreateEtcdServer("0.0.0.0:0", t.TempDir(), lg)
+	require.NoError(t, err)
+	endpoint := server.Clients[0].Addr().String()
+
+	cfg := ConfigForEtcdTest(endpoint)
+	certMgr := cert.NewCertManager()
+	err = certMgr.Init(cfg, lg, nil)
+	require.NoError(t, err)
+	client, err := InitEtcdClient(lg, cfg, certMgr)
+	require.NoError(t, err)
+
+	client.Put(context.Background(), "key", "value")
+	resp, err := client.Get(context.Background(), "key")
+	require.NoError(t, err)
+	require.Equal(t, "value", string(resp.Kvs[0].Value))
+
+	require.NoError(t, client.Close())
+	server.Close()
+}

--- a/pkg/util/etcd/etcd_test.go
+++ b/pkg/util/etcd/etcd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package etcd


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #591 

Problem Summary:
Integrate VIP manager into the server.

What is changed and how it works:
- Create the VIP manager after creating SQL server and close the VIP manager before closing SQL server
- Move etcd-related code from package `infosync` to `util/etcd` so that all other components can call it
- The `Server` creates an etcd client and passes it to the other components so that it doesn't need to pass config or certMgr
- Rename the member of `Server` from uppercase to lowercase

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
