### PR TITLE
store, capture: load and parse traffic files

### DIFF
--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -209,6 +209,10 @@ func (c *capture) stopNoLock(err error) {
 	}
 	c.startTime = time.Time{}
 	close(c.cmdCh)
+	if err := c.cmdLogger.Close(); err != nil {
+		c.lg.Warn("failed to close command logger", zap.Error(err))
+	}
+	c.cmdLogger = nil
 }
 
 func (c *capture) Stop(err error) {
@@ -220,8 +224,4 @@ func (c *capture) Stop(err error) {
 func (c *capture) Close() {
 	c.Stop(errors.New("shutting down"))
 	c.wg.Wait()
-	if err := c.cmdLogger.Close(); err != nil {
-		c.lg.Warn("failed to close command logger", zap.Error(err))
-	}
-	c.cmdLogger = nil
 }

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -20,15 +20,15 @@ import (
 func TestStartAndStop(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	cpt := NewCapture(lg)
-	writer := newMockWriter(store.WriterCfg{})
-	cpt.cmdLogger = writer
 	defer cpt.Close()
 
 	packet := append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...)
 	cpt.Capture(packet, time.Now(), 100)
+	writer := newMockWriter(store.WriterCfg{})
 	cfg := CaptureConfig{
-		Output:   t.TempDir(),
-		Duration: 10 * time.Second,
+		Output:    t.TempDir(),
+		Duration:  10 * time.Second,
+		cmdLogger: writer,
 	}
 
 	// start capture and the traffic should be outputted
@@ -62,15 +62,15 @@ func TestStartAndStop(t *testing.T) {
 func TestConcurrency(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	cpt := NewCapture(lg)
-	writer := newMockWriter(store.WriterCfg{})
-	cpt.cmdLogger = writer
 	defer cpt.Close()
 
+	writer := newMockWriter(store.WriterCfg{})
 	cfg := CaptureConfig{
 		Output:         t.TempDir(),
 		Duration:       10 * time.Second,
 		bufferCap:      12 * 1024,
 		flushThreshold: 8 * 1024,
+		cmdLogger:      writer,
 	}
 	var wg waitgroup.WaitGroup
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -4,53 +4,53 @@
 package capture
 
 import (
-	"bufio"
-	"compress/gzip"
 	"context"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/store"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStartAndStop(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	tmpDir := t.TempDir()
-	fileName := filepath.Join(tmpDir, "traffic.log")
 	cpt := NewCapture(lg)
+	writer := newMockWriter(store.WriterCfg{})
+	cpt.cmdLogger = writer
 	defer cpt.Close()
 
 	packet := append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...)
 	cpt.Capture(packet, time.Now(), 100)
-	cfg := CaptureConfig{Filename: fileName, Duration: 10 * time.Second}
+	cfg := CaptureConfig{
+		Output:   t.TempDir(),
+		Duration: 10 * time.Second,
+	}
 
 	// start capture and the traffic should be outputted
 	require.NoError(t, cpt.Start(cfg))
 	cpt.Capture(packet, time.Now(), 100)
 	cpt.Stop(nil)
 	cpt.wg.Wait()
-	fileSize := getFileSize(t, fileName)
-	require.Greater(t, fileSize, int64(0))
-	data := readFile(t, fileName)
+	data := writer.getData()
+	require.Greater(t, len(data), 0)
 	require.Contains(t, string(data), "select 1")
 
 	// stop capture and traffic should not be outputted
 	cpt.Capture(packet, time.Now(), 100)
 	cpt.wg.Wait()
-	require.Equal(t, fileSize, getFileSize(t, fileName))
+	require.Equal(t, len(data), len(writer.getData()))
 
 	// start capture again
 	require.NoError(t, cpt.Start(cfg))
 	cpt.Capture(packet, time.Now(), 100)
 	cpt.Stop(nil)
 	cpt.wg.Wait()
-	require.Greater(t, getFileSize(t, fileName), fileSize)
+	require.Greater(t, len(writer.getData()), len(data))
 
 	// duplicated start and stop
 	require.NoError(t, cpt.Start(cfg))
@@ -59,62 +59,16 @@ func TestStartAndStop(t *testing.T) {
 	cpt.Stop(nil)
 }
 
-func TestFileRotation(t *testing.T) {
-	lg, _ := logger.CreateLoggerForTest(t)
-	tmpDir := t.TempDir()
-	fileName := filepath.Join(tmpDir, "traffic.log")
-	cpt := NewCapture(lg)
-	defer cpt.Close()
-
-	packet := make([]byte, 100*1024)
-	packet[0] = pnet.ComQuery.Byte()
-	cfg := CaptureConfig{
-		Filename:       fileName,
-		Duration:       10 * time.Second,
-		fileSize:       1,
-		bufferCap:      120 * 1024,
-		flushThreshold: 80 * 1024,
-	}
-
-	require.NoError(t, cpt.Start(cfg))
-	for i := 0; i < 11; i++ {
-		cpt.Capture(packet, time.Now(), 100)
-	}
-	cpt.Stop(nil)
-	cpt.wg.Wait()
-
-	// files are rotated and compressed
-	require.Eventually(t, func() bool {
-		files := listFiles(t, tmpDir)
-		count := 0
-		compressed := false
-		for _, f := range files {
-			if strings.HasPrefix(f, "traffic") {
-				count++
-			}
-			if strings.HasSuffix(f, ".gz") {
-				compressed = true
-			}
-		}
-		if count == 2 && compressed {
-			return true
-		}
-		t.Logf("traffic files: %v", files)
-		return false
-	}, 5*time.Second, 10*time.Millisecond)
-}
-
 func TestConcurrency(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	tmpDir := t.TempDir()
-	fileName := filepath.Join(tmpDir, "traffic.log")
 	cpt := NewCapture(lg)
+	writer := newMockWriter(store.WriterCfg{})
+	cpt.cmdLogger = writer
 	defer cpt.Close()
 
 	cfg := CaptureConfig{
-		Filename:       fileName,
+		Output:         t.TempDir(),
 		Duration:       10 * time.Second,
-		fileSize:       1,
 		bufferCap:      12 * 1024,
 		flushThreshold: 8 * 1024,
 	}
@@ -151,60 +105,28 @@ func TestConcurrency(t *testing.T) {
 	wg.Wait()
 	cancel()
 
-	files := listFiles(t, tmpDir)
-	require.GreaterOrEqual(t, len(files), 1)
+	require.Greater(t, len(writer.getData()), 0)
 }
 
 func TestCaptureCfgError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "traffic.log")
+	require.NoError(t, os.WriteFile(path, []byte{}, 0666))
 	cfgs := []CaptureConfig{
 		{
 			Duration: 10 * time.Second,
 		},
 		{
-			Filename: "traffic.log",
+			Output: dir,
 		},
 		{
-			Filename: t.TempDir(),
+			Duration: 10 * time.Second,
+			Output:   path,
 		},
 	}
 
-	for _, cfg := range cfgs {
+	for i, cfg := range cfgs {
 		err := checkCaptureConfig(&cfg)
-		require.Error(t, err)
+		require.Error(t, err, "case %d", i)
 	}
-}
-
-func readFile(t *testing.T, fileName string) []byte {
-	file, err := os.Open(fileName)
-	require.NoError(t, err)
-
-	var reader *bufio.Reader
-	if strings.HasSuffix(fileName, ".gz") {
-		gr, err := gzip.NewReader(file)
-		require.NoError(t, err)
-		reader = bufio.NewReader(gr)
-	} else {
-		reader = bufio.NewReader(file)
-	}
-
-	p := make([]byte, 1024)
-	n, err := reader.Read(p)
-	require.NoError(t, err)
-	return p[:n]
-}
-
-func getFileSize(t *testing.T, fileName string) int64 {
-	file, err := os.Stat(fileName)
-	require.NoError(t, err)
-	return file.Size()
-}
-
-func listFiles(t *testing.T, dir string) []string {
-	files, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	var names []string
-	for _, f := range files {
-		names = append(names, f.Name())
-	}
-	return names
 }

--- a/pkg/sqlreplay/capture/mock_test.go
+++ b/pkg/sqlreplay/capture/mock_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/store"
+)
+
+var _ store.Writer = (*mockWriter)(nil)
+
+type mockWriter struct {
+	sync.Mutex
+	buf bytes.Buffer
+}
+
+func newMockWriter(store.WriterCfg) *mockWriter {
+	return &mockWriter{}
+}
+
+func (w *mockWriter) Write(p []byte) error {
+	w.Lock()
+	defer w.Unlock()
+	_, err := w.buf.Write(p)
+	return err
+}
+
+func (w *mockWriter) getData() []byte {
+	w.Lock()
+	defer w.Unlock()
+	return w.buf.Bytes()
+}
+
+func (w *mockWriter) Close() error {
+	return nil
+}

--- a/pkg/sqlreplay/cmd/mock_test.go
+++ b/pkg/sqlreplay/cmd/mock_test.go
@@ -13,25 +13,25 @@ type mockReader struct {
 	curIdx int
 }
 
-func (mr *mockReader) ReadLine() ([]byte, error) {
+func (mr *mockReader) ReadLine() ([]byte, string, int, error) {
 	if mr.curIdx >= len(mr.data) {
-		return nil, io.EOF
+		return nil, "", 0, io.EOF
 	}
 	idx := slices.Index(mr.data[mr.curIdx:], byte('\n'))
 	if idx == -1 {
-		return nil, io.EOF
+		return nil, "", 0, io.EOF
 	}
 	idx += mr.curIdx
 	line := mr.data[mr.curIdx:idx]
 	mr.curIdx = idx + 1
-	return line, nil
+	return line, "", 0, nil
 }
 
-func (mr *mockReader) Read(n int) ([]byte, error) {
+func (mr *mockReader) Read(n int) ([]byte, string, int, error) {
 	if mr.curIdx+n > len(mr.data) {
-		return nil, io.EOF
+		return nil, "", 0, io.EOF
 	}
 	line := mr.data[mr.curIdx : mr.curIdx+n]
 	mr.curIdx += n
-	return line, nil
+	return line, "", 0, nil
 }

--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -1,0 +1,13 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+const (
+	fileNamePrefix     = "traffic"
+	fileNameSuffix     = ".log"
+	fileName           = fileNamePrefix + fileNameSuffix
+	fileTsLayout       = "2006-01-02T15-04-05.000"
+	fileCompressFormat = ".gz"
+	fileSize           = 300 // 300MB
+)

--- a/pkg/sqlreplay/store/loader.go
+++ b/pkg/sqlreplay/store/loader.go
@@ -1,0 +1,191 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"bufio"
+	"compress/gzip"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"go.uber.org/zap"
+)
+
+type LoaderCfg struct {
+	Dir string
+}
+
+var _ cmd.LineReader = (*loader)(nil)
+
+type loader struct {
+	cfg LoaderCfg
+	// the time in the file name
+	curFileName string
+	curFileTs   int64
+	curLineIdx  int
+	reader      *bufio.Reader
+	lg          *zap.Logger
+}
+
+func NewLoader(lg *zap.Logger, cfg LoaderCfg) *loader {
+	return &loader{
+		cfg: cfg,
+		lg:  lg,
+	}
+}
+
+func (l *loader) Read(n int) ([]byte, string, int, error) {
+	if l.reader == nil {
+		if err := l.nextReader(); err != nil {
+			return nil, l.curFileName, l.curLineIdx, err
+		}
+	}
+
+	data := make([]byte, n)
+	for readLen := 0; readLen < n; {
+		m, err := l.reader.Read(data[readLen:])
+		if err != nil {
+			if err == io.EOF {
+				readLen += m
+				if err = l.nextReader(); err != nil {
+					return nil, l.curFileName, l.curLineIdx, err
+				}
+				continue
+			}
+			return nil, l.curFileName, l.curLineIdx, errors.WithStack(err)
+		}
+		readLen += m
+	}
+	curLineIdx := l.curLineIdx
+	for _, b := range data {
+		if b == '\n' {
+			l.curLineIdx++
+		}
+	}
+	return data, l.curFileName, curLineIdx, nil
+}
+
+func (l *loader) ReadLine() ([]byte, string, int, error) {
+	if l.reader == nil {
+		if err := l.nextReader(); err != nil {
+			return nil, l.curFileName, l.curLineIdx, err
+		}
+	}
+
+	isPrefix := true
+	var result, line []byte
+	var err error
+	for isPrefix {
+		if line, isPrefix, err = l.reader.ReadLine(); err != nil {
+			if err == io.EOF {
+				if err = l.nextReader(); err != nil {
+					return nil, l.curFileName, l.curLineIdx, err
+				}
+				isPrefix = true
+				continue
+			}
+			return nil, l.curFileName, l.curLineIdx, errors.WithStack(err)
+		}
+		// The returned line is a reference to the internal buffer of the reader, so copy it.
+		result = append(result, line...)
+	}
+	l.curLineIdx++
+	return result, l.curFileName, l.curLineIdx - 1, nil
+}
+
+func (l *loader) nextReader() error {
+	// has read the latest file
+	if l.curFileTs == math.MaxInt64 {
+		return io.EOF
+	}
+	files, err := os.ReadDir(l.cfg.Dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	var minFileTs int64
+	var minFileName string
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		name := file.Name()
+		if !strings.HasPrefix(name, fileNamePrefix) {
+			continue
+		}
+		// traffic.log
+		if name == fileName {
+			if minFileName == "" {
+				minFileTs = math.MaxInt64
+				minFileName = name
+			}
+			continue
+		}
+		// rotated traffic file
+		fileTs := parseFileTs(name)
+		if fileTs == 0 {
+			l.lg.Warn("traffic file name is invalid", zap.String("filename", name))
+			continue
+		}
+		if fileTs <= l.curFileTs {
+			continue
+		}
+		if minFileName == "" || fileTs < minFileTs {
+			minFileTs = fileTs
+			minFileName = name
+		}
+	}
+	if minFileName == "" {
+		return io.EOF
+	}
+	r, err := os.Open(filepath.Join(l.cfg.Dir, minFileName))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	l.curFileTs = minFileTs
+	l.curFileName = minFileName
+	l.curLineIdx = 1
+	if strings.HasSuffix(minFileName, fileCompressFormat) {
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		l.reader = bufio.NewReader(gr)
+	}
+	l.reader = bufio.NewReader(r)
+	return nil
+}
+
+// Parse the file name to get the file time.
+// filename pattern: traffic-2024-08-29T17-37-12.477.log.gz
+// Ordering by string should also work.
+func parseFileTs(name string) int64 {
+	startIdx := len(fileNamePrefix)
+	if len(name) <= startIdx {
+		return 0
+	}
+	if name[startIdx] != '-' {
+		return 0
+	}
+	startIdx++
+	endIdx := len(name)
+	if strings.HasSuffix(name, fileCompressFormat) {
+		endIdx -= 3
+	}
+	if !strings.HasSuffix(name[:endIdx], fileNameSuffix) {
+		return 0
+	}
+	endIdx -= len(fileNameSuffix)
+	timeStr := name[startIdx:endIdx]
+	t, err := time.Parse(fileTsLayout, timeStr)
+	if err != nil {
+		return 0
+	}
+	return t.UnixMilli()
+}

--- a/pkg/sqlreplay/store/loader_test.go
+++ b/pkg/sqlreplay/store/loader_test.go
@@ -1,0 +1,341 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFileTs(t *testing.T) {
+	tests := []struct {
+		fileName string
+		ts       int64
+	}{
+		{"traffic-2024-08-29T17-37-12.477.log", 1724953032477},
+		{"traffic-2024-08-29T17-37-12.477.log.gz", 1724953032477},
+		{"traffic-2024-08-29T17-37-12.477.gz", 0},
+		{"traffic-2024-08-29T17-37-12.log", 0},
+		{"traffic-2024-08-29T17-37-12.log.gz", 0},
+		{"traffic-.log", 0},
+		{"traffic-.log.gz", 0},
+		{"test.log", 0},
+		{"test", 0},
+		{"traffic.log.gz", 0},
+	}
+
+	for i, test := range tests {
+		ts := parseFileTs(test.fileName)
+		require.Equal(t, test.ts, ts, "case %d", i)
+	}
+}
+
+func TestIterateFiles(t *testing.T) {
+	tests := []struct {
+		fileNames []string
+		order     []string
+	}{
+		{
+			fileNames: []string{},
+			order:     []string{},
+		},
+		{
+			fileNames: []string{
+				"traffic.log",
+			},
+			order: []string{
+				"traffic.log",
+			},
+		},
+		{
+			fileNames: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic.log",
+			},
+			order: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic.log",
+			},
+		},
+		{
+			fileNames: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic-2024-08-30T17-37-12.477.log.gz",
+				"traffic.log",
+			},
+			order: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic-2024-08-30T17-37-12.477.log.gz",
+				"traffic.log",
+			},
+		},
+		{
+			fileNames: []string{
+				"traffic-2024-08-29T17-37-12.477.log",
+				"traffic-2024-08-30T17-37-12.477.log",
+				"traffic.log",
+			},
+			order: []string{
+				"traffic-2024-08-29T17-37-12.477.log",
+				"traffic-2024-08-30T17-37-12.477.log",
+				"traffic.log",
+			},
+		},
+		{
+			fileNames: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic-2024-08-30T17-37-12.477.log.gz",
+				"traffic.log",
+				"meta",
+				"dir",
+			},
+			order: []string{
+				"traffic-2024-08-29T17-37-12.477.log.gz",
+				"traffic-2024-08-30T17-37-12.477.log.gz",
+				"traffic.log",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := LoaderCfg{Dir: dir}
+	for i, test := range tests {
+		require.NoError(t, os.RemoveAll(dir), "case %d", i)
+		require.NoError(t, os.MkdirAll(dir, 0777), "case %d", i)
+		for _, name := range test.fileNames {
+			if name == "dir" {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, name), 0777), "case %d", i)
+				break
+			}
+			f, err := os.Create(filepath.Join(dir, name))
+			require.NoError(t, err, "case %d", i)
+			if strings.HasSuffix(name, ".gz") {
+				w := gzip.NewWriter(f)
+				w.Write([]byte{})
+				w.Close()
+			}
+			require.NoError(t, f.Close())
+		}
+		l := NewLoader(lg, cfg)
+		fileOrder := make([]string, 0, len(test.order))
+		for {
+			if err := l.nextReader(); err != nil {
+				require.True(t, errors.Is(err, io.EOF))
+				break
+			}
+			fileOrder = append(fileOrder, l.curFileName)
+		}
+		require.Equal(t, test.order, fileOrder)
+	}
+}
+
+func TestReadLine(t *testing.T) {
+	tests := []struct {
+		data  []string
+		lines [][]string
+	}{
+		{
+			data:  []string{},
+			lines: [][]string{},
+		},
+		{
+			data: []string{
+				"hello",
+			},
+			lines: [][]string{
+				{
+					"hello",
+				},
+			},
+		},
+		{
+			data: []string{
+				"hello\nworld",
+			},
+			lines: [][]string{
+				{
+					"hello",
+					"world",
+				},
+			},
+		},
+		{
+			data: []string{
+				"hello\n",
+			},
+			lines: [][]string{
+				{
+					"hello",
+				},
+			},
+		},
+		{
+			data: []string{
+				"hello\n",
+				"world\n",
+			},
+			lines: [][]string{
+				{
+					"hello",
+				},
+				{
+					"world",
+				},
+			},
+		},
+		{
+			data: []string{
+				"hello\nworld\n",
+				"hello\nworld\n",
+			},
+			lines: [][]string{
+				{
+					"hello",
+					"world",
+				},
+				{
+					"hello",
+					"world",
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := LoaderCfg{Dir: dir}
+	now := time.Now()
+	for i, test := range tests {
+		require.NoError(t, os.RemoveAll(dir), "case %d", i)
+		require.NoError(t, os.MkdirAll(dir, 0777), "case %d", i)
+		fileNames := make([]string, 0, len(test.data))
+		for j, data := range test.data {
+			name := fmt.Sprintf("traffic-%s.log", now.Add(time.Duration(j)*time.Second).Format(fileTsLayout))
+			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0777)
+			require.NoError(t, err, "case %d", i)
+			fileNames = append(fileNames, name)
+		}
+
+		l := NewLoader(lg, cfg)
+		for fileIdx := 0; fileIdx < len(test.lines); fileIdx++ {
+			for lineIdx := 0; lineIdx < len(test.lines[fileIdx]); lineIdx++ {
+				data, filename, idx, err := l.ReadLine()
+				require.NoError(t, err)
+				require.Equal(t, test.lines[fileIdx][lineIdx], string(data), "case %d file %d line %d", i, fileIdx, lineIdx)
+				require.Equal(t, fileNames[fileIdx], filename, "case %d file %d", i, fileIdx)
+				require.Equal(t, lineIdx+1, idx, "case %d file %d", i, fileIdx)
+			}
+		}
+		_, _, _, err := l.ReadLine()
+		require.True(t, errors.Is(err, io.EOF))
+	}
+}
+
+func TestRead(t *testing.T) {
+	tests := []struct {
+		data    []string
+		str     []string
+		fileIdx []int
+		lineIdx []int
+	}{
+		{
+			data:    []string{},
+			str:     []string{},
+			fileIdx: []int{},
+			lineIdx: []int{},
+		},
+		{
+			data: []string{
+				"hello",
+			},
+			str: []string{
+				"hello",
+			},
+			fileIdx: []int{0},
+			lineIdx: []int{1},
+		},
+		{
+			data: []string{
+				"hel\nlo",
+			},
+			str: []string{
+				"hel\nl",
+			},
+			fileIdx: []int{0},
+			lineIdx: []int{1},
+		},
+		{
+			data: []string{
+				"中hello",
+			},
+			str: []string{
+				"中he",
+			},
+			fileIdx: []int{0},
+			lineIdx: []int{1},
+		},
+		{
+			data: []string{
+				"hello\nworld\nhello",
+			},
+			str: []string{
+				"hello",
+				"\nworl",
+				"d\nhel",
+			},
+			fileIdx: []int{0, 0, 0},
+			lineIdx: []int{1, 1, 2},
+		},
+		{
+			data: []string{
+				"hello",
+				"world",
+			},
+			str: []string{
+				"hello",
+				"world",
+			},
+			fileIdx: []int{0, 1},
+			lineIdx: []int{1, 1},
+		},
+	}
+
+	dir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	cfg := LoaderCfg{Dir: dir}
+	now := time.Now()
+	for i, test := range tests {
+		require.NoError(t, os.RemoveAll(dir), "case %d", i)
+		require.NoError(t, os.MkdirAll(dir, 0777), "case %d", i)
+		fileNames := make([]string, 0, len(test.data))
+		for j, data := range test.data {
+			name := fmt.Sprintf("traffic-%s.log", now.Add(time.Duration(j)*time.Second).Format(fileTsLayout))
+			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0777)
+			require.NoError(t, err, "case %d", i)
+			fileNames = append(fileNames, name)
+		}
+
+		l := NewLoader(lg, cfg)
+		for j := 0; j < len(test.str); j++ {
+			data, filename, idx, err := l.Read(5)
+			require.NoError(t, err)
+			require.Equal(t, test.str[j], string(data), "case %d", i)
+			require.Equal(t, fileNames[test.fileIdx[j]], filename, "case %d", i)
+			require.Equal(t, test.lineIdx[j], idx, "case %d", i)
+		}
+		_, _, _, err := l.Read(5)
+		require.True(t, errors.Is(err, io.EOF))
+	}
+}

--- a/pkg/sqlreplay/store/loader_test.go
+++ b/pkg/sqlreplay/store/loader_test.go
@@ -123,8 +123,9 @@ func TestIterateFiles(t *testing.T) {
 			require.NoError(t, err, "case %d", i)
 			if strings.HasSuffix(name, ".gz") {
 				w := gzip.NewWriter(f)
-				w.Write([]byte{})
-				w.Close()
+				_, err := w.Write([]byte{})
+				require.NoError(t, err)
+				require.NoError(t, w.Close())
 			}
 			require.NoError(t, f.Close())
 		}

--- a/pkg/sqlreplay/store/writer.go
+++ b/pkg/sqlreplay/store/writer.go
@@ -1,0 +1,49 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"path/filepath"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+type Writer interface {
+	Write([]byte) error
+	Close() error
+}
+
+type WriterCfg struct {
+	Dir      string
+	FileSize int
+}
+
+var _ Writer = (*writer)(nil)
+
+type writer struct {
+	lg *lumberjack.Logger
+}
+
+func NewWriter(cfg WriterCfg) *writer {
+	if cfg.FileSize == 0 {
+		cfg.FileSize = fileSize
+	}
+	return &writer{
+		lg: &lumberjack.Logger{
+			Filename:  filepath.Join(cfg.Dir, fileName),
+			MaxSize:   cfg.FileSize,
+			LocalTime: true,
+			Compress:  true,
+		},
+	}
+}
+
+func (w *writer) Write(data []byte) error {
+	_, err := w.lg.Write(data)
+	return err
+}
+
+func (w *writer) Close() error {
+	return w.lg.Close()
+}

--- a/pkg/sqlreplay/store/writer_test.go
+++ b/pkg/sqlreplay/store/writer_test.go
@@ -4,8 +4,6 @@
 package store
 
 import (
-	"bufio"
-	"compress/gzip"
 	"os"
 	"strings"
 	"testing"
@@ -46,31 +44,6 @@ func TestFileRotation(t *testing.T) {
 		t.Logf("traffic files: %v", files)
 		return false
 	}, 5*time.Second, 10*time.Millisecond)
-}
-
-func readFile(t *testing.T, fileName string) []byte {
-	file, err := os.Open(fileName)
-	require.NoError(t, err)
-
-	var reader *bufio.Reader
-	if strings.HasSuffix(fileName, ".gz") {
-		gr, err := gzip.NewReader(file)
-		require.NoError(t, err)
-		reader = bufio.NewReader(gr)
-	} else {
-		reader = bufio.NewReader(file)
-	}
-
-	p := make([]byte, 1024)
-	n, err := reader.Read(p)
-	require.NoError(t, err)
-	return p[:n]
-}
-
-func getFileSize(t *testing.T, fileName string) int64 {
-	file, err := os.Stat(fileName)
-	require.NoError(t, err)
-	return file.Size()
 }
 
 func listFiles(t *testing.T, dir string) []string {

--- a/pkg/sqlreplay/store/writer_test.go
+++ b/pkg/sqlreplay/store/writer_test.go
@@ -49,7 +49,7 @@ func TestFileRotation(t *testing.T) {
 func listFiles(t *testing.T, dir string) []string {
 	files, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	var names []string
+	names := make([]string, 0, len(files))
 	for _, f := range files {
 		names = append(names, f.Name())
 	}

--- a/pkg/sqlreplay/store/writer_test.go
+++ b/pkg/sqlreplay/store/writer_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"bufio"
+	"compress/gzip"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileRotation(t *testing.T) {
+	tmpDir := t.TempDir()
+	writer := NewWriter(WriterCfg{
+		Dir:      tmpDir,
+		FileSize: 1,
+	})
+	defer writer.Close()
+
+	data := make([]byte, 100*1024)
+	for i := 0; i < 11; i++ {
+		require.NoError(t, writer.Write(data))
+	}
+
+	// files are rotated and compressed at backendground asynchronously
+	require.Eventually(t, func() bool {
+		files := listFiles(t, tmpDir)
+		count := 0
+		compressed := false
+		for _, f := range files {
+			if strings.HasPrefix(f, "traffic") {
+				count++
+			}
+			if strings.HasSuffix(f, ".gz") {
+				compressed = true
+			}
+		}
+		if count == 2 && compressed {
+			return true
+		}
+		t.Logf("traffic files: %v", files)
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func readFile(t *testing.T, fileName string) []byte {
+	file, err := os.Open(fileName)
+	require.NoError(t, err)
+
+	var reader *bufio.Reader
+	if strings.HasSuffix(fileName, ".gz") {
+		gr, err := gzip.NewReader(file)
+		require.NoError(t, err)
+		reader = bufio.NewReader(gr)
+	} else {
+		reader = bufio.NewReader(file)
+	}
+
+	p := make([]byte, 1024)
+	n, err := reader.Read(p)
+	require.NoError(t, err)
+	return p[:n]
+}
+
+func getFileSize(t *testing.T, fileName string) int64 {
+	file, err := os.Stat(fileName)
+	require.NoError(t, err)
+	return file.Size()
+}
+
+func listFiles(t *testing.T, dir string) []string {
+	files, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, f := range files {
+		names = append(names, f.Name())
+	}
+	return names
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #657 

Problem Summary:
Support loading and parsing traffic files.

What is changed and how it works:
- Add `loader` to read traffic files
- Separate `load.writer` from `capture.capture` to write traffic files
- Output the filename and line index when parsing `Command` fails
- Update the configuration `output` from a filename to a directory

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
