### PR TITLE
balance, infosync: support reading metrics from both prometheus and backend

### DIFF
--- a/lib/config/health.go
+++ b/lib/config/health.go
@@ -3,6 +3,64 @@
 
 package config
 
+import "time"
+
 type HealthInfo struct {
 	ConfigChecksum uint32 `json:"config_checksum"`
+}
+
+const (
+	healthCheckInterval      = 3 * time.Second
+	healthCheckMaxRetries    = 3
+	healthCheckRetryInterval = 1 * time.Second
+	healthCheckTimeout       = 2 * time.Second
+	readMetricsInterval      = 5 * time.Second
+	readMetricsTimeout       = 3 * time.Second
+)
+
+// HealthCheck contains some configurations for health check.
+// Some general configurations of them may be exposed to users in the future.
+// We can use shorter durations to speed up unit tests.
+type HealthCheck struct {
+	Enable          bool          `yaml:"enable" json:"enable" toml:"enable"`
+	Interval        time.Duration `yaml:"interval" json:"interval" toml:"interval"`
+	MaxRetries      int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
+	RetryInterval   time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
+	DialTimeout     time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
+	MetricsInterval time.Duration `yaml:"metrics-interval" json:"metrics-interval" toml:"metrics-interval"`
+	MetricsTimeout  time.Duration `yaml:"metrics-timeout" json:"metrics-timeout" toml:"metrics-timeout"`
+}
+
+// NewDefaultHealthCheckConfig creates a default HealthCheck.
+func NewDefaultHealthCheckConfig() *HealthCheck {
+	return &HealthCheck{
+		Enable:          true,
+		Interval:        healthCheckInterval,
+		MaxRetries:      healthCheckMaxRetries,
+		RetryInterval:   healthCheckRetryInterval,
+		DialTimeout:     healthCheckTimeout,
+		MetricsInterval: readMetricsInterval,
+		MetricsTimeout:  readMetricsTimeout,
+	}
+}
+
+func (hc *HealthCheck) Check() {
+	if hc.Interval == 0 {
+		hc.Interval = healthCheckInterval
+	}
+	if hc.MaxRetries == 0 {
+		hc.MaxRetries = healthCheckMaxRetries
+	}
+	if hc.RetryInterval == 0 {
+		hc.RetryInterval = healthCheckRetryInterval
+	}
+	if hc.DialTimeout == 0 {
+		hc.DialTimeout = healthCheckTimeout
+	}
+	if hc.MetricsInterval == 0 {
+		hc.MetricsInterval = readMetricsInterval
+	}
+	if hc.MetricsTimeout == 0 {
+		hc.MetricsTimeout = readMetricsTimeout
+	}
 }

--- a/lib/config/namespace.go
+++ b/lib/config/namespace.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"bytes"
-	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -24,63 +23,6 @@ type FrontendNamespace struct {
 type BackendNamespace struct {
 	Instances []string  `yaml:"instances" json:"instances" toml:"instances"`
 	Security  TLSConfig `yaml:"security" json:"security" toml:"security"`
-	//HealthCheck  HealthCheck `yaml:"health-check" json:"health-check" toml:"health-check"`
-}
-
-const (
-	healthCheckInterval      = 3 * time.Second
-	healthCheckMaxRetries    = 3
-	healthCheckRetryInterval = 1 * time.Second
-	healthCheckTimeout       = 2 * time.Second
-	readMetricsInterval      = 5 * time.Second
-	readMetricsTimeout       = 3 * time.Second
-)
-
-// HealthCheck contains some configurations for health check.
-// Some general configurations of them may be exposed to users in the future.
-// We can use shorter durations to speed up unit tests.
-type HealthCheck struct {
-	Enable          bool          `yaml:"enable" json:"enable" toml:"enable"`
-	Interval        time.Duration `yaml:"interval" json:"interval" toml:"interval"`
-	MaxRetries      int           `yaml:"max-retries" json:"max-retries" toml:"max-retries"`
-	RetryInterval   time.Duration `yaml:"retry-interval" json:"retry-interval" toml:"retry-interval"`
-	DialTimeout     time.Duration `yaml:"dial-timeout" json:"dial-timeout" toml:"dial-timeout"`
-	MetricsInterval time.Duration `yaml:"metrics-interval" json:"metrics-interval" toml:"metrics-interval"`
-	MetricsTimeout  time.Duration `yaml:"metrics-timeout" json:"metrics-timeout" toml:"metrics-timeout"`
-}
-
-// NewDefaultHealthCheckConfig creates a default HealthCheck.
-func NewDefaultHealthCheckConfig() *HealthCheck {
-	return &HealthCheck{
-		Enable:          true,
-		Interval:        healthCheckInterval,
-		MaxRetries:      healthCheckMaxRetries,
-		RetryInterval:   healthCheckRetryInterval,
-		DialTimeout:     healthCheckTimeout,
-		MetricsInterval: readMetricsInterval,
-		MetricsTimeout:  readMetricsTimeout,
-	}
-}
-
-func (hc *HealthCheck) Check() {
-	if hc.Interval == 0 {
-		hc.Interval = healthCheckInterval
-	}
-	if hc.MaxRetries == 0 {
-		hc.MaxRetries = healthCheckMaxRetries
-	}
-	if hc.RetryInterval == 0 {
-		hc.RetryInterval = healthCheckRetryInterval
-	}
-	if hc.DialTimeout == 0 {
-		hc.DialTimeout = healthCheckTimeout
-	}
-	if hc.MetricsInterval == 0 {
-		hc.MetricsInterval = readMetricsInterval
-	}
-	if hc.MetricsTimeout == 0 {
-		hc.MetricsTimeout = readMetricsTimeout
-	}
 }
 
 func NewNamespace(data []byte) (*Namespace, error) {

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -83,8 +83,8 @@ func TestCPUBalanceOnce(t *testing.T) {
 			values = append(values, createSampleStream(test.cpus[j], j, model.Now()))
 		}
 		mmr := &mockMetricsReader{
-			qrs: map[uint64]metricsreader.QueryResult{
-				1: {
+			qrs: map[string]metricsreader.QueryResult{
+				"cpu": {
 					UpdateTime: monotime.Now(),
 					Value:      model.Matrix(values),
 				},
@@ -197,7 +197,7 @@ func TestCPUBalanceContinuously(t *testing.T) {
 			values = append(values, createSampleStream(test.cpus[j], j, curTime))
 		}
 		curTime = curTime.Add(time.Millisecond)
-		mmr.qrs[1] = metricsreader.QueryResult{
+		mmr.qrs["cpu"] = metricsreader.QueryResult{
 			UpdateTime: monotime.Now(),
 			Value:      model.Matrix(values),
 		}
@@ -251,7 +251,7 @@ func TestNoCPUMetric(t *testing.T) {
 			ss := createSampleStream(test.cpus[j], j, model.Time(test.updateTime/monotime.Time(time.Millisecond)))
 			values = append(values, ss)
 		}
-		mmr.qrs[1] = metricsreader.QueryResult{
+		mmr.qrs["cpu"] = metricsreader.QueryResult{
 			UpdateTime: test.updateTime,
 			Value:      model.Matrix(values),
 		}
@@ -290,7 +290,7 @@ func TestCPUResultNotUpdated(t *testing.T) {
 	for i, test := range tests {
 		array := []float64{test.cpu}
 		values := []*model.SampleStream{createSampleStream(array, 0, test.updateTime), createSampleStream(array, 1, test.updateTime)}
-		mmr.qrs[1] = metricsreader.QueryResult{
+		mmr.qrs["cpu"] = metricsreader.QueryResult{
 			UpdateTime: monotime.Now(),
 			Value:      model.Matrix(values),
 		}
@@ -329,6 +329,14 @@ tidb_server_maxprocs 2
 			timestamp:  model.Time(2000),
 			curValue:   6,
 			finalValue: 1,
+		},
+		{
+			text: `process_cpu_seconds_total 2
+tidb_server_maxprocs 2
+`,
+			timestamp:  model.Time(3000),
+			curValue:   1,
+			finalValue: model.SampleValue(math.NaN()),
 		},
 	}
 

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -95,8 +95,8 @@ func TestMemoryScore(t *testing.T) {
 		values = append(values, createSampleStream(test.memory, i, model.Now()))
 	}
 	mmr := &mockMetricsReader{
-		qrs: map[uint64]metricsreader.QueryResult{
-			1: {
+		qrs: map[string]metricsreader.QueryResult{
+			"memory": {
 				UpdateTime: monotime.Now(),
 				Value:      model.Matrix(values),
 			},
@@ -160,8 +160,8 @@ func TestMemoryBalance(t *testing.T) {
 			values = append(values, createSampleStream(test.memory[j], j, model.Now()))
 		}
 		mmr := &mockMetricsReader{
-			qrs: map[uint64]metricsreader.QueryResult{
-				1: {
+			qrs: map[string]metricsreader.QueryResult{
+				"memory": {
 					UpdateTime: monotime.Now(),
 					Value:      model.Matrix(values),
 				},
@@ -214,7 +214,7 @@ func TestNoMemMetrics(t *testing.T) {
 			ss.Values[0].Timestamp = model.Time(test.updateTime / monotime.Time(time.Millisecond))
 			values = append(values, ss)
 		}
-		mmr.qrs[1] = metricsreader.QueryResult{
+		mmr.qrs["memory"] = metricsreader.QueryResult{
 			UpdateTime: test.updateTime,
 			Value:      model.Matrix(values),
 		}
@@ -262,7 +262,7 @@ func TestMemoryBalanceCount(t *testing.T) {
 	}
 
 	mmr := &mockMetricsReader{
-		qrs: map[uint64]metricsreader.QueryResult{},
+		qrs: map[string]metricsreader.QueryResult{},
 	}
 	ts := model.Now().Add(-100 * time.Millisecond)
 	updateMmr := func(riskLevel int) {
@@ -280,7 +280,7 @@ func TestMemoryBalanceCount(t *testing.T) {
 			createSampleStream(usage, 0, ts),
 			createSampleStream([]float64{0, 0}, 1, ts),
 		}
-		mmr.qrs[1] = metricsreader.QueryResult{
+		mmr.qrs["memory"] = metricsreader.QueryResult{
 			UpdateTime: monotime.Now(),
 			Value:      model.Matrix(values),
 		}

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/prometheus/common/model"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var _ policy.BackendCtx = (*mockBackend)(nil)
@@ -93,36 +94,26 @@ func (mf *mockFactor) Close() {
 var _ metricsreader.MetricsReader = (*mockMetricsReader)(nil)
 
 type mockMetricsReader struct {
-	queryID uint64
-	qrs     map[uint64]metricsreader.QueryResult
+	qrs map[string]metricsreader.QueryResult
 }
 
 func newMockMetricsReader() *mockMetricsReader {
 	return &mockMetricsReader{
-		qrs: make(map[uint64]metricsreader.QueryResult),
+		qrs: make(map[string]metricsreader.QueryResult),
 	}
 }
 
-func (mmr *mockMetricsReader) Start(ctx context.Context) {
+func (mmr *mockMetricsReader) Start(ctx context.Context, etcdCli *clientv3.Client) {
 }
 
-func (mmr *mockMetricsReader) AddQueryExpr(queryExpr metricsreader.QueryExpr) uint64 {
-	mmr.queryID++
-	return mmr.queryID
+func (mmr *mockMetricsReader) AddQueryExpr(key string, queryExpr metricsreader.QueryExpr, queryRule metricsreader.QueryRule) {
 }
 
-func (mmr *mockMetricsReader) RemoveQueryExpr(id uint64) {
+func (mmr *mockMetricsReader) RemoveQueryExpr(key string) {
 }
 
-func (mmr *mockMetricsReader) GetQueryResult(id uint64) metricsreader.QueryResult {
-	return mmr.qrs[id]
-}
-
-func (mmr *mockMetricsReader) Subscribe(receiverName string) <-chan struct{} {
-	return nil
-}
-
-func (mmr *mockMetricsReader) Unsubscribe(receiverName string) {
+func (mmr *mockMetricsReader) GetQueryResult(key string) metricsreader.QueryResult {
+	return mmr.qrs[key]
 }
 
 func (mmr *mockMetricsReader) Close() {

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -103,7 +103,8 @@ func newMockMetricsReader() *mockMetricsReader {
 	}
 }
 
-func (mmr *mockMetricsReader) Start(ctx context.Context, etcdCli *clientv3.Client) {
+func (mmr *mockMetricsReader) Start(ctx context.Context, etcdCli *clientv3.Client) error {
+	return nil
 }
 
 func (mmr *mockMetricsReader) AddQueryExpr(key string, queryExpr metricsreader.QueryExpr, queryRule metricsreader.QueryRule) {

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/manager/elect"
 	"github.com/pingcap/tiproxy/pkg/util/http"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
@@ -292,10 +293,12 @@ func (br *BackendReader) history2Value(backend string) map[string]model.Value {
 
 // mergeQueryResult merges the result of one backend into the final result.
 func (br *BackendReader) mergeQueryResult(backendValues map[string]model.Value, backend string) {
+	now := monotime.Now()
 	br.Lock()
 	defer br.Unlock()
 	for ruleKey, value := range backendValues {
 		result := br.queryResults[ruleKey]
+		result.UpdateTime = now
 		if result.Value == nil || reflect.ValueOf(result.Value).IsNil() {
 			result.Value = value
 			br.queryResults[ruleKey] = result

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -136,7 +136,6 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 	} else {
 		owner, err := br.election.GetOwnerID(ctx)
 		if err != nil {
-			br.lg.Error("get owner failed, won't read metrics", zap.Error(err))
 			return err
 		}
 		if err = br.readFromOwner(ctx, owner); err != nil {

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -49,7 +49,9 @@ type backendHistory struct {
 
 type BackendReader struct {
 	sync.Mutex
-	queryRules   map[string]QueryRule
+	// rule key: QueryRule
+	queryRules map[string]QueryRule
+	// rule key: QueryResult
 	queryResults map[string]QueryResult
 	// the owner generates the history from querying backends and other members query the history from the owner
 	// rule key: {backend name: backendHistory}
@@ -125,22 +127,22 @@ func (br *BackendReader) GetQueryResult(key string) QueryResult {
 	return br.queryResults[key]
 }
 
-func (br *BackendReader) ReadMetrics(ctx context.Context) (map[string]QueryResult, error) {
+func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 	if br.isOwner.Load() {
 		if err := br.readFromBackends(ctx); err != nil {
-			return nil, err
+			return err
 		}
 	} else {
 		owner, err := br.election.GetOwnerID(ctx)
 		if err != nil {
 			br.lg.Error("get owner failed, won't read metrics", zap.Error(err))
-			return nil, err
+			return err
 		}
 		if err = br.readFromOwner(ctx, owner); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return br.queryResults, nil
+	return nil
 }
 
 func (br *BackendReader) readFromBackends(ctx context.Context) error {
@@ -173,7 +175,8 @@ func (br *BackendReader) readFromBackends(ctx context.Context) error {
 					br.lg.Error("parse metrics failed", zap.String("addr", addr), zap.Error(err))
 					return
 				}
-				result := br.groupMetricsByRule(mf, addr)
+				br.metric2History(mf, addr)
+				result := br.history2Value(addr)
 				br.mergeQueryResult(result, addr)
 			}, nil, br.lg)
 		}(addr)
@@ -206,13 +209,12 @@ func (br *BackendReader) readBackendMetric(ctx context.Context, addr string) ([]
 	return br.httpCli.Get(addr, backendMetricPath, b, br.cfg.DialTimeout)
 }
 
-// groupMetricsByRule gets the result for each rule of one backend.
-func (br *BackendReader) groupMetricsByRule(mfs map[string]*dto.MetricFamily, backend string) map[string]model.Value {
+// metric2History appends the metrics to history for each rule of one backend.
+func (br *BackendReader) metric2History(mfs map[string]*dto.MetricFamily, backend string) {
 	now := model.TimeFromUnixNano(time.Now().UnixNano())
 	br.Lock()
 	defer br.Unlock()
-	// rule key: backend value
-	results := make(map[string]model.Value, len(br.queryRules))
+
 	for ruleKey, rule := range br.queryRules {
 		// If the metric doesn't exist, skip it.
 		metricExists := true
@@ -249,14 +251,32 @@ func (br *BackendReader) groupMetricsByRule(mfs map[string]*dto.MetricFamily, ba
 		}
 		beHistory.Step2History = append(beHistory.Step2History, model.SamplePair{Timestamp: now, Value: sampleValue})
 		ruleHistory[backend] = beHistory
+	}
+}
 
-		// step 3: return the result
-		// E.g. return the metrics for 1 minute as a matrix
-		labels := map[model.LabelName]model.LabelValue{LabelNameInstance: model.LabelValue(backend)}
+// history2Value converts the history to results for all rules of one backend.
+// E.g. return the metrics for 1 minute as a matrix
+func (br *BackendReader) history2Value(backend string) map[string]model.Value {
+	results := make(map[string]model.Value, len(br.queryRules))
+	labels := map[model.LabelName]model.LabelValue{LabelNameInstance: model.LabelValue(backend)}
+	br.Lock()
+	defer br.Unlock()
+
+	for ruleKey, rule := range br.queryRules {
+		ruleHistory := br.history[ruleKey]
+		if len(ruleHistory) == 0 {
+			continue
+		}
+		beHistory := ruleHistory[backend]
+		if len(beHistory.Step2History) == 0 {
+			continue
+		}
+
 		switch rule.ResultType {
 		case model.ValVector:
 			// vector indicates returning the latest pair
-			results[ruleKey] = model.Vector{{Value: sampleValue, Timestamp: now, Metric: labels}}
+			lastPair := beHistory.Step2History[len(beHistory.Step2History)-1]
+			results[ruleKey] = model.Vector{{Value: lastPair.Value, Timestamp: lastPair.Timestamp, Metric: labels}}
 		case model.ValMatrix:
 			// matrix indicates returning the history
 			// copy a slice to avoid data race
@@ -372,6 +392,18 @@ func (br *BackendReader) readFromOwner(ctx context.Context, addr string) error {
 	br.history = newHistory
 	br.marshalledHistory = nil
 	br.Unlock()
+
+	backends := make(map[string]struct{})
+	for _, ruleHistory := range newHistory {
+		for backend := range ruleHistory {
+			backends[backend] = struct{}{}
+		}
+	}
+
+	for backend := range backends {
+		result := br.history2Value(backend)
+		br.mergeQueryResult(result, backend)
+	}
 	return nil
 }
 

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -6,6 +6,7 @@ package metricsreader
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
@@ -204,7 +205,7 @@ func TestReadBackendMetric(t *testing.T) {
 	}
 }
 
-// test groupMetricsByRule
+// test metric2History and history2Value
 func TestOneRuleOneHistory(t *testing.T) {
 	tests := []struct {
 		names      []string
@@ -255,7 +256,8 @@ func TestOneRuleOneHistory(t *testing.T) {
 			},
 		}
 
-		res := br.groupMetricsByRule(mfs, "backend")
+		br.metric2History(mfs, "backend")
+		res := br.history2Value("backend")
 		value := res["key"]
 		switch test.returnType {
 		case model.ValVector:
@@ -279,7 +281,7 @@ func TestOneRuleOneHistory(t *testing.T) {
 	}
 }
 
-// test groupMetricsByRule
+// test metric2History and history2Value
 func TestOneRuleMultiHistory(t *testing.T) {
 	tests := []struct {
 		step1Value model.SampleValue
@@ -326,10 +328,10 @@ func TestOneRuleMultiHistory(t *testing.T) {
 			},
 		}
 
-		res := br.groupMetricsByRule(mfs, "backend")
+		br.metric2History(mfs, "backend")
+		res := br.history2Value("backend")
 		value := res["key"]
 		if math.IsNaN(float64(test.step2Value)) {
-			require.Nil(t, value, "case %d", i)
 			continue
 		}
 		length++
@@ -345,7 +347,7 @@ func TestOneRuleMultiHistory(t *testing.T) {
 	}
 }
 
-// test groupMetricsByRule
+// test metric2History and history2Value
 func TestMultiRules(t *testing.T) {
 	returnedValues := []model.SampleValue{model.SampleValue(1), model.SampleValue(2)}
 	rule1 := QueryRule{
@@ -406,7 +408,8 @@ func TestMultiRules(t *testing.T) {
 		} else {
 			delete(br.queryRules, "key2")
 		}
-		res := br.groupMetricsByRule(mfs, "backend")
+		br.metric2History(mfs, "backend")
+		res := br.history2Value("backend")
 		require.Len(t, res, len(br.queryRules), "case %d", i)
 
 		if test.hasRule1 {
@@ -798,4 +801,98 @@ func TestReadFromOwner(t *testing.T) {
 		require.NoError(t, err, "case %d", i)
 		require.Equal(t, data, data2, "case %d", i)
 	}
+}
+
+func TestElection(t *testing.T) {
+	// setup backend
+	backendPort, infos := setupTypicalBackendListener(t, "cpu 80.0\n")
+
+	// setup history
+	now := model.Time(time.Now().UnixMilli())
+	backendKey := net.JoinHostPort("127.0.0.1", strconv.Itoa(backendPort))
+	history := map[string]map[string]backendHistory{
+		"rule_id1": {
+			backendKey: {
+				Step1History: []model.SamplePair{
+					{Timestamp: now, Value: 100.0},
+				},
+				Step2History: []model.SamplePair{
+					{Timestamp: now, Value: 100.0},
+				},
+			},
+		},
+	}
+	hitoryText, err := json.Marshal(history)
+	require.NoError(t, err)
+
+	// setup rule
+	rule := QueryRule{
+		Names:     []string{"cpu"},
+		Retention: time.Minute,
+		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			return model.SampleValue(*mfs["cpu"].Metric[0].Untyped.Value)
+		},
+		Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+			return pairs[len(pairs)-1].Value
+		},
+		ResultType: model.ValVector,
+	}
+
+	// setup owner listener
+	ownerHttpHandler := newMockHttpHandler(t)
+	ownerPort := ownerHttpHandler.Start()
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(ownerPort))
+	ownerFunc := func(_ string) string {
+		return string(hitoryText)
+	}
+	ownerHttpHandler.getRespBody.Store(&ownerFunc)
+	t.Cleanup(ownerHttpHandler.Close)
+
+	// setup backend reader
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := newHealthCheckConfigForTest()
+	fetcher := newMockBackendFetcher(infos, nil)
+	httpCli := httputil.NewHTTPClient(func() *tls.Config { return nil })
+	br := NewBackendReader(lg, nil, httpCli, fetcher, cfg)
+	election := newMockElection()
+	br.election = election
+	br.AddQueryRule("rule_id1", rule)
+	t.Cleanup(br.Close)
+
+	// test not owner
+	election.owner.Store(&addr)
+	election.isOwner.Store(false)
+	br.OnRetired()
+	err = br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	qr := br.GetQueryResult("rule_id1")
+	require.False(t, qr.Empty())
+	require.Equal(t, model.SampleValue(100.0), qr.Value.(model.Vector)[0].Value)
+
+	// test owner
+	election.isOwner.Store(true)
+	br.OnElected()
+	err = br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	qr = br.GetQueryResult("rule_id1")
+	require.False(t, qr.Empty())
+	require.Equal(t, model.SampleValue(80.0), qr.Value.(model.Vector)[0].Value)
+}
+
+func setupTypicalBackendListener(t *testing.T, respBody string) (backendPort int, infos map[string]*infosync.TiDBTopologyInfo) {
+	// setup backend listener
+	backendHttpHandler := newMockHttpHandler(t)
+	backendFunc := func(reqBody string) string {
+		return respBody
+	}
+	backendHttpHandler.getRespBody.Store(&backendFunc)
+	backendPort = backendHttpHandler.Start()
+	infos = map[string]*infosync.TiDBTopologyInfo{
+		"127.0.0.1:4000": {
+			IP:         "127.0.0.1",
+			StatusPort: uint(backendPort),
+		},
+	}
+	t.Cleanup(backendHttpHandler.Close)
+	return
 }

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -5,31 +5,24 @@ package metricsreader
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"reflect"
-	"strconv"
-	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/pingcap/tiproxy/lib/config"
-	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
-	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
-	"github.com/pingcap/tiproxy/pkg/util/monotime"
-	"github.com/prometheus/client_golang/api"
-	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/pingcap/tiproxy/pkg/util/http"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
 const (
-	readResultNone = iota
-	readResultOK
-	readResultFail
+	sourceNone int32 = iota
+	sourceProm
+	sourceBackend
 )
 
+// PromInfoFetcher is an interface to fetch the Prometheus info from ETCD.
 type PromInfoFetcher interface {
 	GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, error)
 }
@@ -40,66 +33,44 @@ type TopologyFetcher interface {
 }
 
 type MetricsReader interface {
-	Start(ctx context.Context)
-	AddQueryExpr(queryExpr QueryExpr) uint64
-	RemoveQueryExpr(id uint64)
-	GetQueryResult(id uint64) QueryResult
+	Start(ctx context.Context, etcdCli *clientv3.Client)
+	AddQueryExpr(key string, queryExpr QueryExpr, queryRule QueryRule)
+	RemoveQueryExpr(key string)
+	GetQueryResult(key string) QueryResult
 	Close()
 }
 
 var _ MetricsReader = (*DefaultMetricsReader)(nil)
 
 type DefaultMetricsReader struct {
-	sync.Mutex
-	queryExprs   map[uint64]QueryExpr
-	queryResults map[uint64]QueryResult
-	wg           waitgroup.WaitGroup
-	promFetcher  PromInfoFetcher
-	cancel       context.CancelFunc
-	lg           *zap.Logger
-	cfg          *config.HealthCheck
-	lastID       uint64
-	readResult   int
+	source        atomic.Int32
+	backendReader *BackendReader
+	promReader    *PromReader
+	wg            waitgroup.WaitGroup
+	cancel        context.CancelFunc
+	lg            *zap.Logger
+	cfg           *config.HealthCheck
 }
 
-func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, cfg *config.HealthCheck) *DefaultMetricsReader {
+func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, backendFetcher TopologyFetcher, httpCli *http.Client,
+	cfg *config.HealthCheck, cfgGetter config.ConfigGetter) *DefaultMetricsReader {
 	return &DefaultMetricsReader{
-		lg:           lg,
-		promFetcher:  promFetcher,
-		cfg:          cfg,
-		queryExprs:   make(map[uint64]QueryExpr),
-		queryResults: make(map[uint64]QueryResult),
+		lg:            lg,
+		cfg:           cfg,
+		promReader:    NewPromReader(lg.Named("prom_reader"), promFetcher, cfg),
+		backendReader: NewBackendReader(lg.Named("backend_reader"), cfgGetter, httpCli, backendFetcher, cfg),
 	}
 }
 
-func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
-	// No PD, using static backends.
-	if dmr.promFetcher == nil || reflect.ValueOf(dmr.promFetcher).IsNil() {
-		return
-	}
+func (dmr *DefaultMetricsReader) Start(ctx context.Context, etcdCli *clientv3.Client) {
+	dmr.backendReader.Start(ctx, etcdCli)
 	childCtx, cancel := context.WithCancel(ctx)
 	dmr.cancel = cancel
 	dmr.wg.RunWithRecover(func() {
 		ticker := time.NewTicker(dmr.cfg.MetricsInterval)
 		defer ticker.Stop()
 		for childCtx.Err() == nil {
-			if results, err := dmr.readMetrics(childCtx); err != nil {
-				// If there are successive errors, only log it once.
-				if dmr.readResult != readResultFail {
-					dmr.readResult = readResultFail
-					dmr.lg.Warn("read metrics failed", zap.Error(err))
-				}
-			} else {
-				if dmr.readResult != readResultOK {
-					dmr.readResult = readResultOK
-					dmr.lg.Debug("read metrics succeed")
-				}
-				if len(results) > 0 {
-					dmr.Lock()
-					dmr.queryResults = results
-					dmr.Unlock()
-				}
-			}
+			dmr.readMetrics(childCtx)
 			select {
 			case <-ticker.C:
 			case <-childCtx.Done():
@@ -109,120 +80,61 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) {
 	}, nil, dmr.lg)
 }
 
-// Always refresh the prometheus address just in case it changes.
-func (dmr *DefaultMetricsReader) getPromAPI(ctx context.Context) (promv1.API, error) {
-	promInfo, err := dmr.promFetcher.GetPromInfo(ctx)
-	if promInfo == nil {
-		if err == nil {
-			err = errors.New("no prometheus info found")
-		}
-		return nil, err
-	}
-	if err != nil {
-		return nil, err
-	}
-	// TODO: support TLS and authentication.
-	promAddr := fmt.Sprintf("http://%s", net.JoinHostPort(promInfo.IP, strconv.Itoa(promInfo.Port)))
-	promClient, err := api.NewClient(api.Config{
-		Address: promAddr,
-	})
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return promv1.NewAPI(promClient), nil
-}
-
-func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) (map[uint64]QueryResult, error) {
+// readMetrics reads from Prometheus first. If it fails, fall back to read backends.
+func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return
 	}
-	promQLAPI, err := dmr.getPromAPI(ctx)
-	if err != nil {
-		return nil, err
+	promErr := dmr.promReader.ReadMetrics(ctx)
+	if promErr == nil {
+		dmr.setSource(sourceProm, nil)
+		return
 	}
 
-	dmr.Lock()
-	copyedMap := make(map[uint64]QueryExpr, len(dmr.queryExprs))
-	for id, expr := range dmr.queryExprs {
-		copyedMap[id] = expr
+	if ctx.Err() != nil {
+		return
 	}
-	dmr.Unlock()
-	results := make(map[uint64]QueryResult, len(copyedMap))
-	now := time.Now()
-	for id, expr := range copyedMap {
-		qr := dmr.queryMetric(ctx, promQLAPI, expr, now)
-		// Only update the result when it succeeds.
-		if qr.Err == nil {
-			qr.UpdateTime = monotime.Now()
-			results[id] = qr
-		} else {
-			dmr.lg.Warn("querying metrics fails", zap.String("expr", expr.PromQL), zap.Error(qr.Err))
-		}
+	backendErr := dmr.backendReader.ReadMetrics(ctx)
+	if backendErr == nil {
+		dmr.setSource(sourceBackend, promErr)
+		return
 	}
-	return results, nil
+	dmr.lg.Info("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
 }
 
-func (dmr *DefaultMetricsReader) queryMetric(ctx context.Context, promQLAPI promv1.API, expr QueryExpr, curTime time.Time) QueryResult {
-	promRange := expr.PromRange(curTime)
-	if !expr.HasLabel {
-		return dmr.queryOnce(ctx, promQLAPI, expr.PromQL, promRange)
-	}
-
-	// The label key is `job` in TiUP but is `component` in TiOperator. We don't know which, so try them both.
-	var qr QueryResult
-	for _, label := range [2]string{"job", "component"} {
-		promQL := fmt.Sprintf(expr.PromQL, label)
-		qr = dmr.queryOnce(ctx, promQLAPI, promQL, promRange)
-		if qr.Err != nil {
-			continue
-		}
-		if !qr.Empty() {
-			expr.PromQL = promQL
-			expr.HasLabel = false
-			break
+func (dmr *DefaultMetricsReader) setSource(source int32, err error) {
+	old := dmr.source.Load()
+	if old != source {
+		dmr.source.Store(source)
+		switch source {
+		case sourceProm:
+			dmr.lg.Info("read metrics from Prometheus")
+		case sourceBackend:
+			dmr.lg.Info("read Prometheus failed, turn to read backends", zap.Error(err))
 		}
 	}
-	return qr
 }
 
-func (dmr *DefaultMetricsReader) queryOnce(ctx context.Context, promQLAPI promv1.API, promQL string, promRange promv1.Range) QueryResult {
-	childCtx, cancel := context.WithTimeout(ctx, dmr.cfg.MetricsTimeout)
-	var qr QueryResult
-	qr.Err = backoff.Retry(func() error {
-		var err error
-		if promRange.Start.IsZero() {
-			qr.Value, _, err = promQLAPI.Query(childCtx, promQL, time.Time{})
-		} else {
-			qr.Value, _, err = promQLAPI.QueryRange(childCtx, promQL, promRange)
-		}
-		if !pnet.IsRetryableError(err) {
-			return backoff.Permanent(errors.WithStack(err))
-		}
-		return errors.WithStack(err)
-	}, backoff.WithContext(backoff.NewExponentialBackOff(), childCtx))
-	cancel()
-	return qr
+func (dmr *DefaultMetricsReader) AddQueryExpr(key string, queryExpr QueryExpr, queryRule QueryRule) {
+	dmr.promReader.AddQueryExpr(key, queryExpr)
+	dmr.backendReader.AddQueryRule(key, queryRule)
 }
 
-func (dmr *DefaultMetricsReader) AddQueryExpr(queryExpr QueryExpr) uint64 {
-	dmr.Lock()
-	defer dmr.Unlock()
-	dmr.lastID++
-	dmr.queryExprs[dmr.lastID] = queryExpr
-	return dmr.lastID
+func (dmr *DefaultMetricsReader) RemoveQueryExpr(key string) {
+	dmr.promReader.RemoveQueryExpr(key)
+	dmr.backendReader.RemoveQueryRule(key)
 }
 
-func (dmr *DefaultMetricsReader) RemoveQueryExpr(id uint64) {
-	dmr.Lock()
-	defer dmr.Unlock()
-	delete(dmr.queryExprs, id)
-}
-
-func (dmr *DefaultMetricsReader) GetQueryResult(id uint64) QueryResult {
-	dmr.Lock()
-	defer dmr.Unlock()
-	// Return an empty QueryResult if it's not found.
-	return dmr.queryResults[id]
+// GetQueryResult returns an empty result if the key or the result is not found.
+func (dmr *DefaultMetricsReader) GetQueryResult(key string) QueryResult {
+	switch dmr.source.Load() {
+	case sourceProm:
+		return dmr.promReader.GetQueryResult(key)
+	case sourceBackend:
+		return dmr.backendReader.GetQueryResult(key)
+	default:
+		return QueryResult{}
+	}
 }
 
 func (dmr *DefaultMetricsReader) Close() {
@@ -230,4 +142,6 @@ func (dmr *DefaultMetricsReader) Close() {
 		dmr.cancel()
 	}
 	dmr.wg.Wait()
+	dmr.backendReader.Close()
+	dmr.promReader.Close()
 }

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -102,7 +102,7 @@ func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
 		dmr.setSource(sourceBackend, promErr)
 		return
 	}
-	dmr.lg.Info("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
+	dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
 }
 
 func (dmr *DefaultMetricsReader) setSource(source int32, err error) {

--- a/pkg/balance/metricsreader/metrics_reader_test.go
+++ b/pkg/balance/metricsreader/metrics_reader_test.go
@@ -5,257 +5,75 @@ package metricsreader
 
 import (
 	"context"
-	"fmt"
+	"crypto/tls"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
-	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	httputil "github.com/pingcap/tiproxy/pkg/util/http"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadMetrics(t *testing.T) {
-	tests := []struct {
-		promQL         string
-		hasLabel       bool
-		respBody       string
-		expectedString string
-		expectedType   model.ValueType
-	}{
-		{
-			promQL:         `tidb_server_connections`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
-			expectedType:   model.ValMatrix,
-		},
-		{
-			promQL:         `go_goroutines{%s="tidb"}`,
-			hasLabel:       true,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
-			expectedType:   model.ValMatrix,
-		},
-		{
-			promQL:         `unknown`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
-			expectedString: ``,
-			expectedType:   model.ValMatrix,
-		},
-	}
+func TestFallback(t *testing.T) {
+	// setup backend
+	_, infos := setupTypicalBackendListener(t, "cpu 80.0\n")
 
-	httpHandler, mr := setupTypicalMetricsReader(t)
-	for i, test := range tests {
-		id := mr.AddQueryExpr(QueryExpr{
-			PromQL:   test.promQL,
-			Range:    time.Minute,
-			HasLabel: test.hasLabel,
-		})
-		f := func(reqBody string) string {
-			return test.respBody
-		}
-		httpHandler.getRespBody.Store(&f)
-		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
-		var qr QueryResult
-		require.Eventually(t, func() bool {
-			qr = mr.GetQueryResult(id)
-			return qr.Value != nil || qr.Err != nil
-		}, 3*time.Second, time.Millisecond, msg)
-		require.NoError(t, qr.Err, msg)
-		require.Equal(t, test.expectedType, qr.Value.Type(), msg)
-		require.Equal(t, test.expectedString, qr.Value.String(), msg)
-		mr.RemoveQueryExpr(id)
-	}
-}
-
-func TestMultiExprs(t *testing.T) {
-	tests := []struct {
-		promQL         string
-		respBody       string
-		expectedString string
-	}{
-		{
-			promQL:         `tidb_server_connections`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
-		},
-		{
-			promQL:         `go_goroutines`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
-		},
-		{
-			promQL:         `unknown`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
-			expectedString: ``,
-		},
-	}
-
-	httpHandler, mr := setupTypicalMetricsReader(t)
+	// setup prom
+	promHttpHandler := newMockHttpHandler(t)
+	port := promHttpHandler.Start()
+	t.Cleanup(promHttpHandler.Close)
+	promFetcher := newMockPromFetcher(port)
 	f := func(reqBody string) string {
-		for _, test := range tests {
-			if strings.Contains(reqBody, "query="+test.promQL) {
-				return test.respBody
-			}
-		}
-		return ""
+		return `{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"cpu"},"value":[1712738879.406,"100.0"]}]}}`
 	}
-	httpHandler.getRespBody.Store(&f)
-	for _, test := range tests {
-		mr.AddQueryExpr(QueryExpr{
-			PromQL: test.promQL,
-			Range:  time.Minute,
-		})
-	}
+	promHttpHandler.getRespBody.Store(&f)
 
-	waitResultReady(t, mr, len(tests))
-	for i, test := range tests {
-		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
-		qr := mr.GetQueryResult(uint64(i + 1))
-		require.NoError(t, qr.Err, msg)
-		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+	// setup rule
+	expr := QueryExpr{
+		PromQL: "cpu",
 	}
-	mr.RemoveQueryExpr(1)
-	require.Eventually(t, func() bool {
-		qr := mr.GetQueryResult(uint64(1))
-		return qr.Value == nil && qr.Err == nil
-	}, 3*time.Second, time.Millisecond)
-}
-
-func TestBackendLabel(t *testing.T) {
-	tests := []struct {
-		promQL         string
-		respBody       string
-		expectedString string
-		label          string
-	}{
-		{
-			promQL:         `tidb_server_connections`,
-			label:          `job`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+	rule := QueryRule{
+		Names:     []string{"cpu"},
+		Retention: time.Minute,
+		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			return model.SampleValue(*mfs["cpu"].Metric[0].Untyped.Value)
 		},
-		{
-			promQL:         `go_goroutines`,
-			label:          `component`,
-			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","component":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{component=\"tidb\", instance=\"127.0.0.1:10080\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+			return pairs[len(pairs)-1].Value
 		},
+		ResultType: model.ValVector,
 	}
 
-	f := func(reqBody string) string {
-		for _, test := range tests {
-			if strings.Contains(reqBody, test.promQL) {
-				if strings.Contains(reqBody, test.label) {
-					return test.respBody
-				} else {
-					return `{"status":"success","data":{"resultType":"matrix","result":[]}}`
-				}
-			}
-		}
-		return ""
-	}
-
-	httpHandler, mr := setupTypicalMetricsReader(t)
-	httpHandler.getRespBody.Store(&f)
-	for _, test := range tests {
-		mr.AddQueryExpr(QueryExpr{
-			PromQL:   test.promQL + `{%s="tidb"}`,
-			Range:    time.Minute,
-			HasLabel: true,
-		})
-	}
-
-	waitResultReady(t, mr, len(tests))
-	for i, test := range tests {
-		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
-		qr := mr.GetQueryResult(uint64(i + 1))
-		require.NoError(t, qr.Err, msg)
-		require.Equal(t, test.expectedString, qr.Value.String(), msg)
-	}
-}
-
-func TestPromUnavailable(t *testing.T) {
-	httpHandler, mr := setupTypicalMetricsReader(t)
-	f := func(reqBody string) string {
-		return `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"any"},"values":[[1712738879.406,"0"]]}]}}`
-	}
-	httpHandler.getRespBody.Store(&f)
-	id := mr.AddQueryExpr(QueryExpr{
-		PromQL: "any",
-		Range:  time.Minute,
-	})
-	require.Eventually(t, func() bool {
-		qr := mr.GetQueryResult(id)
-		return !qr.Empty()
-	}, 3*time.Second, 10*time.Millisecond)
-
-	httpHandler.statusCode.Store(http.StatusInternalServerError)
-	require.Eventually(t, func() bool {
-		// The qr doesn't update anymore.
-		qr := mr.GetQueryResult(id)
-		time.Sleep(100 * time.Millisecond)
-		return qr.UpdateTime == mr.GetQueryResult(id).UpdateTime
-	}, 3*time.Second, time.Millisecond)
-}
-
-func TestNoPromAddr(t *testing.T) {
-	mpf := &mockPromFetcher{
-		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
-			return nil, nil
-		},
-	}
-	lg, text := logger.CreateLoggerForTest(t)
-	cfg := newHealthCheckConfigForTest()
-	mr := NewDefaultMetricsReader(lg, mpf, cfg)
-	promInfo, err := mr.getPromAPI(context.Background())
-	require.Nil(t, promInfo)
-	require.NotNil(t, err)
-	require.Equal(t, true, strings.Contains(err.Error(), "no prometheus info found"))
-
-	mr.Start(context.Background())
-	t.Cleanup(mr.Close)
-	id := mr.AddQueryExpr(QueryExpr{
-		PromQL: "any",
-		Range:  time.Minute,
-	})
-	time.Sleep(10 * cfg.MetricsInterval)
-	qr := mr.GetQueryResult(id)
-	require.True(t, qr.Empty())
-	require.Equal(t, 1, strings.Count(text.String(), "no prometheus info found"))
-}
-
-func setupTypicalMetricsReader(t *testing.T) (*mockHttpHandler, MetricsReader) {
-	httpHandler := newMockHttpHandler(t)
-	port := httpHandler.Start()
-	t.Cleanup(httpHandler.Close)
-	mpf := newMockPromFetcher(port)
+	// setup metrics reader
 	lg, _ := logger.CreateLoggerForTest(t)
-	mr := NewDefaultMetricsReader(lg, mpf, newHealthCheckConfigForTest())
-	mr.Start(context.Background())
+	cfg := newHealthCheckConfigForTest()
+	cfgGetter := newMockConfigGetter(&config.Config{})
+	backendFetcher := newMockBackendFetcher(infos, nil)
+	httpCli := httputil.NewHTTPClient(func() *tls.Config { return nil })
+	mr := NewDefaultMetricsReader(lg, promFetcher, backendFetcher, httpCli, cfg, cfgGetter)
+	mr.AddQueryExpr("rule_id1", expr, rule)
 	t.Cleanup(mr.Close)
-	return httpHandler, mr
-}
 
-func waitResultReady(t *testing.T, mr MetricsReader, resultNum int) {
-	require.Eventually(t, func() bool {
-		for i := 0; i < resultNum; i++ {
-			qr := mr.GetQueryResult(uint64(i + 1))
-			if qr.Value == nil && qr.Err == nil {
-				return false
-			}
-		}
-		return true
-	}, 3*time.Second, time.Millisecond)
-}
+	// setup backend reader
+	election := newMockElection()
+	mr.backendReader.election = election
+	election.isOwner.Store(true)
+	mr.backendReader.OnElected()
 
-func newHealthCheckConfigForTest() *config.HealthCheck {
-	return &config.HealthCheck{
-		Enable:          true,
-		MetricsInterval: 10 * time.Millisecond,
-		MetricsTimeout:  100 * time.Millisecond,
-	}
+	// read from prom
+	mr.readMetrics(context.Background())
+	qr := mr.GetQueryResult("rule_id1")
+	require.False(t, qr.Empty())
+	require.Equal(t, model.SampleValue(100.0), qr.Value.(model.Vector)[0].Value)
+
+	// read from backend
+	promHttpHandler.statusCode.Store(http.StatusInternalServerError)
+	mr.readMetrics(context.Background())
+	qr = mr.GetQueryResult("rule_id1")
+	require.False(t, qr.Empty())
+	require.Equal(t, model.SampleValue(80.0), qr.Value.(model.Vector)[0].Value)
 }

--- a/pkg/balance/metricsreader/mock_test.go
+++ b/pkg/balance/metricsreader/mock_test.go
@@ -10,9 +10,11 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
+	"github.com/pingcap/tiproxy/pkg/manager/elect"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/testkit"
 	dto "github.com/prometheus/client_model/go"
@@ -148,4 +150,43 @@ func mockMfs() map[string]*dto.MetricFamily {
 		"name1": {Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: &floats[0]}}}},
 		"name2": {Metric: []*dto.Metric{{Gauge: &dto.Gauge{Value: &floats[1]}}}},
 	}
+}
+
+var _ elect.Election = (*mockElection)(nil)
+
+type mockElection struct {
+	owner   atomic.Pointer[string]
+	isOwner atomic.Bool
+}
+
+func newMockElection() *mockElection {
+	return &mockElection{}
+}
+
+func (m *mockElection) Start(context.Context) {
+}
+
+func (m *mockElection) Close() {
+}
+
+func (m *mockElection) GetOwnerID(ctx context.Context) (string, error) {
+	return *m.owner.Load(), nil
+}
+
+func (m *mockElection) IsOwner() bool {
+	return m.isOwner.Load()
+}
+
+type mockConfigGetter struct {
+	cfg *config.Config
+}
+
+func newMockConfigGetter(cfg *config.Config) *mockConfigGetter {
+	return &mockConfigGetter{
+		cfg: cfg,
+	}
+}
+
+func (cfgGetter *mockConfigGetter) GetConfig() *config.Config {
+	return cfgGetter.cfg
 }

--- a/pkg/balance/metricsreader/prom_reader.go
+++ b/pkg/balance/metricsreader/prom_reader.go
@@ -1,0 +1,155 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/util/monotime"
+	"github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"go.uber.org/zap"
+)
+
+type PromReader struct {
+	sync.Mutex
+	queryExprs   map[string]QueryExpr
+	queryResults map[string]QueryResult
+	promFetcher  PromInfoFetcher
+	lg           *zap.Logger
+	cfg          *config.HealthCheck
+}
+
+func NewPromReader(lg *zap.Logger, promFetcher PromInfoFetcher, cfg *config.HealthCheck) *PromReader {
+	return &PromReader{
+		lg:           lg,
+		promFetcher:  promFetcher,
+		cfg:          cfg,
+		queryExprs:   make(map[string]QueryExpr),
+		queryResults: make(map[string]QueryResult),
+	}
+}
+
+func (pr *PromReader) ReadMetrics(ctx context.Context) error {
+	// No PD, using static backends.
+	if pr.promFetcher == nil || reflect.ValueOf(pr.promFetcher).IsNil() {
+		return infosync.ErrNoProm
+	}
+	promQLAPI, err := pr.getPromAPI(ctx)
+	if err != nil {
+		return err
+	}
+
+	pr.Lock()
+	copyedMap := make(map[string]QueryExpr, len(pr.queryExprs))
+	for key, expr := range pr.queryExprs {
+		copyedMap[key] = expr
+	}
+	pr.Unlock()
+	results := make(map[string]QueryResult, len(copyedMap))
+	now := time.Now()
+	for id, expr := range copyedMap {
+		qr, err := pr.queryMetric(ctx, promQLAPI, expr, now)
+		// Stop and fallback to reading backends if prometheus is unavailable.
+		if err != nil {
+			return err
+		}
+		qr.UpdateTime = monotime.Now()
+		results[id] = qr
+	}
+	pr.Lock()
+	pr.queryResults = results
+	pr.Unlock()
+	return nil
+}
+
+// Always refresh the prometheus address just in case it changes.
+func (pr *PromReader) getPromAPI(ctx context.Context) (promv1.API, error) {
+	promInfo, err := pr.promFetcher.GetPromInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: support TLS and authentication.
+	promAddr := fmt.Sprintf("http://%s", net.JoinHostPort(promInfo.IP, strconv.Itoa(promInfo.Port)))
+	promClient, err := api.NewClient(api.Config{
+		Address: promAddr,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return promv1.NewAPI(promClient), nil
+}
+
+func (pr *PromReader) queryMetric(ctx context.Context, promQLAPI promv1.API, expr QueryExpr, curTime time.Time) (QueryResult, error) {
+	promRange := expr.PromRange(curTime)
+	if !expr.HasLabel {
+		return pr.queryOnce(ctx, promQLAPI, expr.PromQL, promRange)
+	}
+
+	// The label key is `job` in TiUP but is `component` in TiOperator. We don't know which, so try them both.
+	var qr QueryResult
+	var err error
+	for _, label := range [2]string{"job", "component"} {
+		promQL := fmt.Sprintf(expr.PromQL, label)
+		qr, err = pr.queryOnce(ctx, promQLAPI, promQL, promRange)
+		if err == nil && !qr.Empty() {
+			expr.PromQL = promQL
+			expr.HasLabel = false
+			break
+		}
+	}
+	return qr, err
+}
+
+func (pr *PromReader) queryOnce(ctx context.Context, promQLAPI promv1.API, promQL string, promRange promv1.Range) (QueryResult, error) {
+	childCtx, cancel := context.WithTimeout(ctx, pr.cfg.MetricsTimeout)
+	var qr QueryResult
+	err := backoff.Retry(func() error {
+		var err error
+		if promRange.Start.IsZero() {
+			qr.Value, _, err = promQLAPI.Query(childCtx, promQL, time.Time{})
+		} else {
+			qr.Value, _, err = promQLAPI.QueryRange(childCtx, promQL, promRange)
+		}
+		if !pnet.IsRetryableError(err) {
+			return backoff.Permanent(errors.WithStack(err))
+		}
+		return errors.WithStack(err)
+	}, backoff.WithContext(backoff.NewExponentialBackOff(), childCtx))
+	cancel()
+	return qr, err
+}
+
+func (pr *PromReader) AddQueryExpr(key string, queryExpr QueryExpr) {
+	pr.Lock()
+	defer pr.Unlock()
+	pr.queryExprs[key] = queryExpr
+}
+
+func (pr *PromReader) RemoveQueryExpr(key string) {
+	pr.Lock()
+	defer pr.Unlock()
+	delete(pr.queryExprs, key)
+}
+
+func (pr *PromReader) GetQueryResult(key string) QueryResult {
+	pr.Lock()
+	defer pr.Unlock()
+	// Return an empty QueryResult if it's not found.
+	return pr.queryResults[key]
+}
+
+func (pr *PromReader) Close() {
+}

--- a/pkg/balance/metricsreader/prom_reader_test.go
+++ b/pkg/balance/metricsreader/prom_reader_test.go
@@ -1,0 +1,244 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metricsreader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPromMetrics(t *testing.T) {
+	tests := []struct {
+		promQL         string
+		hasLabel       bool
+		respBody       string
+		expectedString string
+		expectedType   model.ValueType
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+			expectedType:   model.ValMatrix,
+		},
+		{
+			promQL:         `go_goroutines{%s="tidb"}`,
+			hasLabel:       true,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+			expectedType:   model.ValMatrix,
+		},
+		{
+			promQL:         `unknown`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+			expectedString: ``,
+			expectedType:   model.ValMatrix,
+		},
+	}
+
+	httpHandler, br := setupTypicalPromReader(t)
+	for i, test := range tests {
+		key := strconv.Itoa(i)
+		br.AddQueryExpr(key, QueryExpr{
+			PromQL:   test.promQL,
+			Range:    time.Minute,
+			HasLabel: test.hasLabel,
+		})
+		f := func(reqBody string) string {
+			return test.respBody
+		}
+		httpHandler.getRespBody.Store(&f)
+		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
+		err := br.ReadMetrics(context.Background())
+		require.NoError(t, err, msg)
+		qr := br.GetQueryResult(key)
+		require.Equal(t, test.expectedType, qr.Value.Type(), msg)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+		br.RemoveQueryExpr(key)
+	}
+}
+
+func TestMultiExprs(t *testing.T) {
+	tests := []struct {
+		promQL         string
+		respBody       string
+		expectedString string
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+		},
+		{
+			promQL:         `go_goroutines`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		},
+		{
+			promQL:         `unknown`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[]}}`,
+			expectedString: ``,
+		},
+	}
+
+	httpHandler, br := setupTypicalPromReader(t)
+	f := func(reqBody string) string {
+		for _, test := range tests {
+			if strings.Contains(reqBody, "query="+test.promQL) {
+				return test.respBody
+			}
+		}
+		return ""
+	}
+	httpHandler.getRespBody.Store(&f)
+	for i, test := range tests {
+		key := strconv.Itoa(i)
+		br.AddQueryExpr(key, QueryExpr{
+			PromQL: test.promQL,
+			Range:  time.Minute,
+		})
+	}
+
+	err := br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	for i, test := range tests {
+		key := strconv.Itoa(i)
+		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
+		qr := br.GetQueryResult(key)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+	}
+
+	br.RemoveQueryExpr("0")
+	err = br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	qr := br.GetQueryResult("0")
+	require.True(t, qr.Empty())
+}
+
+func TestBackendLabel(t *testing.T) {
+	tests := []struct {
+		promQL         string
+		respBody       string
+		expectedString string
+		label          string
+	}{
+		{
+			promQL:         `tidb_server_connections`,
+			label:          `job`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+		},
+		{
+			promQL:         `go_goroutines`,
+			label:          `component`,
+			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","component":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
+			expectedString: "go_goroutines{component=\"tidb\", instance=\"127.0.0.1:10080\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+		},
+	}
+
+	f := func(reqBody string) string {
+		for _, test := range tests {
+			if strings.Contains(reqBody, test.promQL) {
+				if strings.Contains(reqBody, test.label) {
+					return test.respBody
+				} else {
+					return `{"status":"success","data":{"resultType":"matrix","result":[]}}`
+				}
+			}
+		}
+		return ""
+	}
+
+	httpHandler, br := setupTypicalPromReader(t)
+	httpHandler.getRespBody.Store(&f)
+	for i, test := range tests {
+		key := strconv.Itoa(i)
+		br.AddQueryExpr(key, QueryExpr{
+			PromQL:   test.promQL + `{%s="tidb"}`,
+			Range:    time.Minute,
+			HasLabel: true,
+		})
+	}
+
+	err := br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	for i, test := range tests {
+		key := strconv.Itoa(i)
+		msg := fmt.Sprintf("%dth test %s", i, test.promQL)
+		qr := br.GetQueryResult(key)
+		require.Equal(t, test.expectedString, qr.Value.String(), msg)
+	}
+}
+
+func TestPromUnavailable(t *testing.T) {
+	httpHandler, mr := setupTypicalPromReader(t)
+	f := func(reqBody string) string {
+		return `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"any"},"values":[[1712738879.406,"0"]]}]}}`
+	}
+	httpHandler.getRespBody.Store(&f)
+	mr.AddQueryExpr("0", QueryExpr{
+		PromQL: "any",
+		Range:  time.Minute,
+	})
+	err := mr.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	qr1 := mr.GetQueryResult("0")
+	require.False(t, qr1.Empty())
+
+	httpHandler.statusCode.Store(http.StatusInternalServerError)
+	err = mr.ReadMetrics(context.Background())
+	require.Error(t, err)
+}
+
+func TestNoPromAddr(t *testing.T) {
+	mpf := &mockPromFetcher{
+		getPromInfo: func(ctx context.Context) (*infosync.PrometheusInfo, error) {
+			return nil, infosync.ErrNoProm
+		},
+	}
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := newHealthCheckConfigForTest()
+	br := NewPromReader(lg, mpf, cfg)
+	promInfo, err := br.getPromAPI(context.Background())
+	require.Nil(t, promInfo)
+	require.ErrorIs(t, err, infosync.ErrNoProm)
+
+	br.AddQueryExpr("0", QueryExpr{
+		PromQL: "any",
+		Range:  time.Minute,
+	})
+	err = br.ReadMetrics(context.Background())
+	require.Error(t, err)
+	qr := br.GetQueryResult("0")
+	require.True(t, qr.Empty())
+}
+
+func setupTypicalPromReader(t *testing.T) (*mockHttpHandler, *PromReader) {
+	httpHandler := newMockHttpHandler(t)
+	port := httpHandler.Start()
+	t.Cleanup(httpHandler.Close)
+	mpf := newMockPromFetcher(port)
+	lg, _ := logger.CreateLoggerForTest(t)
+	pr := NewPromReader(lg, mpf, newHealthCheckConfigForTest())
+	return httpHandler, pr
+}
+
+func newHealthCheckConfigForTest() *config.HealthCheck {
+	return &config.HealthCheck{
+		Enable:          true,
+		MetricsInterval: 10 * time.Millisecond,
+		MetricsTimeout:  100 * time.Millisecond,
+	}
+}

--- a/pkg/balance/metricsreader/query_result.go
+++ b/pkg/balance/metricsreader/query_result.go
@@ -53,7 +53,6 @@ type QueryRule struct {
 
 type QueryResult struct {
 	Value      model.Value
-	Err        error
 	UpdateTime monotime.Time
 }
 

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -45,6 +45,10 @@ const (
 	infoSuffix = "info"
 )
 
+var (
+	ErrNoProm = errors.New("no prometheus info")
+)
+
 // InfoSyncer syncs TiProxy topology to ETCD and queries TiDB topology from ETCD.
 // It writes 2 items to ETCD: `/topology/tiproxy/.../info` and `/topology/tiproxy/.../ttl`.
 // They are erased after TiProxy is down.
@@ -286,7 +290,7 @@ func (is *InfoSyncer) GetPromInfo(ctx context.Context) (*PrometheusInfo, error) 
 		return nil, err
 	}
 	if len(res.Kvs) == 0 {
-		return nil, nil
+		return nil, ErrNoProm
 	}
 	var info PrometheusInfo
 	if err = json.Unmarshal(res.Kvs[0].Value, &info); err != nil {

--- a/pkg/manager/infosync/info_test.go
+++ b/pkg/manager/infosync/info_test.go
@@ -217,7 +217,7 @@ func TestGetPromInfo(t *testing.T) {
 	ts := newEtcdTestSuite(t)
 	t.Cleanup(ts.close)
 	info, err := ts.is.GetPromInfo(context.Background())
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrNoProm)
 	require.Nil(t, info)
 
 	pInfo := &PrometheusInfo{

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -146,6 +146,5 @@ func (mgr *NamespaceManager) Close() error {
 		ns.Close()
 	}
 	mgr.RUnlock()
-	mgr.metricsReader.Close()
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,7 +121,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	{
 		healthCheckCfg := config.NewDefaultHealthCheckConfig()
 		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), srv.infoSyncer, srv.infoSyncer, srv.httpCli, healthCheckCfg, srv.configManager)
-		srv.metricsReader.Start(context.Background(), srv.etcdCli)
+		if err = srv.metricsReader.Start(context.Background(), srv.etcdCli); err != nil {
+			return
+		}
 	}
 
 	// setup namespace manager

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -120,8 +120,8 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	// setup metrics reader
 	{
 		healthCheckCfg := config.NewDefaultHealthCheckConfig()
-		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), srv.infoSyncer, healthCheckCfg)
-		srv.metricsReader.Start(context.Background())
+		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), srv.infoSyncer, srv.infoSyncer, srv.httpCli, healthCheckCfg, srv.configManager)
+		srv.metricsReader.Start(context.Background(), srv.etcdCli)
 	}
 
 	// setup namespace manager


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #605 

Problem Summary:
When Prometheus is available, read metrics from Prometheus. If not, read from backends.

What is changed and how it works:
- Add `PromReader`. `MetricsReader` reads from `PromReader` first, if it fails, reads from `BackendReader`.
- Fix that `BackendReader` doesn't update query results after it reads from the owner.
- Move `HealthCheck` configs from `namespace.go` to `health.go`.
- Fix some query rules that when TiDB has rebooted, the metric value may jump back.
- Change the key of query expressions from `uint64` to `string` so that every TiProxy has the same key.
- Remove `QueryResult.Err` because it's useless.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
