### PR TITLE
metricsreader, elect: read metrics from zone leader

### DIFF
--- a/lib/config/label.go
+++ b/lib/config/label.go
@@ -1,0 +1,17 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+const (
+	// LocationLabelName indicates the label name that decides the location of TiProxy and backends.
+	// We use `zone` because the follower read in TiDB also uses `zone` to decide location.
+	LocationLabelName = "zone"
+)
+
+func (cfg *Config) GetLocation() string {
+	if len(cfg.Labels) == 0 {
+		return ""
+	}
+	return cfg.Labels[LocationLabelName]
+}

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/prometheus/common/model"
-	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 var _ policy.BackendCtx = (*mockBackend)(nil)
@@ -103,7 +102,7 @@ func newMockMetricsReader() *mockMetricsReader {
 	}
 }
 
-func (mmr *mockMetricsReader) Start(ctx context.Context, etcdCli *clientv3.Client) error {
+func (mmr *mockMetricsReader) Start(ctx context.Context) error {
 	return nil
 }
 
@@ -115,6 +114,10 @@ func (mmr *mockMetricsReader) RemoveQueryExpr(key string) {
 
 func (mmr *mockMetricsReader) GetQueryResult(key string) metricsreader.QueryResult {
 	return mmr.qrs[key]
+}
+
+func (mmr *mockMetricsReader) GetBackendMetrics() []byte {
+	return nil
 }
 
 func (mmr *mockMetricsReader) Close() {

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -6,6 +6,7 @@ package metricsreader
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net"
 	"reflect"
@@ -18,21 +19,27 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/manager/elect"
+	"github.com/pingcap/tiproxy/pkg/util/etcd"
 	"github.com/pingcap/tiproxy/pkg/util/http"
 	"github.com/pingcap/tiproxy/pkg/util/monotime"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/siddontang/go/hack"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
 const (
-	// backendReaderKey is the key in etcd for VIP election.
-	backendReaderKey = "/tiproxy/metricreader/owner"
+	// readerOwnerKeyPrefix is the key prefix in etcd for backend reader owner election.
+	// For global owner, the key is "/tiproxy/metricreader/owner".
+	// For zonal owner, the key is "/tiproxy/metricreader/{zone}/owner".
+	readerOwnerKeyPrefix = "/tiproxy/metricreader"
+	readerOwnerKeySuffix = "owner"
 	// sessionTTL is the session's TTL in seconds for backend reader owner election.
 	sessionTTL = 30
 	// backendMetricPath is the path of backend HTTP API to read metrics.
@@ -41,6 +48,10 @@ const (
 	ownerMetricPath = "/api/backend/metrics"
 	goPoolSize      = 100
 	goMaxIdle       = time.Minute
+)
+
+var (
+	errReadFromOwner = errors.New("read metrics from owner failed")
 )
 
 type backendHistory struct {
@@ -60,18 +71,21 @@ type BackendReader struct {
 	// the owner marshalles history to share it to other members
 	// cache the marshalled history to avoid duplicated marshalling
 	marshalledHistory []byte
-	election          elect.Election
 	cfgGetter         config.ConfigGetter
 	backendFetcher    TopologyFetcher
+	lastZone          string
+	electionCfg       elect.ElectionConfig
+	election          elect.Election
+	isOwner           atomic.Bool
+	wgp               *waitgroup.WaitGroupPool
+	etcdCli           *clientv3.Client
 	httpCli           *http.Client
 	lg                *zap.Logger
 	cfg               *config.HealthCheck
-	wgp               *waitgroup.WaitGroupPool
-	isOwner           atomic.Bool
 }
 
-func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *http.Client, backendFetcher TopologyFetcher,
-	cfg *config.HealthCheck) *BackendReader {
+func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *http.Client, etcdCli *clientv3.Client,
+	backendFetcher TopologyFetcher, cfg *config.HealthCheck) *BackendReader {
 	return &BackendReader{
 		queryRules:     make(map[string]QueryRule),
 		queryResults:   make(map[string]QueryResult),
@@ -81,12 +95,18 @@ func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *ht
 		backendFetcher: backendFetcher,
 		cfg:            cfg,
 		wgp:            waitgroup.NewWaitGroupPool(goPoolSize, goMaxIdle),
+		electionCfg:    elect.DefaultElectionConfig(sessionTTL),
+		etcdCli:        etcdCli,
 		httpCli:        httpCli,
 	}
 }
 
-func (br *BackendReader) Start(ctx context.Context, etcdCli *clientv3.Client) error {
+func (br *BackendReader) Start(ctx context.Context) error {
 	cfg := br.cfgGetter.GetConfig()
+	return br.initElection(ctx, cfg)
+}
+
+func (br *BackendReader) initElection(ctx context.Context, cfg *config.Config) error {
 	ip, _, statusPort, err := cfg.GetIPPort()
 	if err != nil {
 		return err
@@ -94,8 +114,14 @@ func (br *BackendReader) Start(ctx context.Context, etcdCli *clientv3.Client) er
 
 	// Use the status address as the key so that it can read metrics from the address.
 	id := net.JoinHostPort(ip, statusPort)
-	electionCfg := elect.DefaultElectionConfig(sessionTTL)
-	election := elect.NewElection(br.lg, etcdCli, electionCfg, id, backendReaderKey, br)
+	var key string
+	br.lastZone = cfg.GetLocation()
+	if len(br.lastZone) > 0 {
+		key = fmt.Sprintf("%s/%s/%s", readerOwnerKeyPrefix, br.lastZone, readerOwnerKeySuffix)
+	} else {
+		key = fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	}
+	election := elect.NewElection(br.lg, br.etcdCli, br.electionCfg, id, key, br)
 	br.election = election
 	election.Start(ctx)
 	return nil
@@ -129,24 +155,115 @@ func (br *BackendReader) GetQueryResult(key string) QueryResult {
 }
 
 func (br *BackendReader) ReadMetrics(ctx context.Context) error {
-	if br.isOwner.Load() {
-		if err := br.readFromBackends(ctx); err != nil {
+	// If the zone changes, start a new election.
+	cfg := br.cfgGetter.GetConfig()
+	zone := cfg.GetLocation()
+	if zone != br.lastZone {
+		br.election.Close()
+		if err := br.initElection(ctx, cfg); err != nil {
 			return err
 		}
-	} else {
-		owner, err := br.election.GetOwnerID(ctx)
-		if err != nil {
-			return err
+	}
+
+	// Read from all owners, regardless of whether the owner is a zone owner or global owner.
+	zones, owners, err := br.queryAllOwners(ctx)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, owner := range owners {
+		if owner == br.election.ID() {
+			continue
 		}
 		if err = br.readFromOwner(ctx, owner); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// If self is a owner, read the backends that are not read by any other owners.
+	if br.isOwner.Load() {
+		if idx := slices.Index(zones, zone); idx >= 0 {
+			zones = slices.Delete(zones, idx, idx+1)
+		}
+		if err := br.readFromBackends(ctx, zones); err != nil {
 			return err
 		}
+	}
+
+	// Purge expired history.
+	br.purgeHistory()
+	if len(errs) > 0 {
+		return errors.Collect(errReadFromOwner, errs...)
 	}
 	return nil
 }
 
-func (br *BackendReader) readFromBackends(ctx context.Context) error {
-	addrs, err := br.getBackendAddrs(ctx)
+// Query all owners, including zone owner and global owner.
+func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []string, err error) {
+	// Get all owner keys.
+	opts := []clientv3.OpOption{clientv3.WithPrefix()}
+	var kvs []*mvccpb.KeyValue
+	kvs, err = etcd.GetKVs(ctx, br.etcdCli, readerOwnerKeyPrefix, opts, br.electionCfg.Timeout, br.electionCfg.RetryIntvl, br.electionCfg.RetryCnt)
+	if err != nil {
+		return
+	}
+
+	type ownerInfo struct {
+		addr     string
+		revision int64
+	}
+	// Multiple members campaign for the same owner key, so there exist multiple keys prefixed with the same owner key.
+	// Choose the one with the least create revision for the same zone.
+	ownerMap := make(map[string]ownerInfo)
+	for _, kv := range kvs {
+		key := hack.String(kv.Key)
+		key = key[len(readerOwnerKeyPrefix):]
+		if len(key) == 0 || key[0] != '/' {
+			continue
+		}
+		key = key[1:]
+
+		var zone string
+		if strings.HasPrefix(key, readerOwnerKeySuffix) {
+			// global owner key, such as "/tiproxy/metricreader/owner/leaseID"
+		} else if endIdx := strings.Index(key, "/"); endIdx > 0 && strings.HasPrefix(key[endIdx+1:], readerOwnerKeySuffix) {
+			// zonal owner key, such as "/tiproxy/metricreader/east/owner/leaseID"
+			zone = key[:endIdx]
+		} else {
+			continue
+		}
+
+		if info, ok := ownerMap[zone]; !ok || info.revision > kv.CreateRevision {
+			ownerMap[zone] = ownerInfo{
+				addr:     hack.String(kv.Value),
+				revision: kv.CreateRevision,
+			}
+		}
+	}
+
+	owners = make([]string, 0, len(ownerMap))
+	zones = make([]string, 0, len(ownerMap))
+	for zone, info := range ownerMap {
+		if len(zone) > 0 && !slices.Contains(zones, zone) {
+			zones = append(zones, zone)
+		}
+		if !slices.Contains(owners, info.addr) {
+			owners = append(owners, info.addr)
+		}
+	}
+	return
+}
+
+// If self is a owner, read backends except excludeZones. The backends in those zones are read by other zonal owners.
+//
+// If the zone is not set, there is only one global owner, who queries all backends.
+// If the zone is set, there are several zonal owners, who query the backends in the same zone.
+// There are some exceptions:
+// 1. In k8s, the zone is not set at startup and then is set by HTTP API, so there may temporarily exist both global and zonal owners.
+// 2. Some backends may not be in the same zone with any owner. E.g. there are only 2 TiProxy in a 3-AZ cluster.
+// In any way, the owner queries the backends that are not queried by other owners.
+func (br *BackendReader) readFromBackends(ctx context.Context, excludeZones []string) error {
+	addrs, err := br.getBackendAddrs(ctx, excludeZones)
 	if err != nil {
 		return err
 	}
@@ -183,10 +300,9 @@ func (br *BackendReader) readFromBackends(ctx context.Context) error {
 	}
 	br.wgp.Wait()
 
-	br.purgeHistory()
-	br.Lock()
-	br.marshalledHistory = nil
-	br.Unlock()
+	if err := br.marshalHistory(addrs); err != nil {
+		br.lg.Error("marshal backend history failed", zap.Any("addrs", addrs), zap.Error(err))
+	}
 	return nil
 }
 
@@ -362,39 +478,28 @@ func (br *BackendReader) purgeHistory() {
 	}
 }
 
-func (br *BackendReader) GetBackendMetrics() ([]byte, error) {
+func (br *BackendReader) GetBackendMetrics() []byte {
 	br.Lock()
 	defer br.Unlock()
-	if br.marshalledHistory != nil {
-		return br.marshalledHistory, nil
-	}
-	marshalled, err := json.Marshal(br.history)
-	if err != nil {
-		return nil, err
-	}
-	br.marshalledHistory = marshalled
-	return marshalled, nil
+	return br.marshalledHistory
 }
 
 // readFromOwner queries metric history from the owner.
 // If every member queries directly from backends, the backends may suffer from too much pressure.
-func (br *BackendReader) readFromOwner(ctx context.Context, addr string) error {
+func (br *BackendReader) readFromOwner(ctx context.Context, ownerAddr string) error {
 	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(br.cfg.RetryInterval), uint64(br.cfg.MaxRetries)), ctx)
-	resp, err := br.httpCli.Get(addr, ownerMetricPath, b, br.cfg.DialTimeout)
+	resp, err := br.httpCli.Get(ownerAddr, ownerMetricPath, b, br.cfg.DialTimeout)
 	if err != nil {
 		return err
+	}
+	if len(resp) == 0 {
+		return nil
 	}
 
 	var newHistory map[string]map[string]backendHistory
 	if err := json.Unmarshal(resp, &newHistory); err != nil {
 		return err
 	}
-	// If this instance becomes the owner in the next round, it can reuse the history.
-	br.Lock()
-	br.history = newHistory
-	br.marshalledHistory = nil
-	br.Unlock()
-
 	backends := make(map[string]struct{})
 	for _, ruleHistory := range newHistory {
 		for backend := range ruleHistory {
@@ -402,6 +507,10 @@ func (br *BackendReader) readFromOwner(ctx context.Context, addr string) error {
 		}
 	}
 
+	// If this instance becomes the owner in the next round, it can reuse the history.
+	br.mergeHistory(newHistory)
+
+	// Update query result for the updated backends.
 	for backend := range backends {
 		result := br.history2Value(backend)
 		br.mergeQueryResult(result, backend)
@@ -409,7 +518,60 @@ func (br *BackendReader) readFromOwner(ctx context.Context, addr string) error {
 	return nil
 }
 
-func (br *BackendReader) getBackendAddrs(ctx context.Context) ([]string, error) {
+// If the history of one backend already exists, choose the latest one.
+func (br *BackendReader) mergeHistory(newHistory map[string]map[string]backendHistory) {
+	br.Lock()
+	defer br.Unlock()
+	for ruleKey, newRuleHistory := range newHistory {
+		ruleHistory, ok := br.history[ruleKey]
+		if !ok {
+			br.history[ruleKey] = newRuleHistory
+			continue
+		}
+		for backend, newBackendHistory := range newRuleHistory {
+			backendHistory, ok := ruleHistory[backend]
+			if !ok {
+				ruleHistory[backend] = newBackendHistory
+				continue
+			}
+			if len(backendHistory.Step1History) == 0 || (len(newBackendHistory.Step1History) > 0 &&
+				newBackendHistory.Step1History[len(newBackendHistory.Step1History)-1].Timestamp.After(backendHistory.Step1History[len(backendHistory.Step1History)-1].Timestamp)) {
+				backendHistory.Step1History = newBackendHistory.Step1History
+			}
+			if len(backendHistory.Step2History) == 0 || (len(newBackendHistory.Step2History) > 0 &&
+				newBackendHistory.Step2History[len(newBackendHistory.Step2History)-1].Timestamp.After(backendHistory.Step2History[len(backendHistory.Step2History)-1].Timestamp)) {
+				backendHistory.Step2History = newBackendHistory.Step2History
+			}
+			ruleHistory[backend] = backendHistory
+		}
+	}
+}
+
+// marshalHistory marshals the backends that are read by this owner. The marshaled data will be returned to other members.
+func (br *BackendReader) marshalHistory(backends []string) error {
+	br.Lock()
+	defer br.Unlock()
+
+	filteredHistory := make(map[string]map[string]backendHistory, len(br.queryRules))
+	for ruleKey, ruleHistory := range br.history {
+		filteredRuleHistory := make(map[string]backendHistory, len(backends))
+		filteredHistory[ruleKey] = filteredRuleHistory
+		for backend, backendHistory := range ruleHistory {
+			if slices.Contains(backends, backend) {
+				filteredRuleHistory[backend] = backendHistory
+			}
+		}
+	}
+
+	marshalled, err := json.Marshal(filteredHistory)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	br.marshalledHistory = marshalled
+	return nil
+}
+
+func (br *BackendReader) getBackendAddrs(ctx context.Context, excludeZones []string) ([]string, error) {
 	backends, err := br.backendFetcher.GetTiDBTopology(ctx)
 	if err != nil {
 		br.lg.Error("failed to get backend addresses, stop reading metrics", zap.Error(err))
@@ -417,6 +579,11 @@ func (br *BackendReader) getBackendAddrs(ctx context.Context) ([]string, error) 
 	}
 	addrs := make([]string, 0, len(backends))
 	for _, backend := range backends {
+		if len(excludeZones) > 0 {
+			if slices.Contains(excludeZones, backend.Labels[config.LocationLabelName]) {
+				continue
+			}
+		}
 		addrs = append(addrs, net.JoinHostPort(backend.IP, strconv.Itoa(int(backend.StatusPort))))
 	}
 	return addrs, nil

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
@@ -32,9 +33,10 @@ import (
 // test getBackendAddrs
 func TestGetBackendAddrs(t *testing.T) {
 	tests := []struct {
-		backends map[string]*infosync.TiDBTopologyInfo
-		hasErr   bool
-		expected []string
+		backends     map[string]*infosync.TiDBTopologyInfo
+		excludeZones []string
+		hasErr       bool
+		expected     []string
 	}{
 		{
 			backends: map[string]*infosync.TiDBTopologyInfo{},
@@ -63,13 +65,60 @@ func TestGetBackendAddrs(t *testing.T) {
 			expected: []string{"1.1.1.1:10080", "2.2.2.2:10080"},
 		},
 		{
+			backends: map[string]*infosync.TiDBTopologyInfo{
+				"1.1.1.1:4000": {
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+					Labels:     map[string]string{config.LocationLabelName: "z1"},
+				},
+				"2.2.2.2:4000": {
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
+					Labels:     map[string]string{config.LocationLabelName: "z2"},
+				},
+			},
+			excludeZones: []string{"z1"},
+			expected:     []string{"2.2.2.2:10080"},
+		},
+		{
+			backends: map[string]*infosync.TiDBTopologyInfo{
+				"1.1.1.1:4000": {
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+					Labels:     map[string]string{config.LocationLabelName: "z1"},
+				},
+				"2.2.2.2:4000": {
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
+					Labels:     map[string]string{config.LocationLabelName: "z2"},
+				},
+			},
+			excludeZones: []string{"z1", "z2"},
+			expected:     []string{},
+		},
+		{
+			backends: map[string]*infosync.TiDBTopologyInfo{
+				"1.1.1.1:4000": {
+					IP:         "1.1.1.1",
+					StatusPort: 10080,
+				},
+				"2.2.2.2:4000": {
+					IP:         "2.2.2.2",
+					StatusPort: 10080,
+					Labels:     map[string]string{config.LocationLabelName: "z2"},
+				},
+			},
+			excludeZones: []string{"z1", "z2"},
+			expected:     []string{"1.1.1.1:10080"},
+		},
+		{
 			hasErr: true,
 		},
 	}
 
 	lg, _ := logger.CreateLoggerForTest(t)
 	fetcher := newMockBackendFetcher(nil, nil)
-	br := NewBackendReader(lg, nil, nil, fetcher, nil)
+	br := NewBackendReader(lg, nil, nil, nil, fetcher, nil)
 	for i, test := range tests {
 		fetcher.infos = test.backends
 		if test.hasErr {
@@ -77,7 +126,7 @@ func TestGetBackendAddrs(t *testing.T) {
 		} else {
 			fetcher.err = nil
 		}
-		addrs, err := br.getBackendAddrs(context.Background())
+		addrs, err := br.getBackendAddrs(context.Background(), test.excludeZones)
 		if test.hasErr {
 			require.Error(t, err, "case %d", i)
 		} else {
@@ -185,7 +234,7 @@ func TestReadBackendMetric(t *testing.T) {
 	t.Cleanup(httpHandler.Close)
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
 	cli := httputil.NewHTTPClient(func() *tls.Config { return nil })
-	br := NewBackendReader(lg, nil, cli, nil, cfg)
+	br := NewBackendReader(lg, nil, cli, nil, nil, cfg)
 	for i, test := range tests {
 		statusCode := http.StatusOK
 		if test.hasErr {
@@ -243,7 +292,7 @@ func TestOneRuleOneHistory(t *testing.T) {
 	mfs := mockMfs()
 	lg, _ := logger.CreateLoggerForTest(t)
 	for i, test := range tests {
-		br := NewBackendReader(lg, nil, nil, nil, nil)
+		br := NewBackendReader(lg, nil, nil, nil, nil, nil)
 		br.queryRules = map[string]QueryRule{
 			"key": {
 				Names: test.names,
@@ -312,7 +361,7 @@ func TestOneRuleMultiHistory(t *testing.T) {
 
 	mfs := mockMfs()
 	lg, _ := logger.CreateLoggerForTest(t)
-	br := NewBackendReader(lg, nil, nil, nil, nil)
+	br := NewBackendReader(lg, nil, nil, nil, nil, nil)
 	var lastTs model.Time
 	var length int
 	for i, test := range tests {
@@ -395,7 +444,7 @@ func TestMultiRules(t *testing.T) {
 
 	mfs := mockMfs()
 	lg, _ := logger.CreateLoggerForTest(t)
-	br := NewBackendReader(lg, nil, nil, nil, nil)
+	br := NewBackendReader(lg, nil, nil, nil, nil, nil)
 	for i, test := range tests {
 		if test.hasRule1 {
 			br.queryRules["key1"] = rule1
@@ -497,7 +546,7 @@ func TestMergeQueryResult(t *testing.T) {
 	}
 
 	lg, _ := logger.CreateLoggerForTest(t)
-	br := NewBackendReader(lg, nil, nil, nil, nil)
+	br := NewBackendReader(lg, nil, nil, nil, nil, nil)
 	for i, test := range tests {
 		br.mergeQueryResult(test.backendValues, test.backend)
 		for id, expectedValue := range test.queryResult {
@@ -525,6 +574,180 @@ func TestMergeQueryResult(t *testing.T) {
 				require.Equal(t, expectedValue.(model.Matrix)[0], sample, "case %d", i)
 			}
 		}
+	}
+}
+
+func TestMergeHistory(t *testing.T) {
+	tests := []struct {
+		oldHistory map[string]map[string]backendHistory
+		newHistory map[string]map[string]backendHistory
+		result     map[string]map[string]backendHistory
+	}{
+		{
+			oldHistory: map[string]map[string]backendHistory{},
+			result:     map[string]map[string]backendHistory{},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{},
+			newHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			newHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend2": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+					"backend2": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+					"backend2": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			newHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend2": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+					"backend2": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			newHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+		},
+		{
+			oldHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+			newHistory: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 1}, {Value: 2, Timestamp: 2}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 3}, {Value: 4, Timestamp: 4}},
+					},
+				},
+			},
+			result: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{{Value: 1, Timestamp: 10}, {Value: 2, Timestamp: 20}},
+						Step2History: []model.SamplePair{{Value: 3, Timestamp: 30}, {Value: 4, Timestamp: 40}},
+					},
+				},
+			},
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	br := NewBackendReader(lg, nil, nil, nil, nil, nil)
+	for i, test := range tests {
+		br.history = test.oldHistory
+		br.mergeHistory(test.newHistory)
+		require.Equal(t, test.result, br.history, "case %d", i)
 	}
 }
 
@@ -573,7 +796,7 @@ func TestPurgeHistory(t *testing.T) {
 	}
 
 	lg, _ := logger.CreateLoggerForTest(t)
-	br := NewBackendReader(lg, nil, nil, nil, nil)
+	br := NewBackendReader(lg, nil, nil, nil, nil, nil)
 	for i, test := range tests {
 		br.AddQueryRule(strconv.Itoa(i), QueryRule{
 			Retention: time.Minute,
@@ -622,7 +845,7 @@ func TestQueryBackendConcurrently(t *testing.T) {
 
 	fetcher := newMockBackendFetcher(infos, nil)
 	cli := httputil.NewHTTPClient(func() *tls.Config { return nil })
-	br := NewBackendReader(lg, nil, cli, fetcher, cfg)
+	br := NewBackendReader(lg, nil, cli, nil, fetcher, cfg)
 	// create 3 rules
 	addRule := func(id int) {
 		rule := QueryRule{
@@ -652,11 +875,11 @@ func TestQueryBackendConcurrently(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	childCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	// fill the initial query result to ensure the result is always non-empty
-	err := br.readFromBackends(childCtx)
+	err := br.readFromBackends(childCtx, nil)
 	require.NoError(t, err)
 	wg.Run(func() {
 		for childCtx.Err() == nil {
-			err := br.readFromBackends(childCtx)
+			err := br.readFromBackends(childCtx, nil)
 			require.NoError(t, err)
 			br.purgeHistory()
 		}
@@ -710,8 +933,7 @@ func TestQueryBackendConcurrently(t *testing.T) {
 		for childCtx.Err() == nil {
 			select {
 			case <-time.After(10 * time.Millisecond):
-				_, err := br.GetBackendMetrics()
-				require.NoError(t, err)
+				br.GetBackendMetrics()
 			case <-childCtx.Done():
 				return
 			}
@@ -723,15 +945,48 @@ func TestQueryBackendConcurrently(t *testing.T) {
 
 func TestReadFromOwner(t *testing.T) {
 	tests := []struct {
-		history    map[string]map[string]backendHistory
-		statusCode int32
+		history  map[string]map[string]backendHistory
+		expected map[string]map[string]backendHistory
+		backends []string
 	}{
 		{
-			history:    make(map[string]map[string]backendHistory),
-			statusCode: http.StatusOK,
+			history:  make(map[string]map[string]backendHistory),
+			expected: make(map[string]map[string]backendHistory),
+			backends: []string{},
 		},
 		{
 			history: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 100.0},
+							{Timestamp: 234, Value: 200.0},
+						},
+						Step2History: []model.SamplePair{
+							{Timestamp: 123, Value: 200.0},
+							{Timestamp: 234, Value: 300.0},
+						},
+					},
+					"backend2": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 400.0},
+						},
+					},
+					"backend3": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 400.0},
+						},
+					},
+				},
+				"rule_id2": {
+					"backend1": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 500.0},
+						},
+					},
+				},
+			},
+			expected: map[string]map[string]backendHistory{
 				"rule_id1": {
 					"backend1": {
 						Step1History: []model.SamplePair{
@@ -757,18 +1012,37 @@ func TestReadFromOwner(t *testing.T) {
 					},
 				},
 			},
-			statusCode: http.StatusOK,
+			backends: []string{"backend1", "backend2"},
 		},
 		{
-			history:    make(map[string]map[string]backendHistory),
-			statusCode: http.StatusNotFound,
+			history: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 100.0},
+							{Timestamp: 234, Value: 200.0},
+						},
+					},
+				},
+			},
+			expected: map[string]map[string]backendHistory{
+				"rule_id1": {
+					"backend1": {
+						Step1History: []model.SamplePair{
+							{Timestamp: 123, Value: 100.0},
+							{Timestamp: 234, Value: 200.0},
+						},
+					},
+				},
+			},
+			backends: []string{"backend1", "backend2"},
 		},
 	}
 
 	lg, _ := logger.CreateLoggerForTest(t)
 	cfg := newHealthCheckConfigForTest()
 	cli := httputil.NewHTTPClient(func() *tls.Config { return nil })
-	br := NewBackendReader(lg, nil, cli, nil, cfg)
+	br := NewBackendReader(lg, nil, cli, nil, nil, cfg)
 	httpHandler := newMockHttpHandler(t)
 	port := httpHandler.Start()
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
@@ -777,31 +1051,132 @@ func TestReadFromOwner(t *testing.T) {
 	for i, test := range tests {
 		// marshal
 		br.history = test.history
-		br.marshalledHistory = nil
-		data, err := br.GetBackendMetrics()
-		require.NoError(t, err, "case %d", i)
+		br.marshalHistory(test.backends)
+		data := br.GetBackendMetrics()
 
 		f := func(_ string) string {
 			return string(data)
 		}
 		httpHandler.getRespBody.Store(&f)
-		httpHandler.statusCode.Store(test.statusCode)
 
 		// unmarshal
 		br.history = make(map[string]map[string]backendHistory)
-		err = br.readFromOwner(context.Background(), addr)
-		if test.statusCode != http.StatusOK {
-			require.Error(t, err, "case %d", i)
-			continue
-		}
+		err := br.readFromOwner(context.Background(), addr)
 		require.NoError(t, err, "case %d", i)
-		require.Equal(t, test.history, br.history, "case %d", i)
+		require.Equal(t, test.expected, br.history, "case %d", i)
 
 		// marshal again
-		data2, err := br.GetBackendMetrics()
-		require.NoError(t, err, "case %d", i)
+		data2 := br.GetBackendMetrics()
 		require.Equal(t, data, data2, "case %d", i)
 	}
+}
+
+// test queryAllOwners
+func TestQueryAllOwners(t *testing.T) {
+	tests := []struct {
+		keys   []string
+		values []string
+		owners []string
+		zones  []string
+	}{
+		{},
+		{
+			keys:   []string{"/owner/1111", "/owner/2222"},
+			values: []string{"backend1", "backend2"},
+			owners: []string{"backend1"},
+		},
+		{
+			keys:   []string{"/east/owner/1111", "/east/owner/2222"},
+			values: []string{"backend1", "backend2"},
+			owners: []string{"backend1"},
+			zones:  []string{"east"},
+		},
+		{
+			keys:   []string{"/east/owner/1111", "/west/owner/2222"},
+			values: []string{"backend1", "backend2"},
+			owners: []string{"backend1", "backend2"},
+			zones:  []string{"east", "west"},
+		},
+		{
+			keys:   []string{"/east/owner/1111", "/owner/2222"},
+			values: []string{"backend1", "backend2"},
+			owners: []string{"backend1", "backend2"},
+			zones:  []string{"east"},
+		},
+		{
+			keys:   []string{"/east/owner/1111", "/owner/2222"},
+			values: []string{"backend1", "backend1"},
+			owners: []string{"backend1"},
+			zones:  []string{"east"},
+		},
+		{
+			keys:   []string{"", "//owner/2222", "/east/3333"},
+			values: []string{"backend1", "backend2", "backend3"},
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	suite := newEtcdTestSuite(t)
+	defer suite.close()
+	br := NewBackendReader(lg, nil, nil, suite.client, nil, nil)
+	for i, test := range tests {
+		for i, key := range test.keys {
+			key = fmt.Sprintf("%s%s", readerOwnerKeyPrefix, key)
+			suite.putKV(key, test.values[i])
+		}
+		zones, owners, err := br.queryAllOwners(context.Background())
+		require.NoError(t, err, "case %d", i)
+		if test.owners == nil {
+			require.Empty(t, owners, "case %d", i)
+		} else {
+			slices.Sort(owners)
+			require.Equal(t, test.owners, owners, "case %d", i)
+		}
+		if test.zones == nil {
+			require.Empty(t, zones, "case %d", i)
+		} else {
+			slices.Sort(zones)
+			require.Equal(t, test.zones, zones, "case %d", i)
+		}
+		suite.delKV(readerOwnerKeyPrefix)
+	}
+}
+
+func TestUpdateLabel(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	suite := newEtcdTestSuite(t)
+	defer suite.close()
+	cfg := config.NewConfig()
+	cfgGetter := newMockConfigGetter(cfg)
+	healthCfg := newHealthCheckConfigForTest()
+	fetcher := newMockBackendFetcher(map[string]*infosync.TiDBTopologyInfo{}, nil)
+	br := NewBackendReader(lg, cfgGetter, nil, suite.client, fetcher, healthCfg)
+	err := br.Start(context.Background())
+	require.NoError(t, err)
+	defer br.Close()
+
+	checkKeyPrefix := func(prefix string) bool {
+		kvs := suite.getKV(readerOwnerKeyPrefix)
+		if len(kvs) != 1 {
+			return false
+		}
+		return strings.HasPrefix(string(kvs[0].Key), prefix)
+	}
+
+	// campaign for the global owner
+	prefix := fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	require.Eventually(t, func() bool {
+		return checkKeyPrefix(prefix)
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// retire the global owner and campaign for the zonal owner
+	cfg.Labels = map[string]string{config.LocationLabelName: "east"}
+	err = br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	prefix = fmt.Sprintf("%s/east/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	require.Eventually(t, func() bool {
+		return checkKeyPrefix(prefix)
+	}, 3*time.Second, 10*time.Millisecond)
 }
 
 func TestElection(t *testing.T) {
@@ -849,22 +1224,31 @@ func TestElection(t *testing.T) {
 	ownerHttpHandler.getRespBody.Store(&ownerFunc)
 	t.Cleanup(ownerHttpHandler.Close)
 
+	// setup etcd
+	suite := newEtcdTestSuite(t)
+	t.Cleanup(suite.close)
+	ownerKey := fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	suite.putKV(ownerKey, addr)
+	require.Eventually(t, func() bool {
+		kvs := suite.getKV(ownerKey)
+		return len(kvs) == 1 && string(kvs[0].Value) == addr
+	}, 3*time.Second, 10*time.Millisecond)
+
 	// setup backend reader
 	lg, _ := logger.CreateLoggerForTest(t)
-	cfg := newHealthCheckConfigForTest()
+	healthCfg := newHealthCheckConfigForTest()
+	cfg := config.NewConfig()
+	cfgGetter := newMockConfigGetter(cfg)
 	fetcher := newMockBackendFetcher(infos, nil)
 	httpCli := httputil.NewHTTPClient(func() *tls.Config { return nil })
-	br := NewBackendReader(lg, nil, httpCli, fetcher, cfg)
-	election := newMockElection()
-	br.election = election
+	br := NewBackendReader(lg, cfgGetter, httpCli, suite.client, fetcher, healthCfg)
+	err = br.Start(context.Background())
+	require.NoError(t, err)
 	br.AddQueryRule("rule_id1", rule)
 	t.Cleanup(br.Close)
 
 	// test not owner
 	ts := monotime.Now()
-	election.owner.Store(&addr)
-	election.isOwner.Store(false)
-	br.OnRetired()
 	err = br.ReadMetrics(context.Background())
 	require.NoError(t, err)
 	qr := br.GetQueryResult("rule_id1")
@@ -874,8 +1258,11 @@ func TestElection(t *testing.T) {
 	ts = qr.UpdateTime
 
 	// test owner
-	election.isOwner.Store(true)
-	br.OnElected()
+	suite.delKV(ownerKey)
+	require.Eventually(t, func() bool {
+		kvs := suite.getKV(ownerKey)
+		return len(kvs) == 1 && strings.HasSuffix(string(kvs[0].Value), "3080")
+	}, 3*time.Second, 10*time.Millisecond)
 	err = br.ReadMetrics(context.Background())
 	require.NoError(t, err)
 	qr = br.GetQueryResult("rule_id1")

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -1051,7 +1051,8 @@ func TestReadFromOwner(t *testing.T) {
 	for i, test := range tests {
 		// marshal
 		br.history = test.history
-		br.marshalHistory(test.backends)
+		err := br.marshalHistory(test.backends)
+		require.NoError(t, err, "case %d", i)
 		data := br.GetBackendMetrics()
 
 		f := func(_ string) string {
@@ -1061,7 +1062,7 @@ func TestReadFromOwner(t *testing.T) {
 
 		// unmarshal
 		br.history = make(map[string]map[string]backendHistory)
-		err := br.readFromOwner(context.Background(), addr)
+		err = br.readFromOwner(context.Background(), addr)
 		require.NoError(t, err, "case %d", i)
 		require.Equal(t, test.expected, br.history, "case %d", i)
 

--- a/pkg/balance/observer/backend_health.go
+++ b/pkg/balance/observer/backend_health.go
@@ -9,12 +9,6 @@ import (
 	"github.com/pingcap/tiproxy/lib/config"
 )
 
-var (
-	// locationLabelName indicates the label name that decides the location of TiProxy and backends.
-	// We use `zone` because the follower read in TiDB also uses `zone` to decide location.
-	locationLabelName = "zone"
-)
-
 type BackendHealth struct {
 	BackendInfo
 	Healthy bool
@@ -31,12 +25,12 @@ func (bh *BackendHealth) setLocal(cfg *config.Config) {
 		bh.Local = true
 		return
 	}
-	selfLocation, ok := cfg.Labels[locationLabelName]
-	if !ok || len(selfLocation) == 0 {
+	selfLocation := cfg.GetLocation()
+	if len(selfLocation) == 0 {
 		bh.Local = true
 		return
 	}
-	if bh.Labels != nil && bh.Labels[locationLabelName] == selfLocation {
+	if bh.Labels != nil && bh.Labels[config.LocationLabelName] == selfLocation {
 		bh.Local = true
 		return
 	}

--- a/pkg/balance/observer/backend_observer_test.go
+++ b/pkg/balance/observer/backend_observer_test.go
@@ -175,23 +175,23 @@ func TestLocal(t *testing.T) {
 			local:         true,
 		},
 		{
-			selfLabels:    map[string]string{locationLabelName: "b"},
+			selfLabels:    map[string]string{config.LocationLabelName: "b"},
 			backendLabels: map[string]string{"a": "b"},
 			local:         false,
 		},
 		{
-			selfLabels:    map[string]string{locationLabelName: "b"},
-			backendLabels: map[string]string{locationLabelName: "c"},
+			selfLabels:    map[string]string{config.LocationLabelName: "b"},
+			backendLabels: map[string]string{config.LocationLabelName: "c"},
 			local:         false,
 		},
 		{
-			selfLabels:    map[string]string{locationLabelName: "b"},
-			backendLabels: map[string]string{locationLabelName: "c", "a": "c"},
+			selfLabels:    map[string]string{config.LocationLabelName: "b"},
+			backendLabels: map[string]string{config.LocationLabelName: "c", "a": "c"},
 			local:         false,
 		},
 		{
-			selfLabels:    map[string]string{locationLabelName: "b"},
-			backendLabels: map[string]string{locationLabelName: "b", "a": "c"},
+			selfLabels:    map[string]string{config.LocationLabelName: "b"},
+			backendLabels: map[string]string{config.LocationLabelName: "b", "a": "c"},
 			local:         true,
 		},
 	}

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -73,7 +73,7 @@ func (mo *mockMember) hang(hang bool) {
 }
 
 type etcdTestSuite struct {
-	elecCfg electionConfig
+	elecCfg ElectionConfig
 	key     string
 	elecs   []*election
 	t       *testing.T
@@ -83,7 +83,7 @@ type etcdTestSuite struct {
 	kv      clientv3.KV
 }
 
-func newEtcdTestSuite(t *testing.T, elecCfg electionConfig, key string) *etcdTestSuite {
+func newEtcdTestSuite(t *testing.T, elecCfg ElectionConfig, key string) *etcdTestSuite {
 	lg, _ := logger.CreateLoggerForTest(t)
 	ts := &etcdTestSuite{
 		t:       t,
@@ -107,11 +107,11 @@ func newEtcdTestSuite(t *testing.T, elecCfg electionConfig, key string) *etcdTes
 }
 
 func (ts *etcdTestSuite) newElection(id string) *election {
-	cfg := electionConfig{
-		sessionTTL: 1,
-		timeout:    100 * time.Millisecond,
-		retryIntvl: 10 * time.Millisecond,
-		retryCnt:   2,
+	cfg := ElectionConfig{
+		SessionTTL: 1,
+		Timeout:    100 * time.Millisecond,
+		RetryIntvl: 10 * time.Millisecond,
+		RetryCnt:   2,
 	}
 	member := newMockMember()
 	elec := NewElection(ts.lg, ts.client, cfg, id, ts.key, member)
@@ -187,11 +187,11 @@ func (ts *etcdTestSuite) shutdownServer() string {
 	return addr
 }
 
-func electionConfigForTest(ttl int) electionConfig {
-	return electionConfig{
-		sessionTTL: ttl,
-		timeout:    100 * time.Millisecond,
-		retryIntvl: 10 * time.Millisecond,
-		retryCnt:   2,
+func electionConfigForTest(ttl int) ElectionConfig {
+	return ElectionConfig{
+		SessionTTL: ttl,
+		Timeout:    100 * time.Millisecond,
+		RetryIntvl: 10 * time.Millisecond,
+		RetryCnt:   2,
 	}
 }

--- a/pkg/manager/infosync/info.go
+++ b/pkg/manager/infosync/info.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/retry"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/util/etcd"
 	"github.com/pingcap/tiproxy/pkg/util/versioninfo"
 	"github.com/siddontang/go/hack"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -278,22 +279,16 @@ func (is *InfoSyncer) GetTiDBTopology(ctx context.Context) (map[string]*TiDBTopo
 }
 
 func (is *InfoSyncer) GetPromInfo(ctx context.Context) (*PrometheusInfo, error) {
-	var res *clientv3.GetResponse
-	err := retry.Retry(func() error {
-		childCtx, cancel := context.WithTimeout(ctx, is.syncConfig.getPromTimeout)
-		var err error
-		res, err = is.etcdCli.Get(childCtx, promTopologyPath, clientv3.WithPrefix())
-		cancel()
-		return errors.WithStack(err)
-	}, ctx, is.syncConfig.getPromRetryIntvl, is.syncConfig.getPromRetryCnt)
+	opts := []clientv3.OpOption{clientv3.WithPrefix()}
+	kvs, err := etcd.GetKVs(ctx, is.etcdCli, promTopologyPath, opts, is.syncConfig.getPromTimeout, is.syncConfig.getPromRetryIntvl, is.syncConfig.getPromRetryCnt)
 	if err != nil {
 		return nil, err
 	}
-	if len(res.Kvs) == 0 {
+	if len(kvs) == 0 {
 		return nil, ErrNoProm
 	}
 	var info PrometheusInfo
-	if err = json.Unmarshal(res.Kvs[0].Value, &info); err != nil {
+	if err = json.Unmarshal(kvs[0].Value, &info); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return &info, nil

--- a/pkg/manager/vip/mock_test.go
+++ b/pkg/manager/vip/mock_test.go
@@ -49,6 +49,10 @@ func newMockElection(ch chan int, member elect.Member) *mockElection {
 	}
 }
 
+func (m *mockElection) ID() string {
+	return ""
+}
+
 func (me *mockElection) GetOwnerID(ctx context.Context) (string, error) {
 	return "", nil
 }

--- a/pkg/server/api/backend.go
+++ b/pkg/server/api/backend.go
@@ -11,15 +11,11 @@ import (
 )
 
 type BackendReader interface {
-	GetBackendMetrics() ([]byte, error)
+	GetBackendMetrics() []byte
 }
 
 func (h *Server) BackendMetrics(c *gin.Context) {
-	metrics, err := h.mgr.br.GetBackendMetrics()
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, err)
-		return
-	}
+	metrics := h.mgr.br.GetBackendMetrics()
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(http.StatusOK)
 	if _, err := c.Writer.Write(metrics); err != nil {

--- a/pkg/server/api/backend_test.go
+++ b/pkg/server/api/backend_test.go
@@ -8,36 +8,46 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
 
 func TestBackendMetrics(t *testing.T) {
+	tests := []struct {
+		data   []byte
+		expect []byte
+	}{
+		{
+			data:   []byte(`{"key": "value"}`),
+			expect: []byte(`{"key": "value"}`),
+		},
+		{
+			data:   []byte{},
+			expect: []byte{},
+		},
+		{
+			data:   nil,
+			expect: []byte{},
+		},
+	}
+
 	server, doHTTP := createServer(t, nil)
 	mbr := server.mgr.br.(*mockBackendReader)
-	mbr.data.Store(`{"key": "value"}`)
-
-	doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
-		all, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.Equal(t, string(all), `{"key": "value"}`)
-		require.Equal(t, http.StatusOK, r.StatusCode)
-	})
-
-	mbr.err.Store(errors.New("mock error"))
-	doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
-		_, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NotEqual(t, http.StatusOK, r.StatusCode)
-	})
+	for _, tt := range tests {
+		mbr.data.Store(string(tt.data))
+		doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
+			all, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, all)
+			require.Equal(t, http.StatusOK, r.StatusCode)
+		})
+	}
 }
 
 type mockBackendReader struct {
 	data atomic.String
-	err  atomic.Error
 }
 
-func (mbr *mockBackendReader) GetBackendMetrics() ([]byte, error) {
-	return []byte(mbr.data.Load()), mbr.err.Load()
+func (mbr *mockBackendReader) GetBackendMetrics() []byte {
+	return []byte(mbr.data.Load())
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -120,8 +120,8 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	// setup metrics reader
 	{
 		healthCheckCfg := config.NewDefaultHealthCheckConfig()
-		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), srv.infoSyncer, srv.infoSyncer, srv.httpCli, healthCheckCfg, srv.configManager)
-		if err = srv.metricsReader.Start(context.Background(), srv.etcdCli); err != nil {
+		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), srv.infoSyncer, srv.infoSyncer, srv.httpCli, srv.etcdCli, healthCheckCfg, srv.configManager)
+		if err = srv.metricsReader.Start(context.Background()); err != nil {
 			return
 		}
 	}
@@ -171,7 +171,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	}
 
 	// setup http & grpc
-	if srv.apiServer, err = api.NewServer(cfg.API, lg.Named("api"), srv.proxy.IsClosing, srv.namespaceManager, srv.configManager, srv.certManager, nil, handler, ready); err != nil {
+	if srv.apiServer, err = api.NewServer(cfg.API, lg.Named("api"), srv.proxy.IsClosing, srv.namespaceManager, srv.configManager, srv.certManager, srv.metricsReader, handler, ready); err != nil {
 		return
 	}
 

--- a/pkg/util/etcd/etcd_test.go
+++ b/pkg/util/etcd/etcd_test.go
@@ -6,6 +6,7 @@ package etcd
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/manager/cert"
@@ -27,9 +28,9 @@ func TestEtcdClient(t *testing.T) {
 
 	_, err = client.Put(context.Background(), "key", "value")
 	require.NoError(t, err)
-	resp, err := client.Get(context.Background(), "key")
+	kvs, err := GetKVs(context.Background(), client, "key", nil, 3*time.Second, 10*time.Millisecond, 3)
 	require.NoError(t, err)
-	require.Equal(t, "value", string(resp.Kvs[0].Value))
+	require.Equal(t, "value", string(kvs[0].Value))
 
 	require.NoError(t, client.Close())
 	server.Close()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #610 

Problem Summary:
There is some cross-az traffic if the metricreader owner reads from all TiDB when there are hundreds of TiDB in a multi-az cluster.

What is changed and how it works:
- Elect a zonal owner for each zone if the zone is set. Otherwise, elect a global owner to read all backends.
- Fix that the `BackendReader` is not set in `ApiServer`.
- Fix that the VIP is not excluded when getting self-IP.
- Extract `etcd.GetKVs` as a common function.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
