### PR TITLE
metricreader: fix that sometimes the metric history is not purged

### DIFF
--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -892,6 +892,7 @@ func TestQueryBackendConcurrently(t *testing.T) {
 	// fill the initial query result to ensure the result is always non-empty
 	err := br.readFromBackends(childCtx, nil)
 	require.NoError(t, err)
+	br.history2QueryResult()
 	wg.Run(func() {
 		for childCtx.Err() == nil {
 			err := br.readFromBackends(childCtx, nil)
@@ -951,7 +952,7 @@ func TestQueryBackendConcurrently(t *testing.T) {
 		}
 	})
 
-	// start a goroutine to marshal history
+	// start a goroutine to query marshalled history
 	wg.Run(func() {
 		for childCtx.Err() == nil {
 			select {

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -890,12 +890,12 @@ func TestQueryBackendConcurrently(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	childCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	// fill the initial query result to ensure the result is always non-empty
-	err := br.readFromBackends(childCtx, nil)
+	_, err := br.readFromBackends(childCtx, nil)
 	require.NoError(t, err)
 	br.history2QueryResult()
 	wg.Run(func() {
 		for childCtx.Err() == nil {
-			err := br.readFromBackends(childCtx, nil)
+			_, err := br.readFromBackends(childCtx, nil)
 			require.NoError(t, err)
 			br.purgeHistory()
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #638 

Problem Summary:
- When multiple TiProxy read the metrics of the same TiDB, the history may grow longer and longer. This is because the history that is read from the other TiProxy overwrites the local history that is purged.
- When the owner can connect to Prometheus but a member fails to connect to Prometheus, the member reads stale metrics.

What is changed and how it works:
- Extract `marshalHistory` and `history2QueryResult` to the common path.
- Call `marshalHistory` and `history2QueryResult` after `purgeHistory`
- Call `readFromBackends` before `readFromOwner`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test:
Follow the steps described in the issue and check the data from `/api/backend/metrics`

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
