### PR TITLE
metricreader: fix backend label value doesn't match Prometheus in k8s

### DIFF
--- a/pkg/balance/metricsreader/query_result.go
+++ b/pkg/balance/metricsreader/query_result.go
@@ -125,3 +125,13 @@ func getLabel4Backend(backend policy.BackendCtx) string {
 	backendInfo := backend.GetBackendInfo()
 	return net.JoinHostPort(backendInfo.IP, strconv.Itoa(int(backendInfo.StatusPort)))
 }
+
+// addr is the address of the backend status port.
+func getLabel4Addr(addr string) string {
+	if strings.Contains(addr, ".svc:") {
+		// In operator deployment, the label value of `instance` is the pod name.
+		return addr[:strings.Index(addr, ".")]
+	}
+	// In tiup deployment, the label value of `instance` is hostname:statusPort.
+	return addr
+}

--- a/pkg/balance/metricsreader/query_result_test.go
+++ b/pkg/balance/metricsreader/query_result_test.go
@@ -174,3 +174,23 @@ func TestVectorMatchLabel(t *testing.T) {
 		require.Equal(t, test.expectedSample.Value, sample.Value, "test index %d", i)
 	}
 }
+
+func TestAddrMatchLabel(t *testing.T) {
+	tests := []struct {
+		addr  string
+		label string
+	}{
+		{
+			addr:  "10.10.11.1:3080",
+			label: "10.10.11.1:3080",
+		},
+		{
+			addr:  "tc-tidb-0.tc-tidb-peer.ns.svc:3080",
+			label: "tc-tidb-0",
+		},
+	}
+
+	for i, test := range tests {
+		require.Equal(t, test.label, getLabel4Addr(test.addr), "test index %d", i)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #634 

Problem Summary:
The balance doesn't work because the backend label value doesn't match that in Prometheus.
- Current label name: `tc-tidb-0.tc-tidb-peer.ns.svc:3080`
- Prometheus label name: `tc-tidb-0`

What is changed and how it works:
Change the label name from backend address to the pod name.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test in k8s and the CPU is balanced.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
