### PR TITLE
Allow adding VIP if the user has sudo permission

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,10 @@ issues:
       linters:
         - gosec
       text: "G101:"
+    - path: pkg/util/cmd/cmd.go
+      linters:
+        - gosec
+      text: "G204:"
 
 linters:
   enable:

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -87,5 +87,9 @@ func (no *networkOperation) DeleteIP() error {
 }
 
 func (no *networkOperation) SendARP() error {
-	return arping.GratuitousArpOverIfaceByName(no.address.IP, no.link.Attrs().Name)
+	err := arping.GratuitousArpOverIfaceByName(no.address.IP, no.link.Attrs().Name)
+	if err != nil && errors.Is(err, syscall.EPERM) {
+		err = exec.Command("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.String()).Run()
+	}
+	return errors.WithStack(err)
 }

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -6,7 +6,7 @@ package vip
 import (
 	"os/exec"
 	"runtime"
-	"strings"
+	"syscall"
 
 	"github.com/j-keck/arping"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -72,7 +72,7 @@ func (no *networkOperation) HasIP() (bool, error) {
 func (no *networkOperation) AddIP() error {
 	err := netlink.AddrAdd(no.link, no.address)
 	// If TiProxy is deployed by TiUP, the user that runs TiProxy only has the sudo permission.
-	if err != nil && strings.Contains(err.Error(), "Operation not permitted") {
+	if err != nil && errors.Is(err, syscall.EPERM) {
 		err = exec.Command("sudo", "ip", "addr", "add", no.address.String(), "dev", no.link.Attrs().Name).Run()
 	}
 	return errors.WithStack(err)
@@ -80,7 +80,7 @@ func (no *networkOperation) AddIP() error {
 
 func (no *networkOperation) DeleteIP() error {
 	err := netlink.AddrDel(no.link, no.address)
-	if err != nil && strings.Contains(err.Error(), "Operation not permitted") {
+	if err != nil && errors.Is(err, syscall.EPERM) {
 		err = exec.Command("sudo", "ip", "addr", "del", no.address.String(), "dev", no.link.Attrs().Name).Run()
 	}
 	return errors.WithStack(err)

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -4,7 +4,9 @@
 package vip
 
 import (
+	"os/exec"
 	"runtime"
+	"strings"
 
 	"github.com/j-keck/arping"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -68,11 +70,20 @@ func (no *networkOperation) HasIP() (bool, error) {
 }
 
 func (no *networkOperation) AddIP() error {
-	return netlink.AddrAdd(no.link, no.address)
+	err := netlink.AddrAdd(no.link, no.address)
+	// If TiProxy is deployed by TiUP, the user that runs TiProxy only has the sudo permission.
+	if err != nil && strings.Contains(err.Error(), "Operation not permitted") {
+		err = exec.Command("sudo", "ip", "addr", "add", no.address.String(), "dev", no.link.Attrs().Name).Run()
+	}
+	return errors.WithStack(err)
 }
 
 func (no *networkOperation) DeleteIP() error {
-	return netlink.AddrDel(no.link, no.address)
+	err := netlink.AddrDel(no.link, no.address)
+	if err != nil && strings.Contains(err.Error(), "Operation not permitted") {
+		err = exec.Command("sudo", "ip", "addr", "del", no.address.String(), "dev", no.link.Attrs().Name).Run()
+	}
+	return errors.WithStack(err)
 }
 
 func (no *networkOperation) SendARP() error {

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -89,7 +89,7 @@ func (no *networkOperation) DeleteIP() error {
 func (no *networkOperation) SendARP() error {
 	err := arping.GratuitousArpOverIfaceByName(no.address.IP, no.link.Attrs().Name)
 	if err != nil && errors.Is(err, syscall.EPERM) {
-		err = exec.Command("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.String()).Run()
+		err = exec.Command("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.IP.String()).Run()
 	}
 	return errors.WithStack(err)
 }

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -4,12 +4,12 @@
 package vip
 
 import (
-	"os/exec"
 	"runtime"
 	"syscall"
 
 	"github.com/j-keck/arping"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/util/cmd"
 	"github.com/vishvananda/netlink"
 )
 
@@ -73,7 +73,7 @@ func (no *networkOperation) AddIP() error {
 	err := netlink.AddrAdd(no.link, no.address)
 	// If TiProxy is deployed by TiUP, the user that runs TiProxy only has the sudo permission.
 	if err != nil && errors.Is(err, syscall.EPERM) {
-		err = exec.Command("sudo", "ip", "addr", "add", no.address.String(), "dev", no.link.Attrs().Name).Run()
+		err = cmd.ExecCmd("sudo", "ip", "addr", "add", no.address.String(), "dev", no.link.Attrs().Name)
 	}
 	return errors.WithStack(err)
 }
@@ -81,7 +81,7 @@ func (no *networkOperation) AddIP() error {
 func (no *networkOperation) DeleteIP() error {
 	err := netlink.AddrDel(no.link, no.address)
 	if err != nil && errors.Is(err, syscall.EPERM) {
-		err = exec.Command("sudo", "ip", "addr", "del", no.address.String(), "dev", no.link.Attrs().Name).Run()
+		err = cmd.ExecCmd("sudo", "ip", "addr", "del", no.address.String(), "dev", no.link.Attrs().Name)
 	}
 	return errors.WithStack(err)
 }
@@ -89,7 +89,7 @@ func (no *networkOperation) DeleteIP() error {
 func (no *networkOperation) SendARP() error {
 	err := arping.GratuitousArpOverIfaceByName(no.address.IP, no.link.Attrs().Name)
 	if err != nil && errors.Is(err, syscall.EPERM) {
-		err = exec.Command("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.IP.String()).Run()
+		err = cmd.ExecCmd("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.IP.String())
 	}
 	return errors.WithStack(err)
 }

--- a/pkg/manager/vip/network_test.go
+++ b/pkg/manager/vip/network_test.go
@@ -53,8 +53,8 @@ func TestAddDelIP(t *testing.T) {
 		require.NotNil(t, operation, "case %d", i)
 
 		err = operation.AddIP()
-		// Maybe the privilege is not granted.
-		if err != nil && strings.Contains(err.Error(), "operation not permitted") {
+		// Maybe the command is not installed.
+		if err != nil && strings.Contains(err.Error(), "command not found") {
 			continue
 		}
 		if test.addErr != "" {
@@ -65,11 +65,13 @@ func TestAddDelIP(t *testing.T) {
 		}
 
 		err = operation.SendARP()
-		if test.sendErr != "" {
-			require.Error(t, err, "case %d", i)
-			require.Contains(t, err.Error(), test.sendErr, "case %d", i)
-		} else {
-			require.NoError(t, err, "case %d", i)
+		if err == nil || !strings.Contains(err.Error(), "command not found") {
+			if test.sendErr != "" {
+				require.Error(t, err, "case %d", i)
+				require.Contains(t, err.Error(), test.sendErr, "case %d", i)
+			} else {
+				require.NoError(t, err, "case %d", i)
+			}
 		}
 
 		if err := operation.DeleteIP(); test.delErr != "" {

--- a/pkg/util/cmd/cmd.go
+++ b/pkg/util/cmd/cmd.go
@@ -1,0 +1,46 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+)
+
+// ExecCmd executes commands with checking potential tainted input.
+func ExecCmd(cmd string, args ...string) error {
+	cmds := make([]string, 0, len(args)+1)
+	if !isValidArg(cmd) {
+		return errors.Errorf("invalid cmd: %s", cmd)
+	}
+	cmds = append(cmds, cmd)
+	for _, arg := range args {
+		if !isValidArg(arg) {
+			return errors.Errorf("invalid argument: %s", arg)
+		}
+		cmds = append(cmds, escapeArg(arg))
+	}
+	output, err := exec.Command(cmds[0], cmds[1:]...).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(errors.WithStack(err), "output: %s", string(output))
+	}
+	return nil
+}
+
+func isValidArg(arg string) bool {
+	dangerousChars := []string{";", "&", "|", "`", "$(", "${", "<", ">", ">>"}
+	for _, char := range dangerousChars {
+		if strings.Contains(arg, char) {
+			return false
+		}
+	}
+	return true
+}
+
+func escapeArg(arg string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "'\\''"))
+}

--- a/pkg/util/cmd/cmd_test.go
+++ b/pkg/util/cmd/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCmd(t *testing.T) {
+	tests := []struct {
+		cmds   []string
+		hasErr bool
+	}{
+		{
+			cmds:   []string{"echo", "$(whoami)"},
+			hasErr: true,
+		},
+		{
+			cmds: []string{"echo", "abc"},
+		},
+		{
+			cmds:   []string{"hello"},
+			hasErr: true,
+		},
+	}
+
+	for i, test := range tests {
+		err := ExecCmd(test.cmds[0], test.cmds[1:]...)
+		require.Equal(t, test.hasErr, err != nil, "case %d", i)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #628 

Problem Summary:
If TiProxy is deployed by TiUP, the user typically only has the sudo permission and can't add VIP.

What is changed and how it works:
Try to execute `ip addr add`, `ip addr del`, and `arping -U` with `sudo` if the permission is denied.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Create a user with sudo permission and run TiProxy. It adds VIP successfully.
2. Create a user without sudo permission and it fails to add VIP.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
