### PR TITLE
metricsreader, api: read backend metrics from owner

### DIFF
--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -93,18 +93,16 @@ func (mgr *NamespaceManager) CommitNamespaces(nss []*config.Namespace, nss_delet
 }
 
 func (mgr *NamespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher observer.TopologyFetcher,
-	promFetcher metricsreader.PromInfoFetcher, httpCli *http.Client, cfgMgr *mconfig.ConfigManager) error {
+	promFetcher metricsreader.PromInfoFetcher, httpCli *http.Client, cfgMgr *mconfig.ConfigManager,
+	metricsReader metricsreader.MetricsReader) error {
 	mgr.Lock()
 	mgr.tpFetcher = tpFetcher
 	mgr.promFetcher = promFetcher
 	mgr.httpCli = httpCli
 	mgr.logger = logger
-	healthCheckCfg := config.NewDefaultHealthCheckConfig()
-	mgr.metricsReader = metricsreader.NewDefaultMetricsReader(logger.Named("mr"), mgr.promFetcher, healthCheckCfg)
 	mgr.cfgMgr = cfgMgr
+	mgr.metricsReader = metricsReader
 	mgr.Unlock()
-
-	mgr.metricsReader.Start(context.Background())
 	return mgr.CommitNamespaces(nscs, nil)
 }
 

--- a/pkg/server/api/backend.go
+++ b/pkg/server/api/backend.go
@@ -1,0 +1,32 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type BackendReader interface {
+	GetBackendMetrics() ([]byte, error)
+}
+
+func (h *Server) BackendMetrics(c *gin.Context) {
+	metrics, err := h.mgr.br.GetBackendMetrics()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, err)
+		return
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	if _, err := c.Writer.Write(metrics); err != nil {
+		h.lg.Error("write backend metrics failed", zap.Error(err))
+	}
+}
+
+func (h *Server) registerBackend(group *gin.RouterGroup) {
+	group.GET("/metrics", h.BackendMetrics)
+}

--- a/pkg/server/api/backend_test.go
+++ b/pkg/server/api/backend_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestBackendMetrics(t *testing.T) {
+	server, doHTTP := createServer(t, nil)
+	mbr := server.mgr.br.(*mockBackendReader)
+	mbr.data.Store(`{"key": "value"}`)
+
+	doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, string(all), `{"key": "value"}`)
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+
+	mbr.err.Store(errors.New("mock error"))
+	doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
+		_, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NotEqual(t, http.StatusOK, r.StatusCode)
+	})
+}
+
+type mockBackendReader struct {
+	data atomic.String
+	err  atomic.Error
+}
+
+func (mbr *mockBackendReader) GetBackendMetrics() ([]byte, error) {
+	return []byte(mbr.data.Load()), mbr.err.Load()
+}

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -36,7 +36,7 @@ func createServer(t *testing.T, closing *bool) (*Server, func(t *testing.T, meth
 		Addr: "0.0.0.0:0",
 	}, lg, func() bool {
 		return *closing
-	}, mgrns.NewNamespaceManager(), cfgmgr, crtmgr, nil, ready)
+	}, mgrns.NewNamespaceManager(), cfgmgr, crtmgr, &mockBackendReader{}, nil, ready)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, srv.Close())

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -1,0 +1,51 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+)
+
+func Get(httpCli http.Client, addr, path string, b backoff.BackOff) ([]byte, error) {
+	schema := "http"
+	if v, ok := httpCli.Transport.(*http.Transport); ok && v != nil && v.TLSClientConfig != nil {
+		schema = "https"
+	}
+	url := fmt.Sprintf("%s://%s%s", schema, addr, path)
+	var body []byte
+	err := ConnectWithRetry(func() error {
+		resp, err := httpCli.Get(url)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return backoff.Permanent(errors.Errorf("http status %d", resp.StatusCode))
+		}
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Errorf("read response body failed, url: %s, err: %s", url, err.Error())
+		}
+		return err
+	}, b)
+	return body, err
+}
+
+func ConnectWithRetry(connect func() error, b backoff.BackOff) error {
+	err := backoff.Retry(func() error {
+		err := connect()
+		if !pnet.IsRetryableError(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}, b)
+	return err
+}

--- a/pkg/util/httputil/http_test.go
+++ b/pkg/util/httputil/http_test.go
@@ -1,0 +1,87 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/testkit"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestHTTPGet(t *testing.T) {
+	httpHandler := &mockHttpHandler{
+		t: t,
+	}
+	httpHandler.setHTTPResp(true)
+	httpHandler.setHTTPRespBody("hello")
+	statusListener, statusAddr := testkit.StartListener(t, "")
+	statusServer := &http.Server{Addr: statusAddr, Handler: httpHandler}
+	var wg waitgroup.WaitGroup
+	wg.Run(func() {
+		_ = statusServer.Serve(statusListener)
+	})
+
+	httpCli := *http.DefaultClient
+	httpCli.Timeout = time.Second
+	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), uint64(2)), context.Background())
+
+	resp, err := Get(httpCli, statusAddr, "", b)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(resp))
+
+	httpHandler.setHTTPResp(false)
+	_, err = Get(httpCli, statusAddr, "", b)
+	require.Error(t, err)
+
+	httpCli.Timeout = time.Millisecond
+	httpHandler.setHTTPWait(100 * time.Millisecond)
+	_, err = Get(httpCli, statusAddr, "", b)
+	require.Error(t, err)
+
+	err = statusServer.Close()
+	require.NoError(t, err)
+	wg.Wait()
+
+	_, err = Get(httpCli, statusAddr, "", b)
+	require.Error(t, err)
+}
+
+type mockHttpHandler struct {
+	t        *testing.T
+	httpOK   atomic.Bool
+	respBody atomic.String
+	wait     atomic.Int64
+}
+
+func (handler *mockHttpHandler) setHTTPResp(succeed bool) {
+	handler.httpOK.Store(succeed)
+}
+
+func (handler *mockHttpHandler) setHTTPRespBody(body string) {
+	handler.respBody.Store(body)
+}
+
+func (handler *mockHttpHandler) setHTTPWait(wait time.Duration) {
+	handler.wait.Store(int64(wait))
+}
+
+func (handler *mockHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	wait := handler.wait.Load()
+	if wait > 0 {
+		time.Sleep(time.Duration(wait))
+	}
+	if handler.httpOK.Load() {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(handler.respBody.Load()))
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #600

Problem Summary:
Read the backend metrics from the owner because if everyone reads from the backends, the backends may suffer from big pressure if the cluster is large.

What is changed and how it works:
- `BackendReader` supports marshaling and unmarshaling backend metric history
- The HTTP API reads metric data from `BackendReader`
- Move the creation of `BackendReader` from `NamespaceManager` to `Server` so that it can be passed to `api.Server`
- Move the common code of reconnection to package `httputil`
- Change the rule key from uint64 to string so that the keys of every TiProxy are the same. The caller is responsible for specifying the rule key

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
