### PR TITLE
backend, cli: fix vulnerability issues scanned by third-party tools

### DIFF
--- a/lib/cli/util.go
+++ b/lib/cli/util.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -39,8 +38,8 @@ func doRequest(ctx context.Context, bctx *Context, method string, url string, rd
 
 	var rete string
 	var res *http.Response
-	for _, i := range rand.Perm(len(bctx.CUrls)) {
-		req.URL.Host = bctx.CUrls[i]
+	for _, url := range bctx.CUrls {
+		req.URL.Host = url
 
 		res, err = bctx.Client.Do(req)
 		if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #620 

Problem Summary:
Third-party tools treat `math/rand` and `unsafe` as insecure packages.

What is changed and how it works:
- Replace `unsafe`
- Remove `math/rand`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
