### PR TITLE
elect, vip: fix incorrect metric_reader owner metrics

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -157,7 +157,6 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 	zone := cfg.GetLocation()
 	if zone != br.lastZone {
 		br.election.Close()
-		br.isOwner.Store(false)
 		if err := br.initElection(ctx, cfg); err != nil {
 			return err
 		}

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -157,6 +157,7 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 	zone := cfg.GetLocation()
 	if zone != br.lastZone {
 		br.election.Close()
+		br.isOwner.Store(false)
 		if err := br.initElection(ctx, cfg); err != nil {
 			return err
 		}
@@ -556,8 +557,6 @@ func (br *BackendReader) PreClose() {
 	if br.election != nil {
 		br.election.Close()
 	}
-	// pretend to be not owner
-	br.isOwner.Store(false)
 }
 
 func (br *BackendReader) Close() {

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -287,6 +287,7 @@ func (m *election) watchOwner(ctx context.Context, session *concurrency.Session,
 	}
 }
 
+// Close resigns and retires.
 func (m *election) Close() {
 	if m.cancel != nil {
 		m.cancel()

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -287,12 +287,13 @@ func (m *election) watchOwner(ctx context.Context, session *concurrency.Session,
 	}
 }
 
-// Close is typically called before graceful shutdown. It resigns but doesn't retire or wait for the new owner.
-// The caller has to decide if it should retire after graceful wait.
 func (m *election) Close() {
 	if m.cancel != nil {
 		m.cancel()
 		m.cancel = nil
 	}
 	m.wg.Wait()
+	if m.isOwner {
+		m.onRetired()
+	}
 }

--- a/pkg/manager/elect/election_test.go
+++ b/pkg/manager/elect/election_test.go
@@ -33,7 +33,7 @@ func TestElectOwner(t *testing.T) {
 		ownerID := ts.getOwnerID()
 		elec := ts.getElection(ownerID)
 		elec.Close()
-		ts.expectNoEvent(ownerID)
+		ts.expectEvent(ownerID, eventTypeRetired)
 		ownerID2 := ts.getOwnerID()
 		require.NotEqual(t, ownerID, ownerID2)
 		ts.expectEvent(ownerID2, eventTypeElected)
@@ -51,11 +51,10 @@ func TestElectOwner(t *testing.T) {
 	{
 		elec := ts.getElection("3")
 		elec.Close()
-		ts.expectNoEvent("3")
 		ownerID := ts.getOwnerID()
 		elec = ts.getElection(ownerID)
 		elec.Close()
-		ts.expectNoEvent(ownerID)
+		ts.expectEvent(ownerID, eventTypeRetired)
 		_, err := elec.GetOwnerID(context.Background())
 		require.Error(t, err)
 	}
@@ -159,4 +158,7 @@ func TestOwnerMetric(t *testing.T) {
 	checkMetric("key", false)
 	checkMetric("key2/1", true)
 	checkMetric("key3/1", true)
+
+	elec3.Close()
+	checkMetric("key3/1", false)
 }

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -126,6 +126,7 @@ func TestNetworkOperation(t *testing.T) {
 		cfgGetter: newMockConfigGetter(&config.Config{HA: config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}}),
 		operation: operation,
 	}
+	vm.delOnRetire.Store(true)
 	vm.election = newMockElection(ch, vm)
 	childCtx, cancel := context.WithCancel(context.Background())
 	vm.election.Start(childCtx)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #636 

Problem Summary:
When closing the election, the metric is not deleted, so both zonal and global owners are shown on Grafana.

What is changed and how it works:
- Revert `election.Close()` so that it calls `onRetire` before closing.
- `VIPManager` prevents deleting VIP in `PreClose()` proactively so that the VIP is not deleted before graceful shutdown.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
