### PR TITLE
elect: retire the owner after the etcd server recovers

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -119,9 +119,8 @@ func (br *BackendReader) initElection(ctx context.Context, cfg *config.Config) e
 	} else {
 		key = fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
 	}
-	election := elect.NewElection(br.lg, br.etcdCli, br.electionCfg, id, key, br)
-	br.election = election
-	election.Start(ctx)
+	br.election = elect.NewElection(br.lg.Named("elect"), br.etcdCli, br.electionCfg, id, key, br)
+	br.election.Start(ctx)
 	return nil
 }
 

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -75,6 +75,8 @@ func TestEtcdServerDown(t *testing.T) {
 	addr := ts.shutdownServer()
 	_, err := elec1.GetOwnerID(context.Background())
 	require.Error(t, err)
+	// the owner should not retire before the server is up again
+	ts.expectNoEvent("1")
 	ts.startServer(addr)
 	// the previous owner only retires when the new one is elected
 	ts.expectEvent("1", eventTypeRetired, eventTypeElected)
@@ -133,15 +135,15 @@ func TestOwnerMetric(t *testing.T) {
 	}
 
 	elec1 := NewElection(lg, nil, electionConfigForTest(1), "1", ownerKeyPrefix+"key"+ownerKeySuffix, newMockMember())
-	elec1.onElected(nil)
+	elec1.onElected()
 	checkMetric("key", true)
 
 	elec2 := NewElection(lg, nil, electionConfigForTest(1), "1", "key2/1", newMockMember())
-	elec2.onElected(nil)
+	elec2.onElected()
 	checkMetric("key2/1", true)
 
 	elec3 := NewElection(lg, nil, electionConfigForTest(1), "1", ownerKeyPrefix+"key3/1", newMockMember())
-	elec3.onElected(nil)
+	elec3.onElected()
 	checkMetric("key3/1", true)
 
 	elec1.onRetired()

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -51,6 +51,15 @@ func (mo *mockMember) expectEvent(t *testing.T, expected ...int) {
 	}
 }
 
+func (mo *mockMember) expectNoEvent(t *testing.T) {
+	select {
+	case <-time.After(100 * time.Millisecond):
+		return
+	case event := <-mo.ch:
+		require.Fail(t, "unexpected event", event)
+	}
+}
+
 func (mo *mockMember) hang(hang bool) {
 	contn := true
 	for contn {
@@ -144,7 +153,6 @@ func (ts *etcdTestSuite) getOwnerID() string {
 		} else {
 			require.Equal(ts.t, ownerID, id)
 		}
-		require.Equal(ts.t, elec.id == ownerID, elec.IsOwner())
 	}
 	return ownerID
 }
@@ -152,6 +160,11 @@ func (ts *etcdTestSuite) getOwnerID() string {
 func (ts *etcdTestSuite) expectEvent(id string, event ...int) {
 	elec := ts.getElection(id)
 	elec.member.(*mockMember).expectEvent(ts.t, event...)
+}
+
+func (ts *etcdTestSuite) expectNoEvent(id string) {
+	elec := ts.getElection(id)
+	elec.member.(*mockMember).expectNoEvent(ts.t)
 }
 
 func (ts *etcdTestSuite) hang(id string, hang bool) {

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -71,15 +71,7 @@ func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error
 
 	id := net.JoinHostPort(ip, port)
 	electionCfg := elect.DefaultElectionConfig(sessionTTL)
-	election := elect.NewElection(vm.lg, etcdCli, electionCfg, id, vipKey, vm)
-	vm.election = election
-	// Check the ownership at startup just in case the node is just down and restarted.
-	// Before it was down, it may be either the owner or not.
-	if election.IsOwner() {
-		vm.OnElected()
-	} else {
-		vm.OnRetired()
-	}
+	vm.election = elect.NewElection(vm.lg.Named("elect"), etcdCli, electionCfg, id, vipKey, vm)
 	vm.election.Start(ctx)
 	return nil
 }

--- a/pkg/manager/vip/mock_test.go
+++ b/pkg/manager/vip/mock_test.go
@@ -57,10 +57,6 @@ func (me *mockElection) GetOwnerID(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (me *mockElection) IsOwner() bool {
-	return true
-}
-
 func (me *mockElection) Start(ctx context.Context) {
 	me.wg.Run(func() {
 		for {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #626 

Problem Summary:
If the owner retires when the etcd server can not be connected, there may be a long failover when the etcd server is down.

What is changed and how it works:
- Retire the owner after the etcd server recovers. Before that, the previous owner still works as the owner.
- Fix the key for `watchOwner`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
