### PR TITLE
cmd: remove quotes for command arguments

### DIFF
--- a/pkg/manager/vip/network_test.go
+++ b/pkg/manager/vip/network_test.go
@@ -42,6 +42,10 @@ func TestAddDelIP(t *testing.T) {
 		},
 	}
 
+	isOtherErr := func(err error) bool {
+		return strings.Contains(err.Error(), "command not found") || strings.Contains(err.Error(), "not in the sudoers file")
+	}
+
 	for i, test := range tests {
 		operation, err := NewNetworkOperation(test.virtualIP, test.link)
 		if test.initErr != "" {
@@ -54,7 +58,7 @@ func TestAddDelIP(t *testing.T) {
 
 		err = operation.AddIP()
 		// Maybe the command is not installed.
-		if err != nil && strings.Contains(err.Error(), "command not found") {
+		if err != nil && isOtherErr(err) {
 			continue
 		}
 		if test.addErr != "" {
@@ -65,7 +69,7 @@ func TestAddDelIP(t *testing.T) {
 		}
 
 		err = operation.SendARP()
-		if err == nil || !strings.Contains(err.Error(), "command not found") {
+		if err == nil || !isOtherErr(err) {
 			if test.sendErr != "" {
 				require.Error(t, err, "case %d", i)
 				require.Contains(t, err.Error(), test.sendErr, "case %d", i)

--- a/pkg/util/cmd/cmd.go
+++ b/pkg/util/cmd/cmd.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -22,7 +21,7 @@ func ExecCmd(cmd string, args ...string) error {
 		if !isValidArg(arg) {
 			return errors.Errorf("invalid argument: %s", arg)
 		}
-		cmds = append(cmds, escapeArg(arg))
+		cmds = append(cmds, arg)
 	}
 	output, err := exec.Command(cmds[0], cmds[1:]...).CombinedOutput()
 	if err != nil {
@@ -39,8 +38,4 @@ func isValidArg(arg string) bool {
 		}
 	}
 	return true
-}
-
-func escapeArg(arg string) string {
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(arg, "'", "'\\''"))
 }

--- a/pkg/util/cmd/cmd_test.go
+++ b/pkg/util/cmd/cmd_test.go
@@ -22,6 +22,9 @@ func TestExecCmd(t *testing.T) {
 			cmds: []string{"echo", "abc"},
 		},
 		{
+			cmds: []string{"cd", "."},
+		},
+		{
 			cmds:   []string{"hello"},
 			hasErr: true,
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #628 

Problem Summary:
Although `"ip" "addr" "add" ...` works on the command line, it fails on `exec.Command(...)`.

What is changed and how it works:
Remove quotes for command arguments.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Run TiProxy with a non-root user and check if the ip is bound.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
