### PR TITLE
factor: define query rules for factors

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -424,7 +424,8 @@ func filterMetrics(all string, names []string) string {
 			all = all[idx+1:]
 		}
 		for i := range names {
-			// strings.Contains() includes the metric description in the result but it's slower.
+			// strings.Contains() includes the metric type in the result but it's slower.
+			// Note that the result is always in `Metric.Untyped` because the metric type is ignored.
 			if strings.HasPrefix(line, names[i]) {
 				buffer.WriteString(line)
 				break


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #598 

Problem Summary:
Define the `QueryRule` for factors `cpu`, `memory`, and `health` so that the factors can query the metrics from backends.

What is changed and how it works:
- Define `QueryRule` for factors `cpu`, `memory`, and `health`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
