### PR TITLE
*: retire after a new owner is elected

### DIFF
--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -120,6 +120,9 @@ func (mmr *mockMetricsReader) GetBackendMetrics() []byte {
 	return nil
 }
 
+func (mmr *mockMetricsReader) PreClose() {
+}
+
 func (mmr *mockMetricsReader) Close() {
 }
 

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -548,9 +548,19 @@ func (br *BackendReader) getBackendAddrs(ctx context.Context, excludeZones []str
 	return addrs, nil
 }
 
+func (br *BackendReader) PreClose() {
+	if br.election != nil {
+		br.election.Close()
+		br.election = nil
+	}
+	// pretend to be not owner
+	br.isOwner.Store(false)
+}
+
 func (br *BackendReader) Close() {
 	if br.election != nil {
 		br.election.Close()
+		br.election = nil
 	}
 }
 

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -551,7 +551,6 @@ func (br *BackendReader) getBackendAddrs(ctx context.Context, excludeZones []str
 func (br *BackendReader) PreClose() {
 	if br.election != nil {
 		br.election.Close()
-		br.election = nil
 	}
 	// pretend to be not owner
 	br.isOwner.Store(false)
@@ -560,7 +559,6 @@ func (br *BackendReader) PreClose() {
 func (br *BackendReader) Close() {
 	if br.election != nil {
 		br.election.Close()
-		br.election = nil
 	}
 }
 

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -38,6 +38,7 @@ type MetricsReader interface {
 	RemoveQueryExpr(key string)
 	GetQueryResult(key string) QueryResult
 	GetBackendMetrics() []byte
+	PreClose()
 	Close()
 }
 
@@ -143,6 +144,12 @@ func (dmr *DefaultMetricsReader) GetQueryResult(key string) QueryResult {
 
 func (dmr *DefaultMetricsReader) GetBackendMetrics() []byte {
 	return dmr.backendReader.GetBackendMetrics()
+}
+
+func (dmr *DefaultMetricsReader) PreClose() {
+	if dmr.backendReader != nil {
+		dmr.backendReader.PreClose()
+	}
 }
 
 func (dmr *DefaultMetricsReader) Close() {

--- a/pkg/balance/metricsreader/metrics_reader_test.go
+++ b/pkg/balance/metricsreader/metrics_reader_test.go
@@ -82,4 +82,6 @@ func TestFallback(t *testing.T) {
 	require.False(t, qr.Empty())
 	require.Equal(t, model.SampleValue(80.0), qr.Value.(model.Vector)[0].Value)
 	require.GreaterOrEqual(t, qr.UpdateTime, ts)
+
+	mr.PreClose()
 }

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -178,6 +178,9 @@ func (m *election) campaignLoop(ctx context.Context) {
 
 		if !m.isOwner {
 			m.onElected()
+		} else {
+			// It was the owner before the etcd failure and now is still the owner.
+			m.lg.Info("still the owner")
 		}
 		m.watchOwner(ctx, session, hack.String(kv.Key))
 	}

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestElectOwner(t *testing.T) {
-	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	ts := newEtcdTestSuite(t, "key")
 	t.Cleanup(ts.close)
 
 	// 2 nodes start and 1 node is the owner
@@ -23,6 +23,8 @@ func TestElectOwner(t *testing.T) {
 		elec2 := ts.newElection("2")
 		elec1.Start(context.Background())
 		elec2.Start(context.Background())
+		require.Equal(t, "1", elec1.ID())
+		require.Equal(t, "2", elec2.ID())
 		ownerID := ts.getOwnerID()
 		ts.expectEvent(ownerID, eventTypeElected)
 	}
@@ -31,7 +33,7 @@ func TestElectOwner(t *testing.T) {
 		ownerID := ts.getOwnerID()
 		elec := ts.getElection(ownerID)
 		elec.Close()
-		ts.expectEvent(ownerID, eventTypeRetired)
+		ts.expectNoEvent(ownerID)
 		ownerID2 := ts.getOwnerID()
 		require.NotEqual(t, ownerID, ownerID2)
 		ts.expectEvent(ownerID2, eventTypeElected)
@@ -49,10 +51,11 @@ func TestElectOwner(t *testing.T) {
 	{
 		elec := ts.getElection("3")
 		elec.Close()
+		ts.expectNoEvent("3")
 		ownerID := ts.getOwnerID()
 		elec = ts.getElection(ownerID)
 		elec.Close()
-		ts.expectEvent(ownerID, eventTypeRetired)
+		ts.expectNoEvent(ownerID)
 		_, err := elec.GetOwnerID(context.Background())
 		require.Error(t, err)
 	}
@@ -64,7 +67,7 @@ func TestElectOwner(t *testing.T) {
 }
 
 func TestEtcdServerDown(t *testing.T) {
-	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	ts := newEtcdTestSuite(t, "key")
 	t.Cleanup(ts.close)
 
 	elec1 := ts.newElection("1")
@@ -78,8 +81,8 @@ func TestEtcdServerDown(t *testing.T) {
 	// the owner should not retire before the server is up again
 	ts.expectNoEvent("1")
 	ts.startServer(addr)
-	// the previous owner only retires when the new one is elected
-	ts.expectEvent("1", eventTypeRetired, eventTypeElected)
+	// the owner should not retire because there's no other member
+	ts.expectNoEvent("1")
 	ownerID := ts.getOwnerID()
 	require.Equal(t, "1", ownerID)
 
@@ -89,16 +92,22 @@ func TestEtcdServerDown(t *testing.T) {
 	require.Error(t, err)
 	elec2 := ts.newElection("2")
 	elec2.Start(context.Background())
+	// the owner should not retire before the server is up again
+	ts.expectNoEvent("1")
 
 	// start the server again and the elections recover
 	ts.startServer(addr)
 	ownerID = ts.getOwnerID()
-	ts.expectEvent("1", eventTypeRetired)
-	ts.expectEvent(ownerID, eventTypeElected)
+	if ownerID == "1" {
+		ts.expectNoEvent("1")
+	} else {
+		ts.expectEvent("1", eventTypeRetired)
+		ts.expectEvent(ownerID, eventTypeElected)
+	}
 }
 
 func TestOwnerHang(t *testing.T) {
-	ts := newEtcdTestSuite(t, electionConfigForTest(1), "key")
+	ts := newEtcdTestSuite(t, "key")
 	t.Cleanup(ts.close)
 
 	// make the owner hang at loop

--- a/pkg/manager/elect/mock_test.go
+++ b/pkg/manager/elect/mock_test.go
@@ -92,12 +92,12 @@ type etcdTestSuite struct {
 	kv      clientv3.KV
 }
 
-func newEtcdTestSuite(t *testing.T, elecCfg ElectionConfig, key string) *etcdTestSuite {
+func newEtcdTestSuite(t *testing.T, key string) *etcdTestSuite {
 	lg, _ := logger.CreateLoggerForTest(t)
 	ts := &etcdTestSuite{
 		t:       t,
 		lg:      lg,
-		elecCfg: elecCfg,
+		elecCfg: electionConfigForTest(1),
 		key:     key,
 	}
 
@@ -116,14 +116,8 @@ func newEtcdTestSuite(t *testing.T, elecCfg ElectionConfig, key string) *etcdTes
 }
 
 func (ts *etcdTestSuite) newElection(id string) *election {
-	cfg := ElectionConfig{
-		SessionTTL: 1,
-		Timeout:    100 * time.Millisecond,
-		RetryIntvl: 10 * time.Millisecond,
-		RetryCnt:   2,
-	}
 	member := newMockMember()
-	elec := NewElection(ts.lg, ts.client, cfg, id, ts.key, member)
+	elec := NewElection(ts.lg, ts.client, ts.elecCfg, id, ts.key, member)
 	ts.elecs = append(ts.elecs, elec)
 	return elec
 }
@@ -202,9 +196,11 @@ func (ts *etcdTestSuite) shutdownServer() string {
 
 func electionConfigForTest(ttl int) ElectionConfig {
 	return ElectionConfig{
-		SessionTTL: ttl,
-		Timeout:    100 * time.Millisecond,
-		RetryIntvl: 10 * time.Millisecond,
-		RetryCnt:   2,
+		SessionTTL:       ttl,
+		Timeout:          100 * time.Millisecond,
+		RetryIntvl:       10 * time.Millisecond,
+		QueryIntvl:       10 * time.Millisecond,
+		WaitBeforeRetire: 3 * time.Second,
+		RetryCnt:         2,
 	}
 }

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -127,7 +127,6 @@ func (vm *vipManager) delVIP() {
 func (vm *vipManager) PreClose() {
 	if vm.election != nil {
 		vm.election.Close()
-		vm.election = nil
 	}
 }
 
@@ -136,7 +135,6 @@ func (vm *vipManager) PreClose() {
 func (vm *vipManager) Close() {
 	if vm.election != nil {
 		vm.election.Close()
-		vm.election = nil
 	}
 	vm.delVIP()
 }

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -60,6 +60,9 @@ func NewVIPManager(lg *zap.Logger, cfgGetter config.ConfigGetter) (*vipManager, 
 }
 
 func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error {
+	// This node may have bound the VIP before last failure.
+	vm.delVIP()
+
 	cfg := vm.cfgGetter.GetConfig()
 	ip, port, _, err := cfg.GetIPPort()
 	if err != nil {

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -52,7 +52,7 @@ func TestVIPCfgError(t *testing.T) {
 
 	lg, _ := logger.CreateLoggerForTest(t)
 	for i, test := range tests {
-		cfgGetter := newMockConfigGetter(test.cfg)
+		cfgGetter := newMockConfigGetter(&config.Config{HA: test.cfg})
 		vm, err := NewVIPManager(lg, cfgGetter)
 		if test.hasErr {
 			require.Error(t, err, "case %d", i)
@@ -123,7 +123,7 @@ func TestNetworkOperation(t *testing.T) {
 	operation := newMockNetworkOperation()
 	vm := &vipManager{
 		lg:        lg,
-		cfgGetter: newMockConfigGetter(config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}),
+		cfgGetter: newMockConfigGetter(&config.Config{HA: config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}}),
 		operation: operation,
 	}
 	vm.election = newMockElection(ch, vm)
@@ -148,7 +148,11 @@ func TestNetworkOperation(t *testing.T) {
 
 func TestStartAndClose(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	vm, err := NewVIPManager(lg, newMockConfigGetter(config.HA{VirtualIP: "127.0.0.2/24", Interface: "lo"}))
+	vm, err := NewVIPManager(lg, newMockConfigGetter(&config.Config{
+		Proxy: config.ProxyServer{Addr: "0.0.0.0:6000"},
+		API:   config.API{Addr: "0.0.0.0:3080"},
+		HA:    config.HA{VirtualIP: "127.0.0.2/24", Interface: "lo"},
+	}))
 	if runtime.GOOS != "linux" {
 		require.Error(t, err)
 	} else {

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -5,12 +5,15 @@ package vip
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/manager/cert"
+	"github.com/pingcap/tiproxy/pkg/util/etcd"
 	"github.com/stretchr/testify/require"
 )
 
@@ -123,7 +126,6 @@ func TestNetworkOperation(t *testing.T) {
 		cfgGetter: newMockConfigGetter(config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}),
 		operation: operation,
 	}
-	vm.delOnRetire.Store(true)
 	vm.election = newMockElection(ch, vm)
 	childCtx, cancel := context.WithCancel(context.Background())
 	vm.election.Start(childCtx)
@@ -144,44 +146,30 @@ func TestNetworkOperation(t *testing.T) {
 	vm.Close()
 }
 
-func TestResign(t *testing.T) {
-	tests := []struct {
-		hasIP       bool
-		expectedLog string
-	}{
-		{
-			hasIP:       false,
-			expectedLog: "do nothing",
-		},
-		{
-			hasIP:       true,
-			expectedLog: "deleting VIP success",
-		},
-	}
-
-	for i, test := range tests {
-		lg, text := logger.CreateLoggerForTest(t)
-		operation := newMockNetworkOperation()
-		vm := &vipManager{
-			lg:        lg,
-			cfgGetter: newMockConfigGetter(config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}),
-			operation: operation,
+func TestStartAndClose(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	vm, err := NewVIPManager(lg, newMockConfigGetter(config.HA{VirtualIP: "127.0.0.2/24", Interface: "lo"}))
+	if runtime.GOOS != "linux" {
+		require.Error(t, err)
+	} else {
+		// Maybe interface doesn't exist or lack of permission.
+		if err != nil {
+			return
 		}
-		vm.delOnRetire.Store(true)
-		operation.hasIP.Store(test.hasIP)
+		server, err := etcd.CreateEtcdServer("0.0.0.0:0", t.TempDir(), lg)
+		require.NoError(t, err)
+		endpoint := server.Clients[0].Addr().String()
+		cfg := etcd.ConfigForEtcdTest(endpoint)
 
-		// resign doesn't delete vip
-		vm.Resign()
-		if test.hasIP {
-			vm.OnRetired()
-		}
-		time.Sleep(100 * time.Millisecond)
-		require.False(t, strings.Contains(text.String(), test.expectedLog), "case %d", i)
+		certMgr := cert.NewCertManager()
+		err = certMgr.Init(cfg, lg, nil)
+		require.NoError(t, err)
+		client, err := etcd.InitEtcdClient(lg, cfg, certMgr)
+		require.NoError(t, err)
 
-		// close deletes vip
+		err = vm.Start(context.Background(), client)
+		require.NoError(t, err)
+		vm.PreClose()
 		vm.Close()
-		require.Eventually(t, func() bool {
-			return strings.Contains(text.String(), test.expectedLog)
-		}, 3*time.Second, 10*time.Millisecond, "case %d", i)
 	}
 }

--- a/pkg/manager/vip/mock_test.go
+++ b/pkg/manager/vip/mock_test.go
@@ -19,9 +19,9 @@ type mockConfigGetter struct {
 	cfg *config.Config
 }
 
-func newMockConfigGetter(cfg config.HA) *mockConfigGetter {
+func newMockConfigGetter(cfg *config.Config) *mockConfigGetter {
 	return &mockConfigGetter{
-		cfg: &config.Config{HA: cfg},
+		cfg: cfg,
 	}
 }
 

--- a/pkg/server/api/backend_test.go
+++ b/pkg/server/api/backend_test.go
@@ -31,7 +31,7 @@ func TestBackendMetrics(t *testing.T) {
 		},
 	}
 
-	server, doHTTP := createServer(t, nil)
+	server, doHTTP := createServer(t)
 	mbr := server.mgr.br.(*mockBackendReader)
 	for _, tt := range tests {
 		mbr.data.Store(string(tt.data))

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	_, doHTTP := createServer(t, nil)
+	_, doHTTP := createServer(t)
 
 	doHTTP(t, http.MethodGet, "/api/admin/config", nil, nil, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
@@ -65,7 +65,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestAcceptType(t *testing.T) {
-	_, doHTTP := createServer(t, nil)
+	_, doHTTP := createServer(t)
 	checkRespContentType := func(expectedType string, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 		data, err := io.ReadAll(r.Body)

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -13,7 +13,7 @@ import (
 
 func (h *Server) DebugHealth(c *gin.Context) {
 	status := http.StatusOK
-	if h.isClosing() {
+	if h.isClosing.Load() {
 		status = http.StatusBadGateway
 	}
 	c.JSON(status, config.HealthInfo{

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -11,17 +11,7 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	closing := true
-	_, doHTTP := createServer(t, &closing)
-
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusBadGateway, r.StatusCode)
-	})
-
-	closing = false
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusOK, r.StatusCode)
-	})
+	server, doHTTP := createServer(t)
 
 	doHTTP(t, http.MethodPost, "/api/debug/redirect", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
@@ -32,5 +22,14 @@ func TestDebug(t *testing.T) {
 
 	doHTTP(t, http.MethodGet, "/api/debug/pprof", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+
+	server.PreClose()
+	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 	})
 }

--- a/pkg/server/api/metrics_test.go
+++ b/pkg/server/api/metrics_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	_, doHTTP := createServer(t, nil)
+	_, doHTTP := createServer(t)
 
 	doHTTP(t, http.MethodGet, "/api/metrics", nil, nil, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)

--- a/pkg/server/api/namespace_test.go
+++ b/pkg/server/api/namespace_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNamespace(t *testing.T) {
-	_, doHTTP := createServer(t, nil)
+	_, doHTTP := createServer(t)
 
 	// test list
 	doHTTP(t, http.MethodGet, "/api/admin/namespace", nil, nil, func(t *testing.T, r *http.Response) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -219,9 +219,7 @@ func (s *Server) preClose() {
 	}
 	// Gracefully drain clients.
 	if s.proxy != nil {
-		var wg waitgroup.WaitGroup
-		wg.RunWithRecover(s.proxy.PreClose, nil, nil)
-		wg.Wait()
+		s.proxy.PreClose()
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #631 

Problem Summary:
When PD restarts, although TiProxy retires the VIP after the etcd server is back, it still takes several seconds before the owner is elected, which causes a long failover time.

What is changed and how it works:
- `election` only retires when a new owner is elected.
- `election.Close()` doesn't retire, it only resigns the owner. The callers `BackendReader` and `VIPManager` decide when to retire.
- Update the graceful shutdown procedure. `Server` calls `BackendReader.PreClose()`, `VIPManager.PreClose()`, `APIServer.PreClose()`, and `SQLServer.PreClose()` before real shutdown so that elections have enough time to wait for the new owner.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
