### PR TITLE
sqlreplay, backend: Support capturing commands, connection ID, and start time

### DIFF
--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
 	"go.uber.org/zap"
 )
 
@@ -24,8 +25,8 @@ type ClientConnection struct {
 }
 
 func NewClientConnection(logger *zap.Logger, conn net.Conn, frontendTLSConfig *tls.Config, backendTLSConfig *tls.Config,
-	hsHandler backend.HandshakeHandler, connID uint64, addr string, bcConfig *backend.BCConfig) *ClientConnection {
-	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, connID, bcConfig)
+	hsHandler backend.HandshakeHandler, cpt capture.Capture, connID uint64, addr string, bcConfig *backend.BCConfig) *ClientConnection {
+	bemgr := backend.NewBackendConnManager(logger.Named("be"), hsHandler, cpt, connID, bcConfig)
 	bemgr.SetValue(backend.ConnContextKeyConnAddr, addr)
 	opts := make([]pnet.PacketIOption, 0, 2)
 	opts = append(opts, pnet.WithWrapError(backend.ErrClientConn))

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -102,7 +102,7 @@ func TestGracefulCloseConn(t *testing.T) {
 		}()
 		conn, err := server.listeners[0].Accept()
 		require.NoError(t, err)
-		clientConn := client.NewClientConnection(lg, conn, nil, nil, hsHandler, 0, "", &backend.BCConfig{})
+		clientConn := client.NewClientConnection(lg, conn, nil, nil, hsHandler, nil, 0, "", &backend.BCConfig{})
 		server.mu.clients[1] = clientConn
 		server.mu.Unlock()
 		return clientConn

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -1,0 +1,85 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"bytes"
+	"sync"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"go.uber.org/zap"
+)
+
+type Capture interface {
+	// Start starts the capture
+	Start(cfg CaptureConfig) error
+	// Stop stops the capture
+	Stop()
+	// Capture captures traffic
+	Capture(packet []byte, startTime time.Time, connID uint64)
+}
+
+type CaptureConfig struct {
+	outputDir string
+	duration  time.Duration
+}
+
+var _ Capture = (*capture)(nil)
+
+type capture struct {
+	sync.Mutex
+	cfg       CaptureConfig
+	startTime time.Time
+	endTime   time.Time
+	lg        *zap.Logger
+}
+
+func NewCapture(lg *zap.Logger) *capture {
+	return &capture{
+		lg: lg,
+	}
+}
+
+func (c *capture) Start(cfg CaptureConfig) error {
+	c.Lock()
+	defer c.Unlock()
+	if !c.startTime.IsZero() {
+		return errors.Errorf("capture already started, start time: %s", c.startTime.String())
+	}
+
+	c.cfg = cfg
+	c.startTime = time.Now()
+	c.endTime = c.startTime.Add(c.cfg.duration)
+	return nil
+}
+
+func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64) {
+	c.Lock()
+	if startTime.After(c.endTime) {
+		c.Unlock()
+		return
+	}
+	c.Unlock()
+
+	// TODO: capture asynchronously
+	command := cmd.NewCommand(packet, startTime, connID)
+	if command == nil {
+		return
+	}
+	// TODO: handle QUIT
+	var buf bytes.Buffer
+	if err := command.Encode(&buf); err != nil {
+		return
+	}
+	// TODO: output to file
+}
+
+func (c *capture) Stop() {
+	c.Lock()
+	defer c.Unlock()
+	c.startTime = time.Time{}
+	c.endTime = time.Time{}
+}

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -1,0 +1,23 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+)
+
+func TestStartAndStop(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	cpt := NewCapture(lg)
+	packet := append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...)
+	cpt.Capture(packet, time.Now(), 100)
+	cpt.Start(CaptureConfig{outputDir: "./", duration: 10 * time.Second})
+	cpt.Capture(packet, time.Now(), 100)
+	cpt.Stop()
+	cpt.Capture(packet, time.Now(), 100)
+}

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -1,0 +1,205 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/siddontang/go/hack"
+)
+
+const (
+	commonKeyPrefix = "# "
+	commonKeySuffix = ": "
+	keyStartTs      = "# Time: "
+	keyConnID       = "# Conn_ID: "
+	keyType         = "# Cmd_type: "
+	keySuccess      = "# Success: "
+	keyPayloadLen   = "# Payload_len: "
+)
+
+type LineReader interface {
+	ReadLine() ([]byte, error)
+	Read(n int) ([]byte, error)
+}
+
+type Command struct {
+	Payload  []byte
+	StartTs  time.Time
+	ConnID   uint64
+	Type     pnet.Command
+	Succeess bool
+}
+
+func NewCommand(packet []byte, startTs time.Time, connID uint64) *Command {
+	if len(packet) == 0 {
+		return nil
+	}
+	// TODO: handle load infile specially
+	return &Command{
+		Payload:  packet[1:],
+		StartTs:  startTs,
+		ConnID:   connID,
+		Type:     pnet.Command(packet[0]),
+		Succeess: true,
+	}
+}
+
+func (c *Command) Equal(that *Command) bool {
+	if that == nil {
+		return false
+	}
+	return c.StartTs.Equal(that.StartTs) &&
+		c.ConnID == that.ConnID &&
+		c.Type == that.Type &&
+		c.Succeess == that.Succeess &&
+		bytes.Equal(c.Payload, that.Payload)
+}
+
+func (c *Command) Validate() error {
+	if c.StartTs.IsZero() {
+		return errors.Errorf("no start time")
+	}
+	if c.ConnID == 0 {
+		return errors.Errorf("no connection id")
+	}
+	if c.Type == pnet.ComQuery && len(c.Payload) == 0 {
+		return errors.Errorf("no query")
+	}
+	return nil
+}
+
+func (c *Command) Encode(writer *bytes.Buffer) error {
+	var err error
+	if err = writeString(keyStartTs, c.StartTs.Format(time.RFC3339Nano), writer); err != nil {
+		return nil
+	}
+	if err = writeString(keyConnID, strconv.FormatUint(c.ConnID, 10), writer); err != nil {
+		return nil
+	}
+	if c.Type != pnet.ComQuery {
+		if err = writeByte(keyType, c.Type.Byte(), writer); err != nil {
+			return nil
+		}
+	}
+	if !c.Succeess {
+		if err = writeString(keySuccess, "false", writer); err != nil {
+			return nil
+		}
+	}
+	if err = writeString(keyPayloadLen, strconv.Itoa(len(c.Payload)), writer); err != nil {
+		return nil
+	}
+	// Unlike TiDB slow log, the payload is binary because StmtExecute can't be transformed to a SQL.
+	if len(c.Payload) > 0 {
+		if _, err = writer.Write(c.Payload); err != nil {
+			return err
+		}
+		if _, err = writer.WriteRune('\n'); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Command) Decode(reader LineReader) error {
+	var payloadLen int
+	c.Succeess = true
+	c.Type = pnet.ComQuery
+	for {
+		line, err := reader.ReadLine()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !strings.HasPrefix(hack.String(line), commonKeyPrefix) {
+			return errors.Errorf("line doesn't start with '%s': %s", commonKeyPrefix, line)
+		}
+		idx := strings.Index(hack.String(line), commonKeySuffix)
+		if idx < 0 {
+			return errors.Errorf("'%s' is not found in line: %s", commonKeySuffix, line)
+		}
+		idx += len(commonKeySuffix)
+		key := hack.String(line[:idx])
+		value := hack.String(line[idx:])
+		if len(value) == 0 {
+			return errors.Errorf("value is empty in line: %s", line)
+		}
+		switch key {
+		case keyStartTs:
+			if !c.StartTs.IsZero() {
+				return errors.Errorf("redundant Time: %s, Time was %v", line, c.StartTs)
+			}
+			c.StartTs, err = time.Parse(time.RFC3339Nano, value)
+			if err != nil {
+				return errors.Errorf("parsing Time failed: %s", line)
+			}
+		case keyConnID:
+			if c.ConnID > 0 {
+				return errors.Errorf("redundant Conn_ID: %s, Conn_ID was %d", line, c.ConnID)
+			}
+			c.ConnID, err = strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return errors.Errorf("parsing Conn_ID failed: %s", line)
+			}
+		case keyType:
+			if c.Type != pnet.ComQuery {
+				return errors.Errorf("redundant Cmd_type: %s, Cmd_type was %v", line, c.Type)
+			}
+			c.Type = pnet.Command(value[0])
+		case keySuccess:
+			c.Succeess = value == "true"
+		case keyPayloadLen:
+			payloadLen, err = strconv.Atoi(value)
+			if err != nil {
+				return errors.Errorf("parsing Payload_len failed: %s", line)
+			}
+			if payloadLen > 0 {
+				if c.Payload, err = reader.Read(payloadLen); err != nil {
+					return errors.WithStack(err)
+				}
+				// skip '\n'
+				if _, err = reader.Read(1); err != nil {
+					return errors.WithStack(err)
+				}
+			}
+			if err = c.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+}
+
+func writeString(key, value string, writer *bytes.Buffer) error {
+	var err error
+	if _, err = writer.WriteString(key); err != nil {
+		return err
+	}
+	if _, err = writer.WriteString(value); err != nil {
+		return err
+	}
+	if _, err = writer.WriteRune('\n'); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeByte(key string, value byte, writer *bytes.Buffer) error {
+	var err error
+	if _, err = writer.WriteString(key); err != nil {
+		return err
+	}
+	if err = writer.WriteByte(value); err != nil {
+		return err
+	}
+	if _, err = writer.WriteRune('\n'); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/sqlreplay/cmd/cmd_test.go
+++ b/pkg/sqlreplay/cmd/cmd_test.go
@@ -1,0 +1,125 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		payload []byte
+		cmd     pnet.Command
+	}{
+		{
+			cmd:     pnet.ComQuery,
+			payload: []byte("select 1"),
+		},
+		{
+			cmd:     pnet.ComStmtSendLongData,
+			payload: []byte{0x01, 0x02, 0x03},
+		},
+		{
+			cmd:     pnet.ComStmtSendLongData,
+			payload: []byte("1\n2\n3"),
+		},
+		{
+			cmd:     pnet.ComStmtExecute,
+			payload: []byte("1\n2\n"),
+		},
+		{
+			cmd: pnet.ComQuit,
+		},
+	}
+
+	var buf bytes.Buffer
+	cmds := make([]*Command, 0, len(tests))
+	for i, test := range tests {
+		packet := append([]byte{byte(test.cmd)}, test.payload...)
+		now := time.Now()
+		cmd := NewCommand(packet, now, 100)
+		require.NoError(t, cmd.Encode(&buf), "case %d", i)
+		cmds = append(cmds, cmd)
+	}
+
+	mr := mockReader{data: buf.Bytes()}
+	for i := range tests {
+		cmd := cmds[i]
+		newCmd := &Command{}
+		require.NoError(t, newCmd.Decode(&mr), "case %d, buf: %s", i, buf.String())
+		require.True(t, cmd.Equal(newCmd), "case %d, buf: %s", i, buf.String())
+	}
+}
+
+func TestDecodeError(t *testing.T) {
+	tests := []string{
+		`select 1`,
+		`select 1
+`,
+		`# Time:2024-08-28T18:51:20.477067+08:00
+`,
+		`# Time: 100
+# Conn_ID: 100
+# Payload_len: 8
+select 1`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: abc
+# Payload_len: 8
+select 1`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+# Type: abc
+# Payload_len: 8
+select 1`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+# Payload_len: 8
+select 1`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Payload_len: 8
+select 1
+`,
+		`# Conn_ID: 100
+# Payload_len: 8
+select 1
+`,
+		`# Conn_ID: 100
+# Payload_len: 100
+select 1
+`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+# Payload_len: 100
+select 1
+`,
+		`# Time: 
+# Conn_ID: 100
+# Payload_len: 8
+select 1
+`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+# Payload_len: 0
+`,
+		`# Time: 2024-08-28T18:51:20.477067+08:00
+# Conn_ID: 100
+# Payload_len: abc
+`,
+	}
+
+	for _, test := range tests {
+		mr := mockReader{data: []byte(test)}
+		cmd := &Command{}
+		require.Error(t, cmd.Decode(&mr), test)
+	}
+}

--- a/pkg/sqlreplay/cmd/mock_test.go
+++ b/pkg/sqlreplay/cmd/mock_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"io"
+	"slices"
+)
+
+type mockReader struct {
+	data   []byte
+	curIdx int
+}
+
+func (mr *mockReader) ReadLine() ([]byte, error) {
+	if mr.curIdx >= len(mr.data) {
+		return nil, io.EOF
+	}
+	idx := slices.Index(mr.data[mr.curIdx:], byte('\n'))
+	if idx == -1 {
+		return nil, io.EOF
+	}
+	idx += mr.curIdx
+	line := mr.data[mr.curIdx:idx]
+	mr.curIdx = idx + 1
+	return line, nil
+}
+
+func (mr *mockReader) Read(n int) ([]byte, error) {
+	if mr.curIdx+n > len(mr.data) {
+		return nil, io.EOF
+	}
+	line := mr.data[mr.curIdx : mr.curIdx+n]
+	mr.curIdx += n
+	return line, nil
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #645

Problem Summary:
Support capturing commands, connection ID, and start time

What is changed and how it works:
- Add `capture.Capture` to capture command, but do not output it now
- Capture commands in `BackendConnManager`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
