### PR TITLE
metrics, elect: Show the metrics reader owner on Grafana

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -36,9 +36,9 @@ import (
 
 const (
 	// readerOwnerKeyPrefix is the key prefix in etcd for backend reader owner election.
-	// For global owner, the key is "/tiproxy/metricreader/owner".
-	// For zonal owner, the key is "/tiproxy/metricreader/{zone}/owner".
-	readerOwnerKeyPrefix = "/tiproxy/metricreader"
+	// For global owner, the key is "/tiproxy/metric_reader/owner".
+	// For zonal owner, the key is "/tiproxy/metric_reader/{zone}/owner".
+	readerOwnerKeyPrefix = "/tiproxy/metric_reader"
 	readerOwnerKeySuffix = "owner"
 	// sessionTTL is the session's TTL in seconds for backend reader owner election.
 	sessionTTL = 30
@@ -225,9 +225,9 @@ func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []st
 
 		var zone string
 		if strings.HasPrefix(key, readerOwnerKeySuffix) {
-			// global owner key, such as "/tiproxy/metricreader/owner/leaseID"
+			// global owner key, such as "/tiproxy/metric_reader/owner/leaseID"
 		} else if endIdx := strings.Index(key, "/"); endIdx > 0 && strings.HasPrefix(key[endIdx+1:], readerOwnerKeySuffix) {
-			// zonal owner key, such as "/tiproxy/metricreader/east/owner/leaseID"
+			// zonal owner key, such as "/tiproxy/metric_reader/east/owner/leaseID"
 			zone = key[:endIdx]
 		} else {
 			continue

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/manager/elect"
-	"github.com/pingcap/tiproxy/pkg/metrics"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
@@ -82,7 +81,6 @@ func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error
 }
 
 func (vm *vipManager) OnElected() {
-	metrics.VIPGauge.Set(1)
 	hasIP, err := vm.operation.HasIP()
 	if err != nil {
 		vm.lg.Error("checking addresses failed", zap.Error(err))
@@ -104,7 +102,6 @@ func (vm *vipManager) OnElected() {
 }
 
 func (vm *vipManager) OnRetired() {
-	metrics.VIPGauge.Set(0)
 	hasIP, err := vm.operation.HasIP()
 	if err != nil {
 		vm.lg.Error("checking addresses failed", zap.Error(err))

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
-	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,14 +138,6 @@ func TestNetworkOperation(t *testing.T) {
 			return strings.Contains(text.String()[logIdx:], test.expectedLog)
 		}, 3*time.Second, 10*time.Millisecond, "case %d", i)
 		logIdx = len(text.String())
-
-		expectedVIPGauge := 0
-		if test.eventType == eventTypeElected {
-			expectedVIPGauge = 1
-		}
-		vipGauge, err := metrics.ReadGauge(metrics.VIPGauge)
-		require.NoError(t, err)
-		require.EqualValues(t, expectedVIPGauge, vipGauge, "case %d", i)
 	}
 	cancel()
 	vm.Close()

--- a/pkg/metrics/grafana/tiproxy_summary.json
+++ b/pkg/metrics/grafana/tiproxy_summary.json
@@ -667,7 +667,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_TEST-CLUSTER}",
-               "description": "1 indicates the VIP owner.",
+               "description": "The TiProxy owner of each job type.",
                "fill": 1,
                "fillGradient": 0,
                "gridPos": {
@@ -704,17 +704,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tiproxy_server_vip{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
+                     "expr": "tiproxy_server_owner{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$instance\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
+                     "legendFormat": "{{instance}} - {{type}}",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "VIP Owner",
+               "title": "Owner",
                "tooltip": {
                   "shared": true,
                   "sort": 0,

--- a/pkg/metrics/grafana/tiproxy_summary.jsonnet
+++ b/pkg/metrics/grafana/tiproxy_summary.jsonnet
@@ -209,17 +209,17 @@ local uptimeP = graphPanel.new(
   )
 );
 
-local vipP = graphPanel.new(
-  title='VIP Owner',
+local ownerP = graphPanel.new(
+  title='Owner',
   datasource=myDS,
   legend_rightSide=true,
-  description='1 indicates the VIP owner.',
+  description='The TiProxy owner of each job type.',
   format='short',
 )
 .addTarget(
   prometheus.target(
-    'tiproxy_server_vip{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}',
-    legendFormat='{{instance}}',
+    'tiproxy_server_owner{k8s_cluster="$k8s_cluster", tidb_cluster="$tidb_cluster", instance=~"$instance"}',
+    legendFormat='{{instance}} - {{type}}',
   )
 );
 
@@ -579,7 +579,7 @@ newDash
   .addPanel(createConnP, gridPos=leftPanelPos)
   .addPanel(disconnP, gridPos=rightPanelPos)
   .addPanel(goroutineP, gridPos=leftPanelPos)
-  .addPanel(vipP, gridPos=rightPanelPos)
+  .addPanel(ownerP, gridPos=rightPanelPos)
   ,
   gridPos=rowPos
 )

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -42,13 +42,13 @@ var (
 			Help:      "Number of disconnections.",
 		}, []string{LblType})
 
-	VIPGauge = prometheus.NewGauge(
+	OwnerGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: ModuleProxy,
 			Subsystem: LabelServer,
-			Name:      "vip",
-			Help:      "VIP owner.",
-		})
+			Name:      "owner",
+			Help:      "The TiProxy owner of each job type.",
+		}, []string{LblType})
 
 	MaxProcsGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #614 

Problem Summary:
Show the metrics reader owner on Grafana

What is changed and how it works:
- Change `VIPGauge` to `OwnerGauge` so that it's general
- Delete the metric when it's not the owner

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
