### PR TITLE
metricreader: fix that the metrics of CPU and health are not collected

### DIFF
--- a/lib/util/logger/logger.go
+++ b/lib/util/logger/logger.go
@@ -38,6 +38,6 @@ func CreateLoggerForTest(t *testing.T) (*zap.Logger, fmt.Stringer) {
 	return zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
 		zapcore.AddSync(log),
-		zap.InfoLevel,
+		zap.DebugLevel,
 	)).Named(t.Name()), log
 }

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -283,13 +283,13 @@ func (br *BackendReader) readFromBackends(ctx context.Context, excludeZones []st
 				}
 				resp, err := br.readBackendMetric(ctx, addr)
 				if err != nil {
-					br.lg.Error("read metrics from backend failed", zap.String("addr", addr), zap.Error(err))
+					br.lg.Debug("read metrics from backend failed", zap.String("addr", addr), zap.Error(err))
 					return
 				}
 				text := filterMetrics(hack.String(resp), allNames)
 				mf, err := parseMetrics(text)
 				if err != nil {
-					br.lg.Error("parse metrics failed", zap.String("addr", addr), zap.Error(err))
+					br.lg.Warn("parse metrics failed", zap.String("addr", addr), zap.Error(err))
 					return
 				}
 				br.metric2History(mf, addr)

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -362,10 +362,9 @@ func (br *BackendReader) metric2History(mfs map[string]*dto.MetricFamily, backen
 		// step 2: get the latest pair by the history and add it to step2History
 		// E.g. calculate irate(process_cpu_seconds_total/tidb_server_maxprocs[30s])
 		sampleValue = rule.Range2Value(beHistory.Step1History)
-		if math.IsNaN(float64(sampleValue)) {
-			continue
+		if !math.IsNaN(float64(sampleValue)) {
+			beHistory.Step2History = append(beHistory.Step2History, model.SamplePair{Timestamp: now, Value: sampleValue})
 		}
-		beHistory.Step2History = append(beHistory.Step2History, model.SamplePair{Timestamp: now, Value: sampleValue})
 		ruleHistory[backend] = beHistory
 	}
 }

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -87,7 +87,7 @@ func (vm *vipManager) OnElected() {
 		return
 	}
 	if hasIP {
-		vm.lg.Info("already has VIP, do nothing")
+		vm.lg.Debug("already has VIP, do nothing")
 		return
 	}
 	if err := vm.operation.AddIP(); err != nil {
@@ -108,7 +108,7 @@ func (vm *vipManager) OnRetired() {
 		return
 	}
 	if !hasIP {
-		vm.lg.Info("does not have VIP, do nothing")
+		vm.lg.Debug("does not have VIP, do nothing")
 		return
 	}
 	if err := vm.operation.DeleteIP(); err != nil {

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -43,12 +43,12 @@ func (no *networkOperation) initAddr(addressStr, linkStr string) error {
 	}
 	address, err := netlink.ParseAddr(addressStr)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrapf(errors.WithStack(err), "failed to parse address '%s'", addressStr)
 	}
 	no.address = address
 	link, err := netlink.LinkByName(linkStr)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrapf(errors.WithStack(err), "failed to find network interface '%s'", linkStr)
 	}
 	no.link = link
 	return nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #616 

Problem Summary:
If the value of `step2` is `NaN`, the value of `step1` is ignored either. But the next time `step2` relies on `Step1History` and `Step1History` is always empty.

What is changed and how it works:
- Write `Step1History` when `step1` is not `NaN`.
- Refine some error reporting.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
