### PR TITLE
factor: check the metric interval for CPU and memory-based balance 

### DIFF
--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -338,6 +338,14 @@ tidb_server_maxprocs 2
 			curValue:   1,
 			finalValue: model.SampleValue(math.NaN()),
 		},
+		{
+			text: `process_cpu_seconds_total 3
+tidb_server_maxprocs 2
+`,
+			timestamp:  model.Time(3500),
+			curValue:   1.5,
+			finalValue: model.SampleValue(math.NaN()),
+		},
 	}
 
 	historyPair := make([]model.SamplePair, 0)

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -204,9 +204,14 @@ func calcMemUsage(usageHistory []model.SamplePair) (latestUsage float64, timeToO
 			latestUsage = value
 			latestTime = usageHistory[i].Timestamp
 		} else {
-			diff := latestUsage - value
-			if diff > 0.0001 {
-				timeToOOM = time.Duration(float64(latestTime-usageHistory[i].Timestamp)*(oomMemoryUsage-latestUsage)/diff) * time.Millisecond
+			timeDiff := latestTime.Sub(usageHistory[i].Timestamp)
+			if timeDiff < 10*time.Second {
+				// Skip this one is the interval is too short.
+				continue
+			}
+			usageDiff := latestUsage - value
+			if usageDiff > 1e-4 {
+				timeToOOM = timeDiff * time.Duration((oomMemoryUsage-latestUsage)/usageDiff)
 			}
 			break
 		}

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -150,6 +150,14 @@ func createSampleStream(values []float64, backendIdx int, curTime model.Time) *m
 	return &model.SampleStream{Metric: labelSet, Values: pairs}
 }
 
+func createPairs(values []float64, ts []model.Time) []model.SamplePair {
+	pairs := make([]model.SamplePair, 0, len(values))
+	for i, value := range values {
+		pairs = append(pairs, model.SamplePair{Timestamp: ts[i], Value: model.SampleValue(value)})
+	}
+	return pairs
+}
+
 func createSample(value float64, backendIdx int) *model.Sample {
 	host := strconv.Itoa(backendIdx)
 	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(host + ":10080")}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #612 

Problem Summary:
Now that the metric may be collected from backends, the interval is not guaranteed. It may be too long or too short. If it's too short, the CPU usage or time to OOM may thrash.

What is changed and how it works:
- If the interval of CPU metric is shorter than 1s, do not calculate CPU usage from that metric.
- If the interval of memory metric is shorter than 1s, do not calculate time to OOM from that metric.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
