### PR TITLE
metricsreader, observer: read metrics from backend HTTP API

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -1,0 +1,443 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/elect"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/siddontang/go/hack"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+)
+
+const (
+	// backendReaderKey is the key in etcd for VIP election.
+	backendReaderKey = "/tiproxy/metricreader/owner"
+	// sessionTTL is the session's TTL in seconds for backend reader owner election.
+	sessionTTL = 30
+	// backendMetricPath is the path of backend HTTP API to read metrics.
+	backendMetricPath = "/metrics"
+	goPoolSize        = 100
+	goMaxIdle         = time.Minute
+)
+
+type backendHistory struct {
+	step1History []model.SamplePair
+	step2History []model.SamplePair
+}
+
+type BackendReader struct {
+	sync.Mutex
+	queryRules   map[uint64]QueryRule
+	queryResults map[uint64]QueryResult
+	// rule id: {backend name: backendHistory}
+	history        map[uint64]map[string]backendHistory
+	election       elect.Election
+	cfgGetter      config.ConfigGetter
+	backendFetcher TopologyFetcher
+	httpCli        *http.Client
+	lg             *zap.Logger
+	cfg            *config.HealthCheck
+	wgp            *waitgroup.WaitGroupPool
+	isOwner        atomic.Bool
+}
+
+func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *http.Client, backendFetcher TopologyFetcher,
+	cfg *config.HealthCheck) *BackendReader {
+	return &BackendReader{
+		queryRules:     make(map[uint64]QueryRule),
+		queryResults:   make(map[uint64]QueryResult),
+		history:        make(map[uint64]map[string]backendHistory),
+		lg:             lg,
+		cfgGetter:      cfgGetter,
+		backendFetcher: backendFetcher,
+		cfg:            cfg,
+		wgp:            waitgroup.NewWaitGroupPool(goPoolSize, goMaxIdle),
+		httpCli:        httpCli,
+	}
+}
+
+func (br *BackendReader) Start(ctx context.Context, etcdCli *clientv3.Client) error {
+	cfg := br.cfgGetter.GetConfig()
+	ip, _, statusPort, err := cfg.GetIPPort()
+	if err != nil {
+		return err
+	}
+
+	// Use the status address as the key so that it can read metrics from the address.
+	id := net.JoinHostPort(ip, statusPort)
+	electionCfg := elect.DefaultElectionConfig(sessionTTL)
+	election := elect.NewElection(br.lg, etcdCli, electionCfg, id, backendReaderKey, br)
+	br.election = election
+	election.Start(ctx)
+	return nil
+}
+
+func (br *BackendReader) OnElected() {
+	br.isOwner.Store(true)
+}
+
+func (br *BackendReader) OnRetired() {
+	br.isOwner.Store(false)
+}
+
+func (br *BackendReader) AddQueryRule(id uint64, rule QueryRule) {
+	br.Lock()
+	defer br.Unlock()
+	br.queryRules[id] = rule
+}
+
+func (br *BackendReader) RemoveQueryRule(id uint64) {
+	br.Lock()
+	defer br.Unlock()
+	delete(br.queryRules, id)
+}
+
+func (br *BackendReader) GetQueryResult(id uint64) QueryResult {
+	br.Lock()
+	defer br.Unlock()
+	// Return an empty QueryResult if it's not found.
+	return br.queryResults[id]
+}
+
+func (br *BackendReader) ReadMetrics(ctx context.Context) (map[uint64]QueryResult, error) {
+	if br.isOwner.Load() {
+		if err := br.readFromBackends(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		owner, err := br.election.GetOwnerID(ctx)
+		if err != nil {
+			br.lg.Error("get owner failed, won't read metrics", zap.Error(err))
+			return nil, err
+		}
+		if err = br.readFromOwner(ctx, owner); err != nil {
+			return nil, err
+		}
+	}
+	br.purgeHistory()
+	return br.queryResults, nil
+}
+
+func (br *BackendReader) readFromBackends(ctx context.Context) error {
+	addrs, err := br.getBackendAddrs(ctx)
+	if err != nil {
+		return err
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+	allNames := br.collectAllNames()
+	if len(allNames) == 0 {
+		return nil
+	}
+
+	for _, addr := range addrs {
+		func(addr string) {
+			br.wgp.RunWithRecover(func() {
+				if ctx.Err() != nil {
+					return
+				}
+				resp, err := br.readBackendMetric(ctx, addr)
+				if err != nil {
+					br.lg.Error("read metrics from backend failed", zap.String("addr", addr), zap.Error(err))
+					return
+				}
+				text := filterMetrics(hack.String(resp), allNames)
+				mf, err := parseMetrics(text)
+				if err != nil {
+					br.lg.Error("parse metrics failed", zap.String("addr", addr), zap.Error(err))
+					return
+				}
+				result := br.groupMetricsByRule(mf, addr)
+				br.mergeQueryResult(result, addr)
+			}, nil, br.lg)
+		}(addr)
+	}
+	br.wgp.Wait()
+	return nil
+}
+
+func (br *BackendReader) collectAllNames() []string {
+	br.Lock()
+	defer br.Unlock()
+	names := make([]string, 0, len(br.queryRules)*3)
+	for _, rule := range br.queryRules {
+		for _, name := range rule.Names {
+			if slices.Index(names, name) < 0 {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+func (br *BackendReader) readBackendMetric(ctx context.Context, addr string) ([]byte, error) {
+	schema := "http"
+	if v, ok := br.httpCli.Transport.(*http.Transport); ok && v != nil && v.TLSClientConfig != nil {
+		schema = "https"
+	}
+	httpCli := *br.httpCli
+	httpCli.Timeout = br.cfg.DialTimeout
+	url := fmt.Sprintf("%s://%s%s", schema, addr, backendMetricPath)
+	var body []byte
+	err := br.connectWithRetry(ctx, func() error {
+		resp, err := httpCli.Get(url)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if ignoredErr := resp.Body.Close(); ignoredErr != nil {
+				br.lg.Warn("close http response failed", zap.String("url", url), zap.Error(ignoredErr))
+			}
+		}()
+
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
+		}
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			br.lg.Error("read response body failed", zap.String("url", url), zap.Error(err))
+		}
+		return err
+	})
+	return body, err
+}
+
+func (br *BackendReader) connectWithRetry(ctx context.Context, connect func() error) error {
+	err := backoff.Retry(func() error {
+		err := connect()
+		if !pnet.IsRetryableError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(br.cfg.RetryInterval), uint64(br.cfg.MaxRetries)), ctx))
+	return err
+}
+
+// groupMetricsByRule gets the result for each rule of one backend.
+func (br *BackendReader) groupMetricsByRule(mfs map[string]*dto.MetricFamily, backend string) map[uint64]model.Value {
+	now := model.TimeFromUnixNano(time.Now().UnixNano())
+	br.Lock()
+	defer br.Unlock()
+	results := make(map[uint64]model.Value, len(br.queryRules))
+	for id, rule := range br.queryRules {
+		// If the metric doesn't exist, skip it.
+		metricExists := true
+		for _, name := range rule.Names {
+			if _, ok := mfs[name]; !ok {
+				metricExists = false
+				break
+			}
+		}
+		if !metricExists {
+			continue
+		}
+
+		// step 1: get the latest pair (at a timepoint) and add it to step1History
+		// E.g. calculate process_cpu_seconds_total/tidb_server_maxprocs
+		sampleValue := rule.Metric2Value(mfs)
+		if math.IsNaN(float64(sampleValue)) {
+			continue
+		}
+		pair := model.SamplePair{Timestamp: now, Value: sampleValue}
+		ruleHistory, ok := br.history[id]
+		if !ok {
+			ruleHistory = make(map[string]backendHistory)
+			br.history[id] = ruleHistory
+		}
+		beHistory := ruleHistory[backend]
+		beHistory.step1History = append(beHistory.step1History, pair)
+
+		// step 2: get the latest pair by the history and add it to step2History
+		// E.g. calculate irate(process_cpu_seconds_total/tidb_server_maxprocs[30s])
+		sampleValue = rule.Range2Value(beHistory.step1History)
+		if math.IsNaN(float64(sampleValue)) {
+			continue
+		}
+		beHistory.step2History = append(beHistory.step2History, model.SamplePair{Timestamp: now, Value: sampleValue})
+		ruleHistory[backend] = beHistory
+
+		// step 3: return the result
+		// E.g. return the metrics for 1 minute as a matrix
+		labels := map[model.LabelName]model.LabelValue{LabelNameInstance: model.LabelValue(backend)}
+		switch rule.ResultType {
+		case model.ValVector:
+			// vector indicates returning the latest pair
+			results[id] = model.Vector{{Value: sampleValue, Timestamp: now, Metric: labels}}
+		case model.ValMatrix:
+			// matrix indicates returning the history
+			// copy a slice to avoid data race
+			pairs := make([]model.SamplePair, len(beHistory.step2History))
+			copy(pairs, beHistory.step2History)
+			results[id] = model.Matrix{{Values: pairs, Metric: labels}}
+		default:
+			br.lg.Error("unsupported value type", zap.String("value type", rule.ResultType.String()))
+		}
+	}
+	return results
+}
+
+// mergeQueryResult merges the result of one backend into the final result.
+func (br *BackendReader) mergeQueryResult(backendValues map[uint64]model.Value, backend string) {
+	br.Lock()
+	defer br.Unlock()
+	for id, value := range backendValues {
+		result := br.queryResults[id]
+		if result.Value == nil || reflect.ValueOf(result.Value).IsNil() {
+			result.Value = value
+			br.queryResults[id] = result
+			continue
+		}
+		switch result.Value.Type() {
+		case model.ValVector:
+			idx := -1
+			for i, v := range result.Value.(model.Vector) {
+				if v.Metric[LabelNameInstance] == model.LabelValue(backend) {
+					idx = i
+					break
+				}
+			}
+			if idx >= 0 {
+				result.Value.(model.Vector)[idx] = value.(model.Vector)[0]
+			} else {
+				result.Value = append(result.Value.(model.Vector), value.(model.Vector)[0])
+			}
+		case model.ValMatrix:
+			idx := -1
+			for i, v := range result.Value.(model.Matrix) {
+				if v.Metric[LabelNameInstance] == model.LabelValue(backend) {
+					idx = i
+					break
+				}
+			}
+			if idx >= 0 {
+				result.Value.(model.Matrix)[idx] = value.(model.Matrix)[0]
+			} else {
+				result.Value = append(result.Value.(model.Matrix), value.(model.Matrix)[0])
+			}
+		default:
+			br.lg.Error("unsupported value type", zap.Stringer("value type", result.Value.Type()))
+		}
+		br.queryResults[id] = result
+	}
+}
+
+// purgeHistory purges the expired or useless history values, otherwise the memory grows infinitely.
+func (br *BackendReader) purgeHistory() {
+	now := time.Now()
+	br.Lock()
+	defer br.Unlock()
+	for id, ruleHistory := range br.history {
+		rule, ok := br.queryRules[id]
+		// the rule is removed
+		if !ok {
+			delete(br.history, id)
+			continue
+		}
+		for backend, backendHistory := range ruleHistory {
+			backendHistory.step1History = purgeHistory(backendHistory.step1History, rule.Retention, now)
+			backendHistory.step2History = purgeHistory(backendHistory.step2History, rule.Retention, now)
+			// the history is expired, maybe the backend is down
+			if len(backendHistory.step1History) == 0 && len(backendHistory.step2History) == 0 {
+				delete(ruleHistory, backend)
+			} else {
+				ruleHistory[backend] = backendHistory
+			}
+		}
+	}
+}
+
+func (br *BackendReader) readFromOwner(ctx context.Context, addr string) error {
+	return nil
+}
+
+func (br *BackendReader) getBackendAddrs(ctx context.Context) ([]string, error) {
+	backends, err := br.backendFetcher.GetTiDBTopology(ctx)
+	if err != nil {
+		br.lg.Error("failed to get backend addresses, stop reading metrics", zap.Error(err))
+		return nil, err
+	}
+	addrs := make([]string, 0, len(backends))
+	for _, backend := range backends {
+		addrs = append(addrs, net.JoinHostPort(backend.IP, strconv.Itoa(int(backend.StatusPort))))
+	}
+	return addrs, nil
+}
+
+func (br *BackendReader) Close() {
+	if br.election != nil {
+		br.election.Close()
+	}
+}
+
+func purgeHistory(history []model.SamplePair, retention time.Duration, now time.Time) []model.SamplePair {
+	idx := -1
+	for i := range history {
+		if time.UnixMilli(int64(history[i].Timestamp)).Add(retention).After(now) {
+			idx = i
+			break
+		}
+	}
+	if idx > 0 {
+		copy(history[:], history[idx:])
+		return history[:len(history)-idx]
+	} else if idx < 0 {
+		history = history[:0]
+	}
+	return history
+}
+
+// filterMetrics filters the necessary metrics so that it's faster to parse.
+func filterMetrics(all string, names []string) string {
+	var buffer strings.Builder
+	buffer.Grow(4096)
+	for {
+		idx := strings.Index(all, "\n")
+		var line string
+		if idx < 0 {
+			line = all
+		} else {
+			line = all[:idx+1]
+			all = all[idx+1:]
+		}
+		for i := range names {
+			// strings.Contains() includes the metric description in the result but it's slower.
+			if strings.HasPrefix(line, names[i]) {
+				buffer.WriteString(line)
+				break
+			}
+		}
+		if idx < 0 {
+			break
+		}
+	}
+	return buffer.String()
+}
+
+func parseMetrics(text string) (map[string]*dto.MetricFamily, error) {
+	var parser expfmt.TextParser
+	return parser.TextToMetricFamilies(strings.NewReader(text))
+}

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -1,0 +1,699 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+// test getBackendAddrs
+func TestGetBackendAddrs(t *testing.T) {
+	tests := []struct {
+		backends map[string]*infosync.TiDBTopologyInfo
+		hasErr   bool
+		expected []string
+	}{
+		{
+			backends: map[string]*infosync.TiDBTopologyInfo{},
+			expected: []string{},
+		},
+		{
+			backends: map[string]*infosync.TiDBTopologyInfo{
+				"1.1.1.1:4000": {
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+				},
+			},
+			expected: []string{"1.1.1.1:10080"},
+		},
+		{
+			backends: map[string]*infosync.TiDBTopologyInfo{
+				"1.1.1.1:4000": {
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+				},
+				"2.2.2.2:4000": {
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
+				},
+			},
+			expected: []string{"1.1.1.1:10080", "2.2.2.2:10080"},
+		},
+		{
+			hasErr: true,
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	fetcher := newMockBackendFetcher(nil, nil)
+	br := NewBackendReader(lg, nil, nil, fetcher, nil)
+	for i, test := range tests {
+		fetcher.infos = test.backends
+		if test.hasErr {
+			fetcher.err = errors.New("mock err")
+		} else {
+			fetcher.err = nil
+		}
+		addrs, err := br.getBackendAddrs(context.Background())
+		if test.hasErr {
+			require.Error(t, err, "case %d", i)
+		} else {
+			require.NoError(t, err, "case %d", i)
+			require.Equal(t, test.expected, addrs, "case %d", i)
+		}
+	}
+}
+
+// test filterMetrics and parseMetrics
+func TestFilterAndParse(t *testing.T) {
+	tests := []struct {
+		names        []string
+		input        string
+		nameInResult []bool
+		hasErr       bool
+	}{
+		{
+			names:        []string{"any"},
+			input:        "",
+			nameInResult: []bool{false},
+		},
+		{
+			names: []string{"process_cpu_seconds_total", "tidb_server_maxprocs"},
+			input: `# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 19.57
+# HELP tidb_server_maxprocs The value of GOMAXPROCS.
+# TYPE tidb_server_maxprocs gauge
+tidb_server_maxprocs 2
+`,
+			nameInResult: []bool{true, true},
+		},
+		{
+			names: []string{"tidb_tikvclient_backoff_seconds_count"},
+			input: `tidb_tikvclient_backoff_seconds_sum{type=""} 0
+tidb_tikvclient_backoff_seconds_count{type=""} 0
+tidb_tikvclient_backoff_seconds_bucket{type="dataNotReady",le="0.0005"} 0
+tidb_tikvclient_backoff_seconds_count{type="dataNotReady"} 0
+tidb_tikvclient_backoff_seconds_bucket{type="isWitness",le="0.0005"} 0
+tidb_tikvclient_backoff_seconds_count{type="isWitness"} 0
+tidb_tikvclient_backoff_seconds_bucket{type="pdRPC",le="0.0005"} 0
+tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 0
+tidb_tikvclient_backoff_seconds_bucket{type="regionMiss",le="0.0005"} 0
+tidb_tikvclient_backoff_seconds_count{type="regionMiss"} 53
+tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 0
+tidb_tikvclient_backoff_seconds_bucket{type="tikvRPC",le="0.0005"} 0
+`,
+			nameInResult: []bool{true, true},
+		},
+		{
+			names: []string{"process_resident_memory_bytes", "tidb_server_memory_quota_bytes"},
+			input: `# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 4.10677248e+08
+`,
+			nameInResult: []bool{true, false},
+		},
+		{
+			names:        []string{"any"},
+			input:        "any with wrong format",
+			hasErr:       true,
+			nameInResult: []bool{false},
+		},
+	}
+
+	for i, test := range tests {
+		output := filterMetrics(test.input, test.names)
+		mf, err := parseMetrics(output)
+		require.Equal(t, test.hasErr, err != nil, "case %d", i)
+		if test.hasErr {
+			continue
+		}
+		containedNames := 0
+		for j, keyword := range test.names {
+			_, keywordInResult := mf[keyword]
+			require.Equal(t, test.nameInResult[j], keywordInResult, "case %d", i)
+			if keywordInResult {
+				containedNames++
+			}
+		}
+		require.Len(t, mf, containedNames, "case %d", i)
+	}
+}
+
+// test readBackendMetric
+func TestReadBackendMetric(t *testing.T) {
+	tests := []struct {
+		resp   string
+		hasErr bool
+	}{
+		{
+			resp: "response",
+		},
+		{
+			hasErr: true,
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := newHealthCheckConfigForTest()
+	httpHandler := newMockHttpHandler(t)
+	port := httpHandler.Start()
+	t.Cleanup(httpHandler.Close)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	br := NewBackendReader(lg, nil, http.DefaultClient, nil, cfg)
+	for i, test := range tests {
+		statusCode := http.StatusOK
+		if test.hasErr {
+			statusCode = http.StatusInternalServerError
+		}
+		httpHandler.statusCode.Store(int32(statusCode))
+		f := func(reqBody string) string {
+			return test.resp
+		}
+		httpHandler.getRespBody.Store(&f)
+		res, err := br.readBackendMetric(context.Background(), addr)
+		if test.hasErr {
+			require.NotNil(t, err, "case %d", i)
+		} else {
+			require.Nil(t, err, "case %d", i)
+			require.Equal(t, test.resp, string(res), "case %d", i)
+		}
+	}
+}
+
+// test groupMetricsByRule
+func TestOneRuleOneHistory(t *testing.T) {
+	tests := []struct {
+		names      []string
+		step1Value model.SampleValue
+		step2Value model.SampleValue
+		returnType model.ValueType
+	}{
+		{
+			names: []string{"name1", "name2", "name3"},
+		},
+		{
+			names:      []string{"name1", "name2"},
+			step1Value: model.SampleValue(math.NaN()),
+		},
+		{
+			names:      []string{"name1", "name2"},
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(math.NaN()),
+		},
+		{
+			names:      []string{"name1", "name2"},
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(2),
+			returnType: model.ValMatrix,
+		},
+		{
+			names:      []string{"name1", "name2"},
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(2),
+			returnType: model.ValVector,
+		},
+	}
+
+	mfs := mockMfs()
+	lg, _ := logger.CreateLoggerForTest(t)
+	for i, test := range tests {
+		br := NewBackendReader(lg, nil, nil, nil, nil)
+		br.queryRules = map[uint64]QueryRule{
+			1: {
+				Names: test.names,
+				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+					return test.step1Value
+				},
+				Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+					return test.step2Value
+				},
+				ResultType: test.returnType,
+			},
+		}
+
+		res := br.groupMetricsByRule(mfs, "backend")
+		value := res[1]
+		switch test.returnType {
+		case model.ValVector:
+			require.Equal(t, test.returnType, value.Type(), "case %d", i)
+			require.Len(t, value.(model.Vector), 1, "case %d", i)
+			sample := value.(model.Vector)[0]
+			require.Equal(t, model.LabelValue("backend"), sample.Metric[LabelNameInstance], "case %d", i)
+			require.Equal(t, test.step2Value, sample.Value, "case %d", i)
+			require.Greater(t, sample.Timestamp, int64(0), "case %d", i)
+		case model.ValMatrix:
+			require.Equal(t, test.returnType, value.Type(), "case %d", i)
+			require.Len(t, value.(model.Matrix), 1, "case %d", i)
+			require.Equal(t, model.LabelValue("backend"), value.(model.Matrix)[0].Metric[LabelNameInstance], "case %d", i)
+			require.Len(t, value.(model.Matrix)[0].Values, 1, "case %d", i)
+			pair := value.(model.Matrix)[0].Values[0]
+			require.Equal(t, test.step2Value, pair.Value, "case %d", i)
+			require.Greater(t, pair.Timestamp, int64(0), "case %d", i)
+		default:
+			require.Nil(t, value, "case %d", i)
+		}
+	}
+}
+
+// test groupMetricsByRule
+func TestOneRuleMultiHistory(t *testing.T) {
+	tests := []struct {
+		step1Value model.SampleValue
+		step2Value model.SampleValue
+	}{
+		{
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(math.NaN()),
+		},
+		{
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(2),
+		},
+		{
+			step1Value: model.SampleValue(1),
+			step2Value: model.SampleValue(math.NaN()),
+		},
+		{
+			step1Value: model.SampleValue(2),
+			step2Value: model.SampleValue(3),
+		},
+		{
+			step1Value: model.SampleValue(3),
+			step2Value: model.SampleValue(4),
+		},
+	}
+
+	mfs := mockMfs()
+	lg, _ := logger.CreateLoggerForTest(t)
+	br := NewBackendReader(lg, nil, nil, nil, nil)
+	var lastTs model.Time
+	var length int
+	for i, test := range tests {
+		br.queryRules = map[uint64]QueryRule{
+			1: {
+				Names: []string{"name1", "name2"},
+				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+					return test.step1Value
+				},
+				Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+					return test.step2Value
+				},
+				ResultType: model.ValMatrix,
+			},
+		}
+
+		res := br.groupMetricsByRule(mfs, "backend")
+		value := res[1]
+		if math.IsNaN(float64(test.step2Value)) {
+			require.Nil(t, value, "case %d", i)
+			continue
+		}
+		length++
+		require.Equal(t, model.ValMatrix, value.Type(), "case %d", i)
+		matrix := value.(model.Matrix)
+		require.Len(t, matrix, 1, "case %d", i)
+		require.Equal(t, model.LabelValue("backend"), matrix[0].Metric[LabelNameInstance], "case %d", i)
+		require.Len(t, matrix[0].Values, length, "case %d", i)
+		pair := matrix[0].Values[len(matrix[0].Values)-1]
+		require.Equal(t, test.step2Value, pair.Value, "case %d", i)
+		require.GreaterOrEqual(t, pair.Timestamp, lastTs, "case %d", i)
+		lastTs = pair.Timestamp
+	}
+}
+
+// test groupMetricsByRule
+func TestMultiRules(t *testing.T) {
+	returnedValues := []model.SampleValue{model.SampleValue(1), model.SampleValue(2)}
+	rule1 := QueryRule{
+		Names: []string{"name1"},
+		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			return 1
+		},
+		Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+			return returnedValues[0]
+		},
+		ResultType: model.ValMatrix,
+	}
+	rule2 := QueryRule{
+		Names: []string{"name2"},
+		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			return 2
+		},
+		Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+			return returnedValues[1]
+		},
+		ResultType: model.ValVector,
+	}
+	tests := []struct {
+		hasRule1   bool
+		hasRule2   bool
+		rule1Value model.SampleValue
+		rule2Value model.SampleValue
+	}{
+		{
+			hasRule1:   true,
+			rule1Value: 1,
+		},
+		{
+			hasRule1:   true,
+			hasRule2:   true,
+			rule1Value: 2,
+			rule2Value: 3,
+		},
+		{
+			hasRule2:   true,
+			rule2Value: 4,
+		},
+	}
+
+	mfs := mockMfs()
+	lg, _ := logger.CreateLoggerForTest(t)
+	br := NewBackendReader(lg, nil, nil, nil, nil)
+	for i, test := range tests {
+		if test.hasRule1 {
+			br.queryRules[1] = rule1
+			returnedValues[0] = test.rule1Value
+		} else {
+			delete(br.queryRules, 1)
+		}
+		if test.hasRule2 {
+			br.queryRules[2] = rule2
+			returnedValues[1] = test.rule2Value
+		} else {
+			delete(br.queryRules, 2)
+		}
+		res := br.groupMetricsByRule(mfs, "backend")
+		require.Len(t, res, len(br.queryRules), "case %d", i)
+
+		if test.hasRule1 {
+			value := res[1]
+			require.Equal(t, rule1.ResultType, value.Type(), "case %d", i)
+			matrix := value.(model.Matrix)
+			require.Len(t, matrix, 1, "case %d", i)
+			require.Equal(t, model.LabelValue("backend"), matrix[0].Metric[LabelNameInstance], "case %d", i)
+			pair := matrix[0].Values[len(matrix[0].Values)-1]
+			require.Equal(t, test.rule1Value, pair.Value, "case %d", i)
+			require.Greater(t, pair.Timestamp, int64(0), "case %d", i)
+		}
+		if test.hasRule2 {
+			value := res[2]
+			require.Equal(t, rule2.ResultType, value.Type(), "case %d", i)
+			require.Len(t, value.(model.Vector), 1, "case %d", i)
+			sample := value.(model.Vector)[0]
+			require.Equal(t, model.LabelValue("backend"), sample.Metric[LabelNameInstance], "case %d", i)
+			require.Equal(t, test.rule2Value, sample.Value, "case %d", i)
+			require.Greater(t, sample.Timestamp, int64(0), "case %d", i)
+		}
+	}
+}
+
+// test mergeQueryResult
+func TestMergeQueryResult(t *testing.T) {
+	tests := []struct {
+		backend       string
+		backendValues map[uint64]model.Value
+		queryResult   map[uint64]model.Value
+	}{
+		{
+			backend: "backend1",
+			backendValues: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(1), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+			},
+			queryResult: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(1), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+			},
+		},
+		{
+			backend: "backend2",
+			backendValues: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(3), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend2"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(4), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend2"}}},
+			},
+			queryResult: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(3), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend2"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(4), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend2"}}},
+			},
+		},
+		{
+			backend: "backend1",
+			backendValues: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(5), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}, {Value: model.SampleValue(6), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+			},
+			queryResult: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(5), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}, {Value: model.SampleValue(6), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+			},
+		},
+		{
+			backend: "backend3",
+			backendValues: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(7), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend3"}}},
+			},
+			queryResult: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(7), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend3"}}},
+			},
+		},
+		{
+			backend: "backend3",
+			backendValues: map[uint64]model.Value{
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(8), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend3"}}},
+			},
+			queryResult: map[uint64]model.Value{
+				1: model.Vector{{Value: model.SampleValue(7), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend3"}}},
+				2: model.Matrix{{Values: []model.SamplePair{{Value: model.SampleValue(8), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend3"}}},
+			},
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	br := NewBackendReader(lg, nil, nil, nil, nil)
+	for i, test := range tests {
+		br.mergeQueryResult(test.backendValues, test.backend)
+		for id, expectedValue := range test.queryResult {
+			qr := br.GetQueryResult(id)
+			require.NotNil(t, qr.Value, "case %d", i)
+			require.Equal(t, expectedValue.Type(), qr.Value.Type(), "case %d", i)
+			switch expectedValue.Type() {
+			case model.ValVector:
+				var sample *model.Sample
+				for _, v := range qr.Value.(model.Vector) {
+					if v.Metric[LabelNameInstance] == model.LabelValue(test.backend) {
+						require.Nil(t, sample, "case %d", i)
+						sample = v
+					}
+				}
+				require.Equal(t, expectedValue.(model.Vector)[0], sample, "case %d", i)
+			case model.ValMatrix:
+				var sample *model.SampleStream
+				for _, v := range qr.Value.(model.Matrix) {
+					if v.Metric[LabelNameInstance] == model.LabelValue(test.backend) {
+						require.Nil(t, sample, "case %d", i)
+						sample = v
+					}
+				}
+				require.Equal(t, expectedValue.(model.Matrix)[0], sample, "case %d", i)
+			}
+		}
+	}
+}
+
+// test purgeHistory
+func TestPurgeHistory(t *testing.T) {
+	now := model.TimeFromUnixNano(time.Now().UnixNano())
+	tests := []struct {
+		backendHistory  map[string]backendHistory
+		expectedHistory map[string]backendHistory
+	}{
+		{
+			backendHistory: map[string]backendHistory{
+				"backend1": {
+					step1History: []model.SamplePair{{Value: model.SampleValue(1), Timestamp: now.Add(-2 * time.Minute)}, {Value: model.SampleValue(2), Timestamp: now.Add(-30 * time.Second)}},
+					step2History: []model.SamplePair{{Value: model.SampleValue(3), Timestamp: now.Add(-2 * time.Minute)}, {Value: model.SampleValue(4), Timestamp: now.Add(-30 * time.Second)}},
+				},
+				"backend2": {
+					step1History: []model.SamplePair{{Value: model.SampleValue(5), Timestamp: now.Add(-2 * time.Minute)}},
+					step2History: []model.SamplePair{{Value: model.SampleValue(7), Timestamp: now.Add(-30 * time.Second)}},
+				},
+			},
+			expectedHistory: map[string]backendHistory{
+				"backend1": {
+					step1History: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: now.Add(-30 * time.Second)}},
+					step2History: []model.SamplePair{{Value: model.SampleValue(4), Timestamp: now.Add(-30 * time.Second)}},
+				},
+				"backend2": {
+					step1History: []model.SamplePair{},
+					step2History: []model.SamplePair{{Value: model.SampleValue(7), Timestamp: now.Add(-30 * time.Second)}},
+				},
+			},
+		},
+		{
+			backendHistory: map[string]backendHistory{
+				"backend1": {
+					step1History: []model.SamplePair{{Value: model.SampleValue(1), Timestamp: now.Add(-2 * time.Minute)}},
+					step2History: []model.SamplePair{{Value: model.SampleValue(3), Timestamp: now.Add(-2 * time.Minute)}},
+				},
+				"backend2": {
+					step1History: []model.SamplePair{{Value: model.SampleValue(1), Timestamp: now.Add(-2 * time.Minute)}},
+					step2History: []model.SamplePair{{Value: model.SampleValue(3), Timestamp: now.Add(-2 * time.Minute)}},
+				},
+			},
+			expectedHistory: map[string]backendHistory{},
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	br := NewBackendReader(lg, nil, nil, nil, nil)
+	for i, test := range tests {
+		br.AddQueryRule(uint64(i), QueryRule{
+			Retention: time.Minute,
+		})
+		br.history[uint64(i)] = test.backendHistory
+	}
+
+	br.purgeHistory()
+	for i, test := range tests {
+		actualHistory := br.history[uint64(i)]
+		require.Equal(t, test.expectedHistory, actualHistory, "case %d", i)
+	}
+}
+
+func TestQueryBackendConcurrently(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := newHealthCheckConfigForTest()
+	const initialRules, initialBackends = 3, 3
+	var buf strings.Builder
+	for i := 0; i < initialRules+1; i++ {
+		buf.WriteString(fmt.Sprintf("name%d 100\n", i))
+	}
+	resp := buf.String()
+
+	// create 3 backends
+	httpHandlers := make([]*mockHttpHandler, 0)
+	infos := make(map[string]*infosync.TiDBTopologyInfo)
+	for i := 0; i < 3; i++ {
+		httpHandler := newMockHttpHandler(t)
+		f := func(reqBody string) string {
+			return resp
+		}
+		httpHandler.getRespBody.Store(&f)
+		port := httpHandler.Start()
+		infos[strconv.Itoa(i)] = &infosync.TiDBTopologyInfo{
+			IP:         "127.0.0.1",
+			StatusPort: uint(port),
+		}
+		httpHandlers = append(httpHandlers, httpHandler)
+	}
+	t.Cleanup(func() {
+		for _, h := range httpHandlers {
+			h.Close()
+		}
+	})
+
+	fetcher := newMockBackendFetcher(infos, nil)
+	br := NewBackendReader(lg, nil, http.DefaultClient, fetcher, cfg)
+	// create 3 rules
+	addRule := func(id uint64) {
+		rule := QueryRule{
+			Names: []string{fmt.Sprintf("name%d", id)},
+			Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+				return model.SampleValue(rand.Float64())
+			},
+			Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+				return model.SampleValue(rand.Float64())
+			},
+		}
+		if id%2 == 0 {
+			rule.ResultType = model.ValVector
+		} else {
+			rule.ResultType = model.ValMatrix
+		}
+		br.AddQueryRule(id, rule)
+	}
+	removeRule := func(id uint64) {
+		br.RemoveQueryRule(id)
+	}
+	for i := 0; i < initialRules; i++ {
+		addRule(uint64(i))
+	}
+
+	// start a goroutine to query metrics
+	var wg waitgroup.WaitGroup
+	childCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// fill the initial query result to ensure the result is always non-empty
+	err := br.readFromBackends(childCtx)
+	require.NoError(t, err)
+	wg.Run(func() {
+		for childCtx.Err() == nil {
+			err := br.readFromBackends(childCtx)
+			require.NoError(t, err)
+			br.purgeHistory()
+		}
+	})
+
+	// start a goroutine to add and remove rules
+	wg.Run(func() {
+		var idx int
+		for childCtx.Err() == nil {
+			select {
+			case <-time.After(10 * time.Millisecond):
+				if idx%2 == 0 {
+					addRule(initialRules)
+				} else {
+					removeRule(initialRules)
+				}
+				idx++
+			case <-childCtx.Done():
+				return
+			}
+		}
+	})
+
+	// start a goroutine to query results
+	wg.Run(func() {
+		for childCtx.Err() == nil {
+			select {
+			case <-time.After(1 * time.Millisecond):
+				for i := 0; i < initialRules; i++ {
+					qr := br.GetQueryResult(uint64(i))
+					require.NotNil(t, qr.Value)
+					if i%2 == 0 {
+						require.Equal(t, model.ValVector, qr.Value.Type())
+						require.Len(t, qr.Value.(model.Vector), initialBackends)
+					} else {
+						require.Equal(t, model.ValMatrix, qr.Value.Type())
+						require.Len(t, qr.Value.(model.Matrix), initialBackends)
+						for j := 0; j < initialBackends; j++ {
+							require.NotEmpty(t, qr.Value.(model.Matrix)[j].Values)
+						}
+					}
+				}
+			case <-childCtx.Done():
+				return
+			}
+		}
+	})
+	wg.Wait()
+	cancel()
+}

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -34,6 +34,11 @@ type PromInfoFetcher interface {
 	GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, error)
 }
 
+// TopologyFetcher is an interface to fetch the tidb topology from ETCD.
+type TopologyFetcher interface {
+	GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error)
+}
+
 type MetricsReader interface {
 	Start(ctx context.Context)
 	AddQueryExpr(queryExpr QueryExpr) uint64

--- a/pkg/balance/metricsreader/mock_test.go
+++ b/pkg/balance/metricsreader/mock_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/testkit"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +35,24 @@ func newMockPromFetcher(port int) *mockPromFetcher {
 				Port: port,
 			}, nil
 		},
+	}
+}
+
+var _ TopologyFetcher = (*mockBackendFetcher)(nil)
+
+type mockBackendFetcher struct {
+	infos map[string]*infosync.TiDBTopologyInfo
+	err   error
+}
+
+func (mbf *mockBackendFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error) {
+	return mbf.infos, mbf.err
+}
+
+func newMockBackendFetcher(infos map[string]*infosync.TiDBTopologyInfo, err error) *mockBackendFetcher {
+	return &mockBackendFetcher{
+		infos: infos,
+		err:   err,
 	}
 }
 
@@ -121,4 +140,12 @@ func (mb *mockBackend) GetBackendInfo() observer.BackendInfo {
 
 func (mb *mockBackend) Local() bool {
 	return true
+}
+
+func mockMfs() map[string]*dto.MetricFamily {
+	floats := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	return map[string]*dto.MetricFamily{
+		"name1": {Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: &floats[0]}}}},
+		"name2": {Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: &floats[1]}}}},
+	}
 }

--- a/pkg/balance/observer/backend_fetcher.go
+++ b/pkg/balance/observer/backend_fetcher.go
@@ -23,7 +23,7 @@ type BackendFetcher interface {
 
 // TopologyFetcher is an interface to fetch the tidb topology from ETCD.
 type TopologyFetcher interface {
-	GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error)
+	GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error)
 }
 
 // PDFetcher fetches backend list from PD.
@@ -46,14 +46,6 @@ func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInf
 	backends := pf.fetchBackendList(ctx)
 	infos := make(map[string]*BackendInfo, len(backends))
 	for addr, backend := range backends {
-		// If ttl is empty, maybe the backend is down.
-		if len(backend.TTL) == 0 {
-			continue
-		}
-		// If topology is empty, maybe the backend is not ready yet.
-		if backend.TiDBTopologyInfo == nil {
-			continue
-		}
 		infos[addr] = &BackendInfo{
 			Labels:     backend.Labels,
 			IP:         backend.IP,
@@ -63,8 +55,8 @@ func (pf *PDFetcher) GetBackendList(ctx context.Context) (map[string]*BackendInf
 	return infos, nil
 }
 
-func (pf *PDFetcher) fetchBackendList(ctx context.Context) map[string]*infosync.TiDBInfo {
-	var backends map[string]*infosync.TiDBInfo
+func (pf *PDFetcher) fetchBackendList(ctx context.Context) map[string]*infosync.TiDBTopologyInfo {
+	var backends map[string]*infosync.TiDBTopologyInfo
 	// The jobs of PDFetcher all rely on the topology, so we retry infinitely.
 	err := retry.RetryNotify(func() error {
 		var err error

--- a/pkg/balance/observer/backend_fetcher_test.go
+++ b/pkg/balance/observer/backend_fetcher_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestPDFetcher(t *testing.T) {
 	tests := []struct {
-		infos map[string]*infosync.TiDBInfo
+		infos map[string]*infosync.TiDBTopologyInfo
 		ctx   context.Context
 		check func(map[string]*BackendInfo)
 	}{
@@ -24,37 +24,11 @@ func TestPDFetcher(t *testing.T) {
 			},
 		},
 		{
-			infos: map[string]*infosync.TiDBInfo{
+			infos: map[string]*infosync.TiDBTopologyInfo{
 				"1.1.1.1:4000": {
-					TTL: "123456789",
-				},
-			},
-			check: func(m map[string]*BackendInfo) {
-				require.Empty(t, m)
-			},
-		},
-		{
-			infos: map[string]*infosync.TiDBInfo{
-				"1.1.1.1:4000": {
-					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
-						IP:         "1.1.1.1",
-						StatusPort: 10080,
-					},
-				},
-			},
-			check: func(m map[string]*BackendInfo) {
-				require.Empty(t, m)
-			},
-		},
-		{
-			infos: map[string]*infosync.TiDBInfo{
-				"1.1.1.1:4000": {
-					TTL: "123456789",
-					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
-						Labels:     map[string]string{"k1": "v1"},
-						IP:         "1.1.1.1",
-						StatusPort: 10080,
-					},
+					Labels:     map[string]string{"k1": "v1"},
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
 				},
 			},
 			check: func(m map[string]*BackendInfo) {
@@ -66,20 +40,14 @@ func TestPDFetcher(t *testing.T) {
 			},
 		},
 		{
-			infos: map[string]*infosync.TiDBInfo{
+			infos: map[string]*infosync.TiDBTopologyInfo{
 				"1.1.1.1:4000": {
-					TTL: "123456789",
-					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
-						IP:         "1.1.1.1",
-						StatusPort: 10080,
-					},
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
 				},
 				"2.2.2.2:4000": {
-					TTL: "123456789",
-					TiDBTopologyInfo: &infosync.TiDBTopologyInfo{
-						IP:         "2.2.2.2",
-						StatusPort: 10080,
-					},
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
 				},
 			},
 			check: func(m map[string]*BackendInfo) {

--- a/pkg/balance/observer/mock_test.go
+++ b/pkg/balance/observer/mock_test.go
@@ -17,7 +17,7 @@ import (
 
 type mockTpFetcher struct {
 	t     *testing.T
-	infos map[string]*infosync.TiDBInfo
+	infos map[string]*infosync.TiDBTopologyInfo
 	err   error
 }
 
@@ -27,7 +27,7 @@ func newMockTpFetcher(t *testing.T) *mockTpFetcher {
 	}
 }
 
-func (ft *mockTpFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBInfo, error) {
+func (ft *mockTpFetcher) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error) {
 	return ft.infos, ft.err
 }
 

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -100,11 +100,11 @@ func TestFetchTiDBTopology(t *testing.T) {
 
 	tests := []struct {
 		update func()
-		check  func(info map[string]*TiDBInfo)
+		check  func(info map[string]*TiDBTopologyInfo)
 	}{
 		{
 			// No backends.
-			check: func(info map[string]*TiDBInfo) {
+			check: func(info map[string]*TiDBTopologyInfo) {
 				require.Empty(t, info)
 			},
 		},
@@ -113,10 +113,8 @@ func TestFetchTiDBTopology(t *testing.T) {
 			update: func() {
 				ts.updateTTL("1.1.1.1:4000", []byte("123456789"))
 			},
-			check: func(info map[string]*TiDBInfo) {
-				require.Len(ts.t, info, 1)
-				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
-				require.Nil(ts.t, info["1.1.1.1:4000"].TiDBTopologyInfo)
+			check: func(info map[string]*TiDBTopologyInfo) {
+				require.Len(ts.t, info, 0)
 			},
 		},
 		{
@@ -127,10 +125,9 @@ func TestFetchTiDBTopology(t *testing.T) {
 					StatusPort: 10080,
 				})
 			},
-			check: func(info map[string]*TiDBInfo) {
+			check: func(info map[string]*TiDBTopologyInfo) {
 				require.Len(ts.t, info, 1)
-				require.Equal(ts.t, "123456789", info["1.1.1.1:4000"].TTL)
-				require.NotNil(ts.t, info["1.1.1.1:4000"].TiDBTopologyInfo)
+				require.NotNil(ts.t, info["1.1.1.1:4000"])
 				require.Equal(ts.t, "1.1.1.1", info["1.1.1.1:4000"].IP)
 				require.Equal(ts.t, uint(10080), info["1.1.1.1:4000"].StatusPort)
 			},
@@ -144,10 +141,9 @@ func TestFetchTiDBTopology(t *testing.T) {
 					StatusPort: 10080,
 				})
 			},
-			check: func(info map[string]*TiDBInfo) {
+			check: func(info map[string]*TiDBTopologyInfo) {
 				require.Len(ts.t, info, 2)
-				require.Equal(ts.t, "123456789", info["2.2.2.2:4000"].TTL)
-				require.NotNil(ts.t, info["2.2.2.2:4000"].TiDBTopologyInfo)
+				require.NotNil(ts.t, info["2.2.2.2:4000"])
 				require.Equal(ts.t, "2.2.2.2", info["2.2.2.2:4000"].IP)
 				require.Equal(ts.t, uint(10080), info["2.2.2.2:4000"].StatusPort)
 			},
@@ -157,10 +153,9 @@ func TestFetchTiDBTopology(t *testing.T) {
 			update: func() {
 				ts.deleteTTL("2.2.2.2:4000")
 			},
-			check: func(info map[string]*TiDBInfo) {
-				require.Len(ts.t, info, 2)
-				require.Empty(ts.t, info["2.2.2.2:4000"].TTL)
-				require.NotNil(ts.t, info["2.2.2.2:4000"].TiDBTopologyInfo)
+			check: func(info map[string]*TiDBTopologyInfo) {
+				require.Len(ts.t, info, 1)
+				require.Contains(ts.t, info, "1.1.1.1:4000")
 			},
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #596 

Problem Summary:

On the cloud, the Prometheus is inaccessible from TiProxy, so TiProxy can only read from TiDB directly.

What is changed and how it works:

- Add `BackendReader` to read metrics directly from backends
- Make `InfoSyncer.GetTiDBTopology` return `TiDBTopologyInfo` because TiProxy doesn't need TTL of TiDB
- Move `GetIPPort` from `InfoSyncer` to `Config`
- Fix the ETCD key path and ID of `VIPManager`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
