### PR TITLE
metrics, vip: add metric to show the VIP owner

### DIFF
--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/manager/elect"
+	"github.com/pingcap/tiproxy/pkg/metrics"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
@@ -83,6 +84,7 @@ func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error
 }
 
 func (vm *vipManager) OnElected() {
+	metrics.VIPGauge.Set(1)
 	hasIP, err := vm.operation.HasIP()
 	if err != nil {
 		vm.lg.Error("checking addresses failed", zap.Error(err))
@@ -104,6 +106,7 @@ func (vm *vipManager) OnElected() {
 }
 
 func (vm *vipManager) OnRetired() {
+	metrics.VIPGauge.Set(0)
 	hasIP, err := vm.operation.HasIP()
 	if err != nil {
 		vm.lg.Error("checking addresses failed", zap.Error(err))

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/stretchr/testify/require"
 )
 
@@ -138,6 +139,14 @@ func TestNetworkOperation(t *testing.T) {
 			return strings.Contains(text.String()[logIdx:], test.expectedLog)
 		}, 3*time.Second, 10*time.Millisecond, "case %d", i)
 		logIdx = len(text.String())
+
+		expectedVIPGauge := 0
+		if test.eventType == eventTypeElected {
+			expectedVIPGauge = 1
+		}
+		vipGauge, err := metrics.ReadGauge(metrics.VIPGauge)
+		require.NoError(t, err)
+		require.EqualValues(t, expectedVIPGauge, vipGauge, "case %d", i)
 	}
 	cancel()
 	vm.Close()

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -660,6 +660,92 @@
                      "show": true
                   }
                ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_TEST-CLUSTER}",
+               "description": "1 indicates the VIP owner.",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": {
+                  "h": 6,
+                  "w": 12,
+                  "x": 12,
+                  "y": 0
+               },
+               "id": 10,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tiproxy_server_vip{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "VIP Owner",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
             }
          ],
          "repeat": null,
@@ -679,7 +765,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 10,
+         "id": 11,
          "panels": [
             {
                "aliasColors": { },
@@ -696,7 +782,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 11,
+               "id": 12,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -796,7 +882,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 12,
+               "id": 13,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -882,7 +968,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 13,
+               "id": 14,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -968,7 +1054,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 14,
+               "id": 15,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1054,7 +1140,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1140,7 +1226,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 16,
+               "id": 17,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1226,7 +1312,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 17,
+               "id": 18,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1329,7 +1415,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 18,
+         "id": 19,
          "panels": [
             {
                "aliasColors": { },
@@ -1346,7 +1432,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 19,
+               "id": 20,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1432,7 +1518,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 20,
+               "id": 21,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1518,7 +1604,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 21,
+               "id": 22,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1618,7 +1704,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 22,
+               "id": 23,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1707,7 +1793,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 23,
+         "id": 24,
          "panels": [
             {
                "aliasColors": { },
@@ -1724,7 +1810,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 24,
+               "id": 25,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1824,7 +1910,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 25,
+               "id": 26,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1910,7 +1996,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 26,
+               "id": 27,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1999,7 +2085,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 27,
+         "id": 28,
          "panels": [
             {
                "aliasColors": { },
@@ -2016,7 +2102,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 28,
+               "id": 29,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2102,7 +2188,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 29,
+               "id": 30,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2188,7 +2274,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 30,
+               "id": 31,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2274,7 +2360,7 @@
                   "x": 12,
                   "y": 0
                },
-               "id": 31,
+               "id": 32,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2360,7 +2446,7 @@
                   "x": 0,
                   "y": 0
                },
-               "id": 32,
+               "id": 33,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -209,6 +209,20 @@ local uptimeP = graphPanel.new(
   )
 );
 
+local vipP = graphPanel.new(
+  title='VIP Owner',
+  datasource=myDS,
+  legend_rightSide=true,
+  description='1 indicates the VIP owner.',
+  format='short',
+)
+.addTarget(
+  prometheus.target(
+    'tiproxy_server_vip{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}',
+    legendFormat='{{instance}}',
+  )
+);
+
 // Query Summary
 local queryRow = row.new(collapse=true, title='Query Summary');
 local durationP = graphPanel.new(
@@ -565,6 +579,7 @@ newDash
   .addPanel(createConnP, gridPos=leftPanelPos)
   .addPanel(disconnP, gridPos=rightPanelPos)
   .addPanel(goroutineP, gridPos=leftPanelPos)
+  .addPanel(vipP, gridPos=rightPanelPos)
   ,
   gridPos=rowPos
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -99,6 +99,7 @@ func init() {
 		CreateConnCounter,
 		DisConnCounter,
 		MaxProcsGauge,
+		VIPGauge,
 		ServerEventCounter,
 		ServerErrCounter,
 		TimeJumpBackCounter,

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -42,6 +42,14 @@ var (
 			Help:      "Number of disconnections.",
 		}, []string{LblType})
 
+	VIPGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelServer,
+			Name:      "vip",
+			Help:      "VIP owner.",
+		})
+
 	MaxProcsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: ModuleProxy,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #593 

Problem Summary:
Add metric to show the VIP owner

What is changed and how it works:
Define `VIPGauge`. It's set to 1 when it's the owner.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
