### PR TITLE
replay: manage connections in traffic replay

### DIFF
--- a/pkg/sqlreplay/replay/conn.go
+++ b/pkg/sqlreplay/replay/conn.go
@@ -1,0 +1,97 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"go.uber.org/zap"
+)
+
+type BackendConn interface {
+	Connect(ctx context.Context, clientIO pnet.PacketIO, frontendTLSConfig, backendTLSConfig *tls.Config, username, password string) error
+	Close() error
+}
+
+var _ BackendConn = (*backend.BackendConnManager)(nil)
+
+type Conn interface {
+	Run(ctx context.Context)
+	Close()
+}
+
+var _ Conn = (*conn)(nil)
+
+type conn struct {
+	username string
+	password string
+	wg       waitgroup.WaitGroup
+	cancel   context.CancelFunc
+	// cli2SrvCh: packets sent from client to server.
+	// The channel is closed when the peer is closed.
+	cli2SrvCh chan []byte
+	// srv2CliCh: packets sent from server to client.
+	srv2CliCh        chan []byte
+	cmdCh            <-chan *cmd.Command
+	exceptionCh      chan<- Exception
+	pkt              pnet.PacketIO
+	lg               *zap.Logger
+	backendTLSConfig *tls.Config
+	backendConn      BackendConn
+}
+
+func newConn(lg *zap.Logger, username, password string, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, connID uint64,
+	bcConfig *backend.BCConfig, cmdCh <-chan *cmd.Command, exceptionCh chan<- Exception) *conn {
+	cli2SrvCh, srv2CliCh := make(chan []byte, 1), make(chan []byte, 1)
+	return &conn{
+		username:         username,
+		password:         password,
+		lg:               lg,
+		backendTLSConfig: backendTLSConfig,
+		pkt:              newPacketIO(cli2SrvCh, srv2CliCh),
+		cli2SrvCh:        cli2SrvCh,
+		srv2CliCh:        srv2CliCh,
+		cmdCh:            cmdCh,
+		exceptionCh:      exceptionCh,
+		backendConn:      backend.NewBackendConnManager(lg.Named("be"), hsHandler, nil, connID, bcConfig),
+	}
+}
+
+func (c *conn) Run(ctx context.Context) {
+	childCtx, cancel := context.WithCancel(ctx)
+	c.wg.RunWithRecover(func() {
+		select {
+		case <-childCtx.Done():
+			return
+		case command := <-c.cmdCh:
+			c.executeCmd(childCtx, command)
+		}
+	}, nil, c.lg)
+	c.wg.RunWithRecover(func() {
+		if err := c.backendConn.Connect(childCtx, c.pkt, nil, c.backendTLSConfig, c.username, c.password); err != nil {
+			c.exceptionCh <- otherException{err: err}
+		}
+	}, nil, c.lg)
+	c.cancel = cancel
+}
+
+func (c *conn) executeCmd(ctx context.Context, command *cmd.Command) {
+}
+
+func (c *conn) Close() {
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+	c.wg.Wait()
+	if err := c.backendConn.Close(); err != nil {
+		c.lg.Warn("failed to close backend connection", zap.Error(err))
+	}
+	_ = c.pkt.Close()
+}

--- a/pkg/sqlreplay/replay/conn_test.go
+++ b/pkg/sqlreplay/replay/conn_test.go
@@ -1,0 +1,25 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnect(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	cmdCh, exceptionCh := make(chan *cmd.Command), make(chan Exception)
+	conn := newConn(lg, "u1", "", nil, nil, 100, &backend.BCConfig{}, cmdCh, exceptionCh)
+	conn.backendConn = &mockBackendConn{connErr: errors.New("mock error")}
+	conn.Run(context.Background())
+	require.NotNil(t, <-exceptionCh)
+	conn.Close()
+}

--- a/pkg/sqlreplay/replay/exception.go
+++ b/pkg/sqlreplay/replay/exception.go
@@ -1,0 +1,21 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+type Exception interface {
+	Critical() bool
+	String() string
+}
+
+type otherException struct {
+	err error
+}
+
+func (he otherException) Critical() bool {
+	return true
+}
+
+func (he otherException) String() string {
+	return he.err.Error()
+}

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"crypto/tls"
+
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+)
+
+var _ BackendConn = (*mockBackendConn)(nil)
+
+type mockBackendConn struct {
+	connErr error
+}
+
+func (c *mockBackendConn) Connect(ctx context.Context, clientIO pnet.PacketIO, frontendTLSConfig, backendTLSConfig *tls.Config, username, password string) error {
+	return c.connErr
+}
+
+func (c *mockBackendConn) Close() error {
+	return nil
+}
+
+var _ Conn = (*mockConn)(nil)
+
+type mockConn struct {
+	cmdCh       chan *cmd.Command
+	exceptionCh chan Exception
+	connID      uint64
+}
+
+func (c *mockConn) Run(ctx context.Context) {
+}
+
+func (c *mockConn) Close() {
+}

--- a/pkg/sqlreplay/replay/packetio.go
+++ b/pkg/sqlreplay/replay/packetio.go
@@ -1,0 +1,159 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/proxy/proxyprotocol"
+)
+
+var _ pnet.PacketIO = (*packetIO)(nil)
+
+type packetIO struct {
+	cli2SrvCh  <-chan []byte
+	srv2CliCh  chan<- []byte
+	srv2CliBuf bytes.Buffer
+}
+
+func newPacketIO(cli2SrvCh <-chan []byte, srv2CliCh chan<- []byte) *packetIO {
+	return &packetIO{
+		cli2SrvCh: cli2SrvCh,
+		srv2CliCh: srv2CliCh,
+	}
+}
+
+// ReadPacket implements net.PacketIO.
+func (p *packetIO) ReadPacket() (data []byte, err error) {
+	data = <-p.cli2SrvCh
+	return data, nil
+}
+
+// WritePacket implements net.PacketIO.
+func (p *packetIO) WritePacket(data []byte, flush bool) (err error) {
+	if _, err := p.srv2CliBuf.Write(data); err != nil {
+		return err
+	}
+	if flush {
+		return p.Flush()
+	}
+	return nil
+}
+
+// Flush implements net.PacketIO.
+func (p *packetIO) Flush() error {
+	p.srv2CliCh <- p.srv2CliBuf.Bytes()
+	p.srv2CliBuf.Reset()
+	return nil
+}
+
+// ForwardUntil implements net.PacketIO.
+// ForwardUntil won't be called on the client side, so no need to implement it.
+func (p *packetIO) ForwardUntil(dest pnet.PacketIO, isEnd func(firstByte byte, firstPktLen int) (end bool, needData bool), process func(response []byte) error) error {
+	panic("unimplemented")
+}
+
+// ClientTLSHandshake implements net.PacketIO.
+func (p *packetIO) ClientTLSHandshake(tlsConfig *tls.Config) error {
+	return nil
+}
+
+// Close implements net.PacketIO.
+func (p *packetIO) Close() error {
+	return nil
+}
+
+// EnableProxyClient implements net.PacketIO.
+func (p *packetIO) EnableProxyClient(proxy *proxyprotocol.Proxy) {
+}
+
+// EnableProxyServer implements net.PacketIO.
+func (p *packetIO) EnableProxyServer() {
+}
+
+// GetSequence implements net.PacketIO.
+func (p *packetIO) GetSequence() uint8 {
+	return 0
+}
+
+// GracefulClose implements net.PacketIO.
+func (p *packetIO) GracefulClose() error {
+	return nil
+}
+
+// InBytes implements net.PacketIO.
+func (p *packetIO) InBytes() uint64 {
+	return 0
+}
+
+// InPackets implements net.PacketIO.
+func (p *packetIO) InPackets() uint64 {
+	return 0
+}
+
+// IsPeerActive implements net.PacketIO.
+func (p *packetIO) IsPeerActive() bool {
+	return true
+}
+
+// LastKeepAlive implements net.PacketIO.
+func (p *packetIO) LastKeepAlive() config.KeepAlive {
+	return config.KeepAlive{}
+}
+
+// LocalAddr implements net.PacketIO.
+func (p *packetIO) LocalAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+// OutBytes implements net.PacketIO.
+func (p *packetIO) OutBytes() uint64 {
+	return 0
+}
+
+// OutPackets implements net.PacketIO.
+func (p *packetIO) OutPackets() uint64 {
+	return 0
+}
+
+// Proxy implements net.PacketIO.
+func (p *packetIO) Proxy() *proxyprotocol.Proxy {
+	return nil
+}
+
+// RemoteAddr implements net.PacketIO.
+func (p *packetIO) RemoteAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
+// ResetSequence implements net.PacketIO.
+func (p *packetIO) ResetSequence() {
+}
+
+// ServerTLSHandshake implements net.PacketIO.
+func (p *packetIO) ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionState, error) {
+	return tls.ConnectionState{}, nil
+}
+
+// SetCompressionAlgorithm implements net.PacketIO.
+func (p *packetIO) SetCompressionAlgorithm(algorithm pnet.CompressAlgorithm, zstdLevel int) error {
+	return nil
+}
+
+// SetKeepalive implements net.PacketIO.
+func (p *packetIO) SetKeepalive(cfg config.KeepAlive) error {
+	return nil
+}
+
+// TLSConnectionState implements net.PacketIO.
+func (p *packetIO) TLSConnectionState() tls.ConnectionState {
+	return tls.ConnectionState{}
+}
+
+func (p *packetIO) ApplyOpts(opts ...pnet.PacketIOption) {
+}

--- a/pkg/sqlreplay/replay/packetio_test.go
+++ b/pkg/sqlreplay/replay/packetio_test.go
@@ -1,0 +1,31 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPacketIO(t *testing.T) {
+	cli2SrvCh, srv2CliCh := make(chan []byte, 1), make(chan []byte, 1)
+	pkt := newPacketIO(cli2SrvCh, srv2CliCh)
+	defer pkt.Close()
+	// test read
+	cli2SrvCh <- []byte("hello")
+	data, err := pkt.ReadPacket()
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), data)
+	// test write
+	require.NoError(t, pkt.WritePacket([]byte("wor"), false))
+	require.NoError(t, pkt.WritePacket([]byte("ld"), true))
+	data = <-srv2CliCh
+	require.Equal(t, []byte("world"), data)
+	// test flush
+	require.NoError(t, pkt.WritePacket([]byte("hi"), false))
+	require.NoError(t, pkt.Flush())
+	data = <-srv2CliCh
+	require.Equal(t, []byte("hi"), data)
+}

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -1,0 +1,107 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"go.uber.org/zap"
+)
+
+type Replay interface {
+	// Start starts the replay
+	Start(cfg ReplayConfig) error
+	// Stop stops the replay
+	Stop(err error)
+	// Close closes the replay
+	Close()
+}
+
+type ReplayConfig struct {
+	Filename string
+	Username string
+	Password string
+}
+
+type connWrapper struct {
+	cmdCh       chan *cmd.Command
+	exceptionCh chan Exception
+	conn        Conn
+}
+
+type connCreator func(connID uint64, cmdCh chan *cmd.Command, exceptionCh chan Exception) Conn
+
+type replay struct {
+	cfg         ReplayConfig
+	conns       map[uint64]*connWrapper
+	connCreator connCreator
+	lg          *zap.Logger
+}
+
+func NewReplay(lg *zap.Logger, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) *replay {
+	r := &replay{
+		conns: make(map[uint64]*connWrapper),
+		lg:    lg,
+	}
+	r.connCreator = func(connID uint64, cmdCh chan *cmd.Command, exceptionCh chan Exception) Conn {
+		lg = r.lg.With(zap.Uint64("connID", connID))
+		return newConn(lg, r.cfg.Username, r.cfg.Password, backendTLSConfig, hsHandler, connID, bcConfig, cmdCh, exceptionCh)
+	}
+	return r
+}
+
+func (r *replay) Start(cfg ReplayConfig) error {
+	return nil
+}
+
+func (r *replay) executeCmd(ctx context.Context, command *cmd.Command) {
+	wrapper, ok := r.conns[command.ConnID]
+	if !ok {
+		cmdCh, exceptionCh := make(chan *cmd.Command, 1), make(chan Exception, 3)
+		wrapper = &connWrapper{
+			conn:        r.connCreator(command.ConnID, cmdCh, exceptionCh),
+			cmdCh:       cmdCh,
+			exceptionCh: exceptionCh,
+		}
+		r.conns[command.ConnID] = wrapper
+		wrapper.conn.Run(ctx)
+	}
+	if wrapper == nil {
+		return
+	}
+
+	// drain exceptions
+	drained := false
+	for !drained {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-wrapper.exceptionCh:
+			if e.Critical() {
+				// Keep the disconnected connections in the map to reject subsequent commands with the same connID,
+				// but release memory as much as possible.
+				wrapper.conn.Close()
+				r.conns[command.ConnID] = nil
+				return
+			}
+			// TODO: report the exception
+		default:
+			drained = true
+		}
+	}
+
+	select {
+	case wrapper.cmdCh <- command:
+	default: // avoid block due to bug
+	}
+}
+
+func (r *replay) Stop(err error) {
+}
+
+func (r *replay) Close() {
+}

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManageConns(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	replay := NewReplay(lg, nil, nil, nil)
+	defer replay.Close()
+	var conn *mockConn
+	replay.connCreator = func(connID uint64, cmdCh chan *cmd.Command, exceptionCh chan Exception) Conn {
+		conn = &mockConn{
+			cmdCh:       cmdCh,
+			exceptionCh: exceptionCh,
+			connID:      connID,
+		}
+		return conn
+	}
+	cmd := &cmd.Command{
+		ConnID: 1,
+		Type:   pnet.ComQuery,
+	}
+	replay.executeCmd(context.Background(), cmd)
+	wrapper, ok := replay.conns[1]
+	require.True(t, ok)
+	require.NotNil(t, wrapper)
+
+	cmd.ConnID = 2
+	replay.executeCmd(context.Background(), cmd)
+	wrapper, ok = replay.conns[2]
+	require.True(t, ok)
+	require.NotNil(t, wrapper)
+
+	conn.exceptionCh <- &otherException{err: errors.New("mock error")}
+	replay.executeCmd(context.Background(), cmd)
+	wrapper, ok = replay.conns[2]
+	require.True(t, ok)
+	require.Nil(t, wrapper)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #654 

Problem Summary:
Create a connection when a new connection ID appears and close the connection when there's an unexpected exception.

What is changed and how it works:
- `replay.executeCmd` creates a connection when a new connection ID appears and closes the connection when there's a critical error
- `conn` creates a `BackendConnManager` and passes data between `replay` and `packetIO`
- `packetIO` is a fake client IO, it puts written data into a channel and reads data from a channel

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
