### PR TITLE
router: fix unstable test `TestControlSpeed`

### DIFF
--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -86,12 +86,20 @@ func TestFileRotation(t *testing.T) {
 	// files are rotated and compressed
 	require.Eventually(t, func() bool {
 		files := listFiles(t, tmpDir)
-		require.Equal(t, 2, len(files))
+		count := 0
+		compressed := false
 		for _, f := range files {
+			if strings.HasPrefix(f, "traffic") {
+				count++
+			}
 			if strings.HasSuffix(f, ".gz") {
-				return true
+				compressed = true
 			}
 		}
+		if count == 2 && compressed {
+			return true
+		}
+		t.Logf("traffic files: %v", files)
 		return false
 	}, 5*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #649 

Problem Summary:
If the machine is slow enough, the actual value exceeds the threshold.

What is changed and how it works:
- Adjust the threshold of `TestControlSpeed ` and add more logs.
- Check the file prefix of `TestFileRotation` and add more logs.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
