### PR TITLE
replay, capture: replay commands at a customized speed

### DIFF
--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -126,7 +126,17 @@ func TestCaptureCfgError(t *testing.T) {
 	}
 
 	for i, cfg := range cfgs {
-		err := checkCaptureConfig(&cfg)
+		err := cfg.Validate()
 		require.Error(t, err, "case %d", i)
 	}
+
+	cfg := CaptureConfig{
+		Output:   dir,
+		Duration: 10 * time.Second,
+	}
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, bufferCap, cfg.bufferCap)
+	require.Equal(t, flushThreshold, cfg.flushThreshold)
+	require.Equal(t, maxBuffers, cfg.maxBuffers)
+	require.Equal(t, maxPendingCommands, cfg.maxPendingCommands)
 }

--- a/pkg/sqlreplay/cmd/mock_test.go
+++ b/pkg/sqlreplay/cmd/mock_test.go
@@ -27,11 +27,15 @@ func (mr *mockReader) ReadLine() ([]byte, string, int, error) {
 	return line, "", 0, nil
 }
 
-func (mr *mockReader) Read(n int) ([]byte, string, int, error) {
+func (mr *mockReader) Read(data []byte) (string, int, error) {
+	n := len(data)
 	if mr.curIdx+n > len(mr.data) {
-		return nil, "", 0, io.EOF
+		return "", 0, io.EOF
 	}
-	line := mr.data[mr.curIdx : mr.curIdx+n]
+	copy(data, mr.data[mr.curIdx:mr.curIdx+n])
 	mr.curIdx += n
-	return line, "", 0, nil
+	return "", 0, nil
+}
+
+func (mr *mockReader) Close() {
 }

--- a/pkg/sqlreplay/replay/conn_test.go
+++ b/pkg/sqlreplay/replay/conn_test.go
@@ -6,20 +6,69 @@ package replay
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/stretchr/testify/require"
 )
 
-func TestConnect(t *testing.T) {
+func TestConnectError(t *testing.T) {
+	tests := []struct {
+		connErr error
+		execErr error
+	}{
+		{
+			connErr: errors.New("mock error"),
+		},
+		{
+			execErr: io.EOF,
+		},
+	}
+
 	lg, _ := logger.CreateLoggerForTest(t)
-	cmdCh, exceptionCh := make(chan *cmd.Command), make(chan Exception)
-	conn := newConn(lg, "u1", "", nil, nil, 100, &backend.BCConfig{}, cmdCh, exceptionCh)
-	conn.backendConn = &mockBackendConn{connErr: errors.New("mock error")}
-	conn.Run(context.Background())
-	require.NotNil(t, <-exceptionCh)
-	conn.Close()
+	var wg waitgroup.WaitGroup
+	for i, test := range tests {
+		exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
+		conn := newConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+		backendConn := &mockBackendConn{connErr: test.connErr, execErr: test.execErr}
+		conn.backendConn = backendConn
+		wg.RunWithRecover(func() {
+			conn.Run(context.Background())
+		}, nil, lg)
+		if test.connErr == nil {
+			conn.ExecuteCmd(&cmd.Command{ConnID: 1, Type: pnet.ComQuery})
+		}
+		e := <-exceptionCh
+		require.Equal(t, uint64(1), e.ConnID(), "case %d", i)
+		require.Equal(t, uint64(1), <-closeCh, "case %d", i)
+		require.True(t, backendConn.close.Load(), "case %d", i)
+		wg.Wait()
+	}
+}
+
+func TestExecuteCmd(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	var wg waitgroup.WaitGroup
+	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
+	conn := newConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	backendConn := &mockBackendConn{}
+	conn.backendConn = backendConn
+	childCtx, cancel := context.WithCancel(context.Background())
+	wg.RunWithRecover(func() {
+		conn.Run(childCtx)
+	}, nil, lg)
+	for i := 0; i < 100; i++ {
+		conn.ExecuteCmd(&cmd.Command{ConnID: 1, Type: pnet.ComQuery})
+	}
+	require.Eventually(t, func() bool {
+		return backendConn.cmds.Load() == 100
+	}, 3*time.Second, time.Millisecond)
+	cancel()
+	wg.Wait()
 }

--- a/pkg/sqlreplay/replay/exception.go
+++ b/pkg/sqlreplay/replay/exception.go
@@ -3,19 +3,37 @@
 
 package replay
 
+import (
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+)
+
 type Exception interface {
-	Critical() bool
+	ConnID() uint64
 	String() string
 }
 
 type otherException struct {
-	err error
+	err    error
+	connID uint64
 }
 
-func (he otherException) Critical() bool {
-	return true
+func (he otherException) ConnID() uint64 {
+	return he.connID
 }
 
 func (he otherException) String() string {
 	return he.err.Error()
+}
+
+type failException struct {
+	err     error
+	command *cmd.Command
+}
+
+func (fe failException) ConnID() uint64 {
+	return fe.command.ConnID
+}
+
+func (fe failException) String() string {
+	return fe.err.Error()
 }

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -121,7 +121,7 @@ func newMockNormalLoader() *mockNormalLoader {
 }
 
 func (m *mockNormalLoader) writeCommand(cmd *cmd.Command) {
-	cmd.Encode(&m.buf)
+	_ = cmd.Encode(&m.buf)
 }
 
 func (m *mockNormalLoader) Read(data []byte) (string, int, error) {

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -4,8 +4,13 @@
 package replay
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
+	"io"
+	"sync/atomic"
+	"time"
 
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
@@ -14,27 +19,132 @@ import (
 var _ BackendConn = (*mockBackendConn)(nil)
 
 type mockBackendConn struct {
+	cmds    atomic.Int32
 	connErr error
+	execErr error
+	close   atomic.Bool
 }
 
 func (c *mockBackendConn) Connect(ctx context.Context, clientIO pnet.PacketIO, frontendTLSConfig, backendTLSConfig *tls.Config, username, password string) error {
 	return c.connErr
 }
 
+func (c *mockBackendConn) ExecuteCmd(ctx context.Context, request []byte) (err error) {
+	c.cmds.Add(1)
+	return c.execErr
+}
+
 func (c *mockBackendConn) Close() error {
+	c.close.Store(true)
 	return nil
 }
 
 var _ Conn = (*mockConn)(nil)
 
 type mockConn struct {
-	cmdCh       chan *cmd.Command
 	exceptionCh chan Exception
+	closeCh     chan uint64
+	cmdCh       chan *cmd.Command
 	connID      uint64
 }
 
-func (c *mockConn) Run(ctx context.Context) {
+func (c *mockConn) ExecuteCmd(command *cmd.Command) {
+	if c.cmdCh != nil {
+		c.cmdCh <- command
+	}
 }
 
-func (c *mockConn) Close() {
+func (c *mockConn) Run(ctx context.Context) {
+	<-ctx.Done()
+	c.closeCh <- c.connID
+}
+
+var _ cmd.LineReader = (*mockChLoader)(nil)
+
+type mockChLoader struct {
+	buf   bytes.Buffer
+	cmdCh chan *cmd.Command
+}
+
+func newMockChLoader() *mockChLoader {
+	return &mockChLoader{
+		cmdCh: make(chan *cmd.Command, 1),
+	}
+}
+
+func (m *mockChLoader) writeCommand(cmd *cmd.Command) {
+	m.cmdCh <- cmd
+}
+
+func (m *mockChLoader) Read(data []byte) (string, int, error) {
+	for {
+		_, err := m.buf.Read(data)
+		if errors.Is(err, io.EOF) {
+			command, ok := <-m.cmdCh
+			if !ok {
+				return "", 0, io.EOF
+			}
+			_ = command.Encode(&m.buf)
+		} else {
+			return "", 0, err
+		}
+	}
+}
+
+func (m *mockChLoader) ReadLine() ([]byte, string, int, error) {
+	for {
+		line, err := m.buf.ReadBytes('\n')
+		if errors.Is(err, io.EOF) {
+			command, ok := <-m.cmdCh
+			if !ok {
+				return nil, "", 0, io.EOF
+			}
+			_ = command.Encode(&m.buf)
+		} else {
+			return line[:len(line)-1], "", 0, err
+		}
+	}
+}
+
+func (m *mockChLoader) Close() {
+	close(m.cmdCh)
+}
+
+var _ cmd.LineReader = (*mockNormalLoader)(nil)
+
+type mockNormalLoader struct {
+	buf bytes.Buffer
+}
+
+func newMockNormalLoader() *mockNormalLoader {
+	return &mockNormalLoader{}
+}
+
+func (m *mockNormalLoader) writeCommand(cmd *cmd.Command) {
+	cmd.Encode(&m.buf)
+}
+
+func (m *mockNormalLoader) Read(data []byte) (string, int, error) {
+	_, err := m.buf.Read(data)
+	return "", 0, err
+}
+
+func (m *mockNormalLoader) ReadLine() ([]byte, string, int, error) {
+	line, err := m.buf.ReadBytes('\n')
+	if err == nil {
+		line = line[:len(line)-1]
+	}
+	return line, "", 0, err
+}
+
+func (m *mockNormalLoader) Close() {
+}
+
+func newMockCommand(connID uint64) *cmd.Command {
+	return &cmd.Command{
+		ConnID:  connID,
+		StartTs: time.Now(),
+		Type:    pnet.ComQuery,
+		Payload: append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...),
+	}
 }

--- a/pkg/sqlreplay/replay/packetio_test.go
+++ b/pkg/sqlreplay/replay/packetio_test.go
@@ -10,22 +10,14 @@ import (
 )
 
 func TestPacketIO(t *testing.T) {
-	cli2SrvCh, srv2CliCh := make(chan []byte, 1), make(chan []byte, 1)
-	pkt := newPacketIO(cli2SrvCh, srv2CliCh)
+	pkt := newPacketIO()
 	defer pkt.Close()
 	// test read
-	cli2SrvCh <- []byte("hello")
-	data, err := pkt.ReadPacket()
-	require.NoError(t, err)
-	require.Equal(t, []byte("hello"), data)
+	_, err := pkt.ReadPacket()
+	require.Error(t, err)
 	// test write
-	require.NoError(t, pkt.WritePacket([]byte("wor"), false))
-	require.NoError(t, pkt.WritePacket([]byte("ld"), true))
-	data = <-srv2CliCh
-	require.Equal(t, []byte("world"), data)
+	require.NoError(t, pkt.WritePacket([]byte("hello"), true))
+	require.NoError(t, pkt.WritePacket([]byte("world"), false))
 	// test flush
-	require.NoError(t, pkt.WritePacket([]byte("hi"), false))
 	require.NoError(t, pkt.Flush())
-	data = <-srv2CliCh
-	require.Equal(t, []byte("hi"), data)
 }

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -4,12 +4,14 @@
 package replay
 
 import (
-	"context"
-	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
-	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/stretchr/testify/require"
 )
@@ -18,33 +20,142 @@ func TestManageConns(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	replay := NewReplay(lg, nil, nil, nil)
 	defer replay.Close()
-	var conn *mockConn
-	replay.connCreator = func(connID uint64, cmdCh chan *cmd.Command, exceptionCh chan Exception) Conn {
-		conn = &mockConn{
-			cmdCh:       cmdCh,
+	replay.connCreator = func(connID uint64, exceptionCh chan Exception, closeCh chan uint64) Conn {
+		return &mockConn{
 			exceptionCh: exceptionCh,
+			closeCh:     closeCh,
 			connID:      connID,
 		}
-		return conn
 	}
-	cmd := &cmd.Command{
-		ConnID: 1,
-		Type:   pnet.ComQuery,
+	loader := newMockChLoader()
+	replay.Start(ReplayConfig{
+		Input:    t.TempDir(),
+		Username: "u1",
+		reader:   loader,
+	})
+
+	command := newMockCommand(1)
+	loader.writeCommand(command)
+	require.Eventually(t, func() bool {
+		replay.Lock()
+		defer replay.Unlock()
+		cn, ok := replay.conns[1]
+		return cn != nil && !reflect.ValueOf(cn).IsNil() && ok
+	}, 3*time.Second, 10*time.Millisecond)
+
+	command = newMockCommand(2)
+	loader.writeCommand(command)
+	require.Eventually(t, func() bool {
+		replay.Lock()
+		defer replay.Unlock()
+		cn, ok := replay.conns[2]
+		return cn != nil && !reflect.ValueOf(cn).IsNil() && ok
+	}, 3*time.Second, 10*time.Millisecond)
+
+	replay.closeCh <- 2
+	require.Eventually(t, func() bool {
+		replay.Lock()
+		defer replay.Unlock()
+		cn, ok := replay.conns[2]
+		return (cn == nil || reflect.ValueOf(cn).IsNil()) && ok
+	}, 3*time.Second, 10*time.Millisecond)
+
+	loader.Close()
+}
+
+func TestValidateCfg(t *testing.T) {
+	dir := t.TempDir()
+	cfgs := []ReplayConfig{
+		{
+			Username: "u1",
+		},
+		{
+			Input: dir,
+		},
+		{
+			Input:    filepath.Join(dir, "input"),
+			Username: "u1",
+		},
+		{
+			Input:    dir,
+			Username: "u1",
+			Speed:    0.01,
+		},
+		{
+			Input:    dir,
+			Username: "u1",
+			Speed:    100,
+		},
 	}
-	replay.executeCmd(context.Background(), cmd)
-	wrapper, ok := replay.conns[1]
-	require.True(t, ok)
-	require.NotNil(t, wrapper)
 
-	cmd.ConnID = 2
-	replay.executeCmd(context.Background(), cmd)
-	wrapper, ok = replay.conns[2]
-	require.True(t, ok)
-	require.NotNil(t, wrapper)
+	for i, cfg := range cfgs {
+		require.Error(t, cfg.Validate(), "case %d", i)
+	}
+}
 
-	conn.exceptionCh <- &otherException{err: errors.New("mock error")}
-	replay.executeCmd(context.Background(), cmd)
-	wrapper, ok = replay.conns[2]
-	require.True(t, ok)
-	require.Nil(t, wrapper)
+func TestReadExceptions(t *testing.T) {
+	lg, text := logger.CreateLoggerForTest(t)
+	replay := NewReplay(lg, nil, nil, nil)
+	defer replay.Close()
+
+	dir := t.TempDir()
+	replay.Start(ReplayConfig{
+		Input:    dir,
+		Username: "u1",
+	})
+	replay.exceptionCh <- otherException{err: errors.New("mock error"), connID: 1}
+	require.Eventually(t, func() bool {
+		return strings.Contains(text.String(), "mock error")
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestReplaySpeed(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	speeds := []float64{10, 1, 0.1}
+
+	var lastTotalTime time.Duration
+	for _, speed := range speeds {
+		replay := NewReplay(lg, nil, nil, nil)
+		cmdCh := make(chan *cmd.Command, 10)
+		replay.connCreator = func(connID uint64, exceptionCh chan Exception, closeCh chan uint64) Conn {
+			return &mockConn{
+				exceptionCh: exceptionCh,
+				closeCh:     closeCh,
+				connID:      connID,
+				cmdCh:       cmdCh,
+			}
+		}
+
+		loader := newMockNormalLoader()
+		now := time.Now()
+		for i := 0; i < 10; i++ {
+			command := newMockCommand(1)
+			command.StartTs = now.Add(time.Duration(i*10) * time.Millisecond)
+			loader.writeCommand(command)
+		}
+		replay.Start(ReplayConfig{
+			Input:    t.TempDir(),
+			Username: "u1",
+			reader:   loader,
+			Speed:    speed,
+		})
+
+		var firstTime, lastTime time.Time
+		for i := 0; i < 10; i++ {
+			<-cmdCh
+			if lastTime.IsZero() {
+				firstTime = time.Now()
+				lastTime = firstTime
+			} else {
+				now = time.Now()
+				interval := now.Sub(lastTime)
+				lastTime = now
+				require.Greater(t, interval, time.Duration(float64(10*time.Millisecond)/speed)/2, "speed: %f", speed)
+			}
+		}
+		totalTime := lastTime.Sub(firstTime)
+		require.Greater(t, totalTime, lastTotalTime, "speed: %f", speed)
+		lastTotalTime = totalTime
+		replay.Close()
+	}
 }

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -28,11 +28,11 @@ func TestManageConns(t *testing.T) {
 		}
 	}
 	loader := newMockChLoader()
-	replay.Start(ReplayConfig{
+	require.NoError(t, replay.Start(ReplayConfig{
 		Input:    t.TempDir(),
 		Username: "u1",
 		reader:   loader,
-	})
+	}))
 
 	command := newMockCommand(1)
 	loader.writeCommand(command)
@@ -99,10 +99,10 @@ func TestReadExceptions(t *testing.T) {
 	defer replay.Close()
 
 	dir := t.TempDir()
-	replay.Start(ReplayConfig{
+	require.NoError(t, replay.Start(ReplayConfig{
 		Input:    dir,
 		Username: "u1",
-	})
+	}))
 	replay.exceptionCh <- otherException{err: errors.New("mock error"), connID: 1}
 	require.Eventually(t, func() bool {
 		return strings.Contains(text.String(), "mock error")
@@ -133,12 +133,12 @@ func TestReplaySpeed(t *testing.T) {
 			command.StartTs = now.Add(time.Duration(i*10) * time.Millisecond)
 			loader.writeCommand(command)
 		}
-		replay.Start(ReplayConfig{
+		require.NoError(t, replay.Start(ReplayConfig{
 			Input:    t.TempDir(),
 			Username: "u1",
 			reader:   loader,
 			Speed:    speed,
-		})
+		}))
 
 		var firstTime, lastTime time.Time
 		for i := 0; i < 10; i++ {
@@ -150,7 +150,7 @@ func TestReplaySpeed(t *testing.T) {
 				now = time.Now()
 				interval := now.Sub(lastTime)
 				lastTime = now
-				require.Greater(t, interval, time.Duration(float64(10*time.Millisecond)/speed)/2, "speed: %f", speed)
+				require.Greater(t, interval, time.Duration(float64(10*time.Millisecond)/speed)/2, "speed: %f, i: %d", speed, i)
 			}
 		}
 		totalTime := lastTime.Sub(firstTime)

--- a/pkg/sqlreplay/store/loader_test.go
+++ b/pkg/sqlreplay/store/loader_test.go
@@ -329,14 +329,15 @@ func TestRead(t *testing.T) {
 		}
 
 		l := NewLoader(lg, cfg)
+		data := make([]byte, 5)
 		for j := 0; j < len(test.str); j++ {
-			data, filename, idx, err := l.Read(5)
+			filename, idx, err := l.Read(data)
 			require.NoError(t, err)
 			require.Equal(t, test.str[j], string(data), "case %d", i)
 			require.Equal(t, fileNames[test.fileIdx[j]], filename, "case %d", i)
 			require.Equal(t, test.lineIdx[j], idx, "case %d", i)
 		}
-		_, _, _, err := l.Read(5)
+		_, _, err := l.Read(data)
 		require.True(t, errors.Is(err, io.EOF))
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #659 

Problem Summary:
Replay commands at a customized speed.

What is changed and how it works:
- Replay commands with `ReplayConfig.Speed` and report errors with `failException`.
- Fix that the files are not closed in `loader`.
- Remove the codes in `packetIO` because it's unnecessary.
- Make `Command.Payload` contain the command type so that it can be used directly in replay.
- Clear the closed connection through `closeCh`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
