### PR TITLE
tiproxyctl: change --curls to --host and --port

### DIFF
--- a/lib/cli/main.go
+++ b/lib/cli/main.go
@@ -27,7 +27,8 @@ func GetRootCmd(tlsConfig *tls.Config) *cobra.Command {
 
 	ctx := &Context{}
 
-	curls := rootCmd.PersistentFlags().StringArray("curls", []string{"localhost:3080"}, "API gateway addresses")
+	host := rootCmd.PersistentFlags().String("host", "localhost", "API gateway host")
+	port := rootCmd.PersistentFlags().Int("port", 3080, "API gateway port")
 	logEncoder := rootCmd.PersistentFlags().String("log_encoder", "tidb", "log in format of tidb, console, or json")
 	logLevel := rootCmd.PersistentFlags().String("log_level", "warn", "log level")
 	insecure := rootCmd.PersistentFlags().BoolP("insecure", "k", false, "enable TLS without CA, useful for testing, or for expired certs")
@@ -76,7 +77,8 @@ func GetRootCmd(tlsConfig *tls.Config) *cobra.Command {
 				ExpectContinueTimeout: 1 * time.Second,
 			},
 		}
-		ctx.CUrls = *curls
+		ctx.Host = *host
+		ctx.Port = *port
 		ctx.SSL = tlsConfig != nil
 		return nil
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #656

Problem Summary:
tiproxyctl --curls=127.0.0.1:3080
tidb-ctl --host=127.0.0.1 --port 10080
They are inconsistent.

What is changed and how it works:
Change tiproxyctl arguments from --curls to --host and --port

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Try `bin/tiproxyctl --help` and `bin/tiproxyctl --host localhost --port 3080 config get`

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Change tiproxyctl arguments from --curls to --host and --port
```
