### PR TITLE
api, server: add http api for capturing and replaying traffic

### DIFF
--- a/lib/cli/util.go
+++ b/lib/cli/util.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"go.uber.org/zap"
@@ -64,4 +66,12 @@ func doRequest(ctx context.Context, bctx *Context, method string, url string, rd
 	default:
 		return "", errors.Errorf("%s: %s", res.Status, string(resb))
 	}
+}
+
+func GetFormReader(m map[string]string) io.Reader {
+	form := url.Values{}
+	for key, value := range m {
+		form.Add(key, value)
+	}
+	return strings.NewReader(form.Encode())
 }

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -315,7 +316,7 @@ func (mgr *BackendConnManager) getBackendIO(ctx context.Context, cctx ConnContex
 // If it finds that the session is ready for redirection, it migrates the session.
 func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (err error) {
 	startTime := time.Now()
-	if mgr.cpt != nil {
+	if mgr.cpt != nil && !reflect.ValueOf(mgr.cpt).IsNil() {
 		mgr.cpt.Capture(request, startTime, mgr.connectionID)
 	}
 	mgr.processLock.Lock()

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -52,13 +52,13 @@ type SQLServer struct {
 }
 
 // NewSQLServer creates a new SQLServer.
-func NewSQLServer(logger *zap.Logger, cfg *config.Config, certMgr *cert.CertManager, hsHandler backend.HandshakeHandler) (*SQLServer, error) {
+func NewSQLServer(logger *zap.Logger, cfg *config.Config, certMgr *cert.CertManager, cpt capture.Capture, hsHandler backend.HandshakeHandler) (*SQLServer, error) {
 	var err error
 	s := &SQLServer{
 		logger:    logger,
 		certMgr:   certMgr,
 		hsHandler: hsHandler,
-		cpt:       capture.NewCapture(logger.Named("capture")),
+		cpt:       cpt,
 		mu: serverState{
 			connID:  0,
 			clients: make(map[uint64]*client.ClientConnection),

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -31,7 +31,7 @@ func TestCreateConn(t *testing.T) {
 	cfg := &config.Config{}
 	certManager := cert.NewCertManager()
 	require.NoError(t, certManager.Init(cfg, lg, nil))
-	server, err := NewSQLServer(lg, cfg, certManager, &mockHsHandler{})
+	server, err := NewSQLServer(lg, cfg, certManager, nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 	defer func() {
@@ -79,7 +79,7 @@ func TestGracefulCloseConn(t *testing.T) {
 			},
 		},
 	}
-	server, err := NewSQLServer(lg, cfg, nil, hsHandler)
+	server, err := NewSQLServer(lg, cfg, nil, nil, hsHandler)
 	require.NoError(t, err)
 	finish := make(chan struct{})
 	go func() {
@@ -109,7 +109,7 @@ func TestGracefulCloseConn(t *testing.T) {
 	}
 
 	// Graceful shutdown will be blocked if there are alive connections.
-	server, err = NewSQLServer(lg, cfg, nil, hsHandler)
+	server, err = NewSQLServer(lg, cfg, nil, nil, hsHandler)
 	require.NoError(t, err)
 	clientConn := createClientConn()
 	go func() {
@@ -135,7 +135,7 @@ func TestGracefulCloseConn(t *testing.T) {
 
 	// Graceful shutdown will shut down after GracefulCloseConnTimeout.
 	cfg.Proxy.GracefulCloseConnTimeout = 1
-	server, err = NewSQLServer(lg, cfg, nil, hsHandler)
+	server, err = NewSQLServer(lg, cfg, nil, nil, hsHandler)
 	require.NoError(t, err)
 	createClientConn()
 	go func() {
@@ -163,7 +163,7 @@ func TestGracefulShutDown(t *testing.T) {
 			},
 		},
 	}
-	server, err := NewSQLServer(lg, cfg, certManager, &mockHsHandler{})
+	server, err := NewSQLServer(lg, cfg, certManager, nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 
@@ -201,7 +201,7 @@ func TestMultiAddr(t *testing.T) {
 		Proxy: config.ProxyServer{
 			Addr: "0.0.0.0:0,0.0.0.0:0",
 		},
-	}, certManager, &mockHsHandler{})
+	}, certManager, nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 
@@ -221,7 +221,7 @@ func TestWatchCfg(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	hsHandler := backend.NewDefaultHandshakeHandler(nil)
 	cfgch := make(chan *config.Config)
-	server, err := NewSQLServer(lg, &config.Config{}, nil, hsHandler)
+	server, err := NewSQLServer(lg, &config.Config{}, nil, nil, hsHandler)
 	require.NoError(t, err)
 	server.Run(context.Background(), cfgch)
 	cfg := &config.Config{
@@ -256,7 +256,7 @@ func TestRecoverPanic(t *testing.T) {
 	certManager := cert.NewCertManager()
 	err := certManager.Init(&config.Config{}, lg, nil)
 	require.NoError(t, err)
-	server, err := NewSQLServer(lg, &config.Config{}, certManager, &mockHsHandler{
+	server, err := NewSQLServer(lg, &config.Config{}, certManager, nil, &mockHsHandler{
 		handshakeResp: func(ctx backend.ConnContext, _ *pnet.HandshakeResp) error {
 			if ctx.Value(backend.ConnContextKeyConnID).(uint64) == 0 {
 				panic("HandleHandshakeResp panic")

--- a/pkg/server/api/backend.go
+++ b/pkg/server/api/backend.go
@@ -15,7 +15,7 @@ type BackendReader interface {
 }
 
 func (h *Server) BackendMetrics(c *gin.Context) {
-	metrics := h.mgr.br.GetBackendMetrics()
+	metrics := h.mgr.BackendReader.GetBackendMetrics()
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(http.StatusOK)
 	if _, err := c.Writer.Write(metrics); err != nil {

--- a/pkg/server/api/backend_test.go
+++ b/pkg/server/api/backend_test.go
@@ -32,10 +32,10 @@ func TestBackendMetrics(t *testing.T) {
 	}
 
 	server, doHTTP := createServer(t)
-	mbr := server.mgr.br.(*mockBackendReader)
+	mbr := server.mgr.BackendReader.(*mockBackendReader)
 	for _, tt := range tests {
 		mbr.data.Store(string(tt.data))
-		doHTTP(t, http.MethodGet, "/api/backend/metrics", nil, nil, func(t *testing.T, r *http.Response) {
+		doHTTP(t, http.MethodGet, "/api/backend/metrics", httpOpts{}, func(t *testing.T, r *http.Response) {
 			all, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, all)

--- a/pkg/server/api/config.go
+++ b/pkg/server/api/config.go
@@ -23,7 +23,7 @@ func (h *Server) ConfigSet(c *gin.Context) {
 		return
 	}
 
-	if err := h.mgr.cfg.SetTOMLConfig(data); err != nil {
+	if err := h.mgr.CfgMgr.SetTOMLConfig(data); err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,
 			Err:  errors.Errorf("can not update config: %+v", err),
@@ -39,9 +39,9 @@ func (h *Server) ConfigGet(c *gin.Context) {
 	// TiDB cluster_config uses format=json, while tiproxyctl expects toml (both PUT and GET) by default.
 	// Users can choose the format on TiDB-Dashboard.
 	if strings.EqualFold(c.Query("format"), "json") || c.GetHeader("Accept") == "application/json" {
-		c.JSON(http.StatusOK, h.mgr.cfg.GetConfig())
+		c.JSON(http.StatusOK, h.mgr.CfgMgr.GetConfig())
 	} else {
-		c.TOML(http.StatusOK, h.mgr.cfg.GetConfig())
+		c.TOML(http.StatusOK, h.mgr.CfgMgr.GetConfig())
 	}
 }
 

--- a/pkg/server/api/config_test.go
+++ b/pkg/server/api/config_test.go
@@ -19,44 +19,44 @@ import (
 func TestConfig(t *testing.T) {
 	_, doHTTP := createServer(t)
 
-	doHTTP(t, http.MethodGet, "/api/admin/config", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Contains(t, string(all), "addr = '0.0.0.0:6000'")
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Contains(t, string(all), `"addr":"0.0.0.0:6000"`)
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = true"), nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", httpOpts{reader: strings.NewReader("security.require-backend-tls = true")}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	sum := ""
 	sumreg := regexp.MustCompile(`{"config_checksum":(.+)}`)
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		sum = string(sumreg.Find(all))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("proxy.require-back = false"), nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", httpOpts{reader: strings.NewReader("proxy.require-back = false")}, func(t *testing.T, r *http.Response) {
 		// no error
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, sum, string(sumreg.Find(all)))
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/config", strings.NewReader("security.require-backend-tls = false"), nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/config", httpOpts{reader: strings.NewReader("security.require-backend-tls = false")}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.NotEqual(t, sum, string(sumreg.Find(all)))
@@ -80,19 +80,19 @@ func TestAcceptType(t *testing.T) {
 			require.NoError(t, toml.Unmarshal(data, &cfg))
 		}
 	}
-	doHTTP(t, http.MethodGet, "/api/admin/config", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config", httpOpts{}, func(t *testing.T, r *http.Response) {
 		checkRespContentType("toml", r)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config", nil, map[string]string{"Accept": "application/json"}, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config", httpOpts{header: map[string]string{"Accept": "application/json"}}, func(t *testing.T, r *http.Response) {
 		checkRespContentType("json", r)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config", nil, map[string]string{"Accept": "application/toml"}, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config", httpOpts{header: map[string]string{"Accept": "application/toml"}}, func(t *testing.T, r *http.Response) {
 		checkRespContentType("toml", r)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=json", httpOpts{}, func(t *testing.T, r *http.Response) {
 		checkRespContentType("json", r)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/config?format=JSON", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/config?format=JSON", httpOpts{}, func(t *testing.T, r *http.Response) {
 		checkRespContentType("json", r)
 	})
 }

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -17,12 +17,12 @@ func (h *Server) DebugHealth(c *gin.Context) {
 		status = http.StatusBadGateway
 	}
 	c.JSON(status, config.HealthInfo{
-		ConfigChecksum: h.mgr.cfg.GetConfigChecksum(),
+		ConfigChecksum: h.mgr.CfgMgr.GetConfigChecksum(),
 	})
 }
 
 func (h *Server) DebugRedirect(c *gin.Context) {
-	errs := h.mgr.ns.RedirectConnections()
+	errs := h.mgr.NsMgr.RedirectConnections()
 	if len(errs) != 0 {
 		for _, err := range errs {
 			c.Errors = append(c.Errors, &gin.Error{

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -13,23 +13,23 @@ import (
 func TestDebug(t *testing.T) {
 	server, doHTTP := createServer(t)
 
-	doHTTP(t, http.MethodPost, "/api/debug/redirect", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/debug/redirect", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/redirect", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/redirect", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusNotFound, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodGet, "/api/debug/pprof", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/pprof", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
 	server.PreClose()
-	doHTTP(t, http.MethodGet, "/api/debug/health", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 	})
 }

--- a/pkg/server/api/metrics_test.go
+++ b/pkg/server/api/metrics_test.go
@@ -13,7 +13,7 @@ import (
 func TestMetrics(t *testing.T) {
 	_, doHTTP := createServer(t)
 
-	doHTTP(t, http.MethodGet, "/api/metrics", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/metrics", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 }

--- a/pkg/server/api/namespace.go
+++ b/pkg/server/api/namespace.go
@@ -18,7 +18,7 @@ func (h *Server) NamespaceGet(c *gin.Context) {
 		return
 	}
 
-	nsc, err := h.mgr.cfg.GetNamespace(c, ns)
+	nsc, err := h.mgr.CfgMgr.GetNamespace(c, ns)
 	if err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,
@@ -42,7 +42,7 @@ func (h *Server) NamespaceUpsert(c *gin.Context) {
 		return
 	}
 
-	if err := h.mgr.cfg.SetNamespace(c, nsc.Namespace, nsc); err != nil {
+	if err := h.mgr.CfgMgr.SetNamespace(c, nsc.Namespace, nsc); err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,
 			Err:  errors.Errorf("can not update namespace[%s]: %+v", nsc.Namespace, err),
@@ -61,7 +61,7 @@ func (h *Server) NamespaceRemove(c *gin.Context) {
 		return
 	}
 
-	if err := h.mgr.cfg.DelNamespace(c, ns); err != nil {
+	if err := h.mgr.CfgMgr.DelNamespace(c, ns); err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,
 			Err:  errors.Errorf("can not update namespace[%s]: %+v", ns, err),
@@ -80,7 +80,7 @@ func (h *Server) NamespaceCommit(c *gin.Context) {
 	var nss_delete []bool
 	var err error
 	if len(ns_names) == 0 {
-		nss, err = h.mgr.cfg.ListAllNamespace(c)
+		nss, err = h.mgr.CfgMgr.ListAllNamespace(c)
 		if err != nil {
 			c.Errors = append(c.Errors, &gin.Error{
 				Type: gin.ErrorTypePrivate,
@@ -93,7 +93,7 @@ func (h *Server) NamespaceCommit(c *gin.Context) {
 		nss = make([]*config.Namespace, len(ns_names))
 		nss_delete = make([]bool, len(ns_names))
 		for i, ns_name := range ns_names {
-			ns, err := h.mgr.cfg.GetNamespace(c, ns_name)
+			ns, err := h.mgr.CfgMgr.GetNamespace(c, ns_name)
 			if err != nil {
 				c.Errors = append(c.Errors, &gin.Error{
 					Type: gin.ErrorTypePrivate,
@@ -107,7 +107,7 @@ func (h *Server) NamespaceCommit(c *gin.Context) {
 		}
 	}
 
-	if err := h.mgr.ns.CommitNamespaces(nss, nss_delete); err != nil {
+	if err := h.mgr.NsMgr.CommitNamespaces(nss, nss_delete); err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,
 			Err:  errors.Errorf("failed to reload namespaces: %v, %+v", nss, err),
@@ -120,7 +120,7 @@ func (h *Server) NamespaceCommit(c *gin.Context) {
 }
 
 func (h *Server) NamespaceList(c *gin.Context) {
-	nscs, err := h.mgr.cfg.ListAllNamespace(c)
+	nscs, err := h.mgr.CfgMgr.ListAllNamespace(c)
 	if err != nil {
 		c.Errors = append(c.Errors, &gin.Error{
 			Type: gin.ErrorTypePrivate,

--- a/pkg/server/api/namespace_test.go
+++ b/pkg/server/api/namespace_test.go
@@ -16,7 +16,7 @@ func TestNamespace(t *testing.T) {
 	_, doHTTP := createServer(t)
 
 	// test list
-	doHTTP(t, http.MethodGet, "/api/admin/namespace", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `""`, string(all))
@@ -24,15 +24,15 @@ func TestNamespace(t *testing.T) {
 	})
 
 	// test set
-	doHTTP(t, http.MethodPut, "/api/admin/namespace/gg", strings.NewReader(`{}`), nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/namespace/gg", httpOpts{reader: strings.NewReader(`{}`)}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPut, "/api/admin/namespace", strings.NewReader(`{"namespace": "dge"}`), nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/admin/namespace", httpOpts{reader: strings.NewReader(`{"namespace": "dge"}`)}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
 	// test get
-	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", httpOpts{}, func(t *testing.T, r *http.Response) {
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, `{"namespace":"dge","frontend":{"user":"","security":{}},"backend":{"instances":null,"security":{}}}`, string(all))
@@ -40,18 +40,18 @@ func TestNamespace(t *testing.T) {
 	})
 
 	// test remove
-	doHTTP(t, http.MethodDelete, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodDelete, "/api/admin/namespace/dge", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodGet, "/api/admin/namespace/dge", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
 
 	// test commit
-	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit?namespace=xx", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit?namespace=xx", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
-	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit", nil, nil, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
 }

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -23,6 +23,7 @@ import (
 	mgrcfg "github.com/pingcap/tiproxy/pkg/manager/config"
 	mgrns "github.com/pingcap/tiproxy/pkg/manager/namespace"
 	"github.com/pingcap/tiproxy/pkg/proxy/proxyprotocol"
+	mgrrp "github.com/pingcap/tiproxy/pkg/sqlreplay/manager"
 	"go.uber.org/atomic"
 	"go.uber.org/ratelimit"
 	"go.uber.org/zap"
@@ -42,11 +43,12 @@ type HTTPHandler interface {
 	RegisterHTTP(c *gin.Engine) error
 }
 
-type managers struct {
-	cfg *mgrcfg.ConfigManager
-	ns  *mgrns.NamespaceManager
-	crt *mgrcrt.CertManager
-	br  BackendReader
+type Managers struct {
+	CfgMgr        *mgrcfg.ConfigManager
+	NsMgr         *mgrns.NamespaceManager
+	CertMgr       *mgrcrt.CertManager
+	BackendReader BackendReader
+	ReplayJobMgr  mgrrp.JobManager
 }
 
 type Server struct {
@@ -57,13 +59,10 @@ type Server struct {
 	lg        *zap.Logger
 	grpc      *grpc.Server
 	isClosing atomic.Bool
-	mgr       managers
+	mgr       Managers
 }
 
-func NewServer(cfg config.API, lg *zap.Logger,
-	nsmgr *mgrns.NamespaceManager, cfgmgr *mgrcfg.ConfigManager,
-	crtmgr *mgrcrt.CertManager, br BackendReader, handler HTTPHandler,
-	ready *atomic.Bool) (*Server, error) {
+func NewServer(cfg config.API, lg *zap.Logger, mgr Managers, handler HTTPHandler, ready *atomic.Bool) (*Server, error) {
 	grpcOpts := []grpc_zap.Option{
 		grpc_zap.WithLevels(func(code codes.Code) zapcore.Level {
 			return zap.InfoLevel
@@ -83,7 +82,7 @@ func NewServer(cfg config.API, lg *zap.Logger,
 				grpc_zap.StreamServerInterceptor(lg.Named("grpcs"), grpcOpts...),
 			),
 		),
-		mgr: managers{cfgmgr, nsmgr, crtmgr, br},
+		mgr: mgr,
 	}
 
 	var err error
@@ -107,8 +106,8 @@ func NewServer(cfg config.API, lg *zap.Logger,
 		h.attachLogger,
 	)
 
-	h.registerGrpc(engine, cfg, cfgmgr)
-	h.registerAPI(engine.Group("/api"), cfg, nsmgr, cfgmgr)
+	h.registerGrpc(mgr.CfgMgr)
+	h.registerAPI(engine.Group("/api"))
 	// The paths are consistent with other components.
 	h.registerMetrics(engine.Group("metrics"))
 	h.registerDebug(engine.Group("debug"))
@@ -119,7 +118,7 @@ func NewServer(cfg config.API, lg *zap.Logger,
 		}
 	}
 
-	if tlscfg := crtmgr.ServerHTTPTLS(); tlscfg != nil {
+	if tlscfg := mgr.CertMgr.ServerHTTPTLS(); tlscfg != nil {
 		h.listener = tls.NewListener(h.listener, tlscfg)
 	}
 
@@ -189,7 +188,7 @@ func (h *Server) readyState(c *gin.Context) {
 	}
 }
 
-func (h *Server) registerGrpc(g *gin.Engine, cfg config.API, cfgmgr *mgrcfg.ConfigManager) {
+func (h *Server) registerGrpc(cfgmgr *mgrcfg.ConfigManager) {
 	diagnosticspb.RegisterDiagnosticsServer(h.grpc, sysutil.NewDiagnosticsServer(cfgmgr.GetConfig().Log.LogFile.Filename))
 }
 
@@ -203,7 +202,7 @@ func (h *Server) grpcServer(ctx *gin.Context) {
 	}
 }
 
-func (h *Server) registerAPI(g *gin.RouterGroup, cfg config.API, nsmgr *mgrns.NamespaceManager, cfgmgr *mgrcfg.ConfigManager) {
+func (h *Server) registerAPI(g *gin.RouterGroup) {
 	{
 		adminGroup := g.Group("admin")
 		h.registerNamespace(adminGroup.Group("namespace"))
@@ -213,6 +212,7 @@ func (h *Server) registerAPI(g *gin.RouterGroup, cfg config.API, nsmgr *mgrns.Na
 	h.registerMetrics(g.Group("metrics"))
 	h.registerDebug(g.Group("debug"))
 	h.registerBackend(g.Group("backend"))
+	h.registerTraffic(g.Group("traffic"))
 }
 
 func (h *Server) PreClose() {

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/config"
@@ -21,7 +23,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path string, rd io.Reader, header map[string]string, f func(*testing.T, *http.Response))) {
+type httpOpts struct {
+	reader io.Reader
+	header map[string]string
+	form   map[string]string
+}
+
+func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path string, opts httpOpts, f func(*testing.T, *http.Response))) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	ready := atomic.NewBool(true)
 	cfgmgr := mgrcfg.NewConfigManager()
@@ -30,20 +38,33 @@ func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path
 	require.NoError(t, crtmgr.Init(cfgmgr.GetConfig(), lg, cfgmgr.WatchConfig()))
 	srv, err := NewServer(config.API{
 		Addr: "0.0.0.0:0",
-	}, lg, mgrns.NewNamespaceManager(), cfgmgr, crtmgr, &mockBackendReader{}, nil, ready)
+	}, lg, Managers{
+		CfgMgr:        cfgmgr,
+		NsMgr:         mgrns.NewNamespaceManager(),
+		CertMgr:       crtmgr,
+		BackendReader: &mockBackendReader{},
+		ReplayJobMgr:  &mockReplayJobManager{},
+	}, nil, ready)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, srv.Close())
 	})
 
 	addr := fmt.Sprintf("http://%s", srv.listener.Addr().String())
-	return srv, func(t *testing.T, method, pa string, rd io.Reader, header map[string]string, f func(*testing.T, *http.Response)) {
+	return srv, func(t *testing.T, method, pa string, opts httpOpts, f func(*testing.T, *http.Response)) {
 		if pa[0] != '/' {
 			pa = "/" + pa
 		}
-		req, err := http.NewRequest(method, fmt.Sprintf("%s%s", addr, pa), rd)
+		if len(opts.form) > 0 {
+			form := url.Values{}
+			for key, value := range opts.form {
+				form.Add(key, value)
+			}
+			opts.reader = strings.NewReader(form.Encode())
+		}
+		req, err := http.NewRequest(method, fmt.Sprintf("%s%s", addr, pa), opts.reader)
 		require.NoError(t, err)
-		for key, value := range header {
+		for key, value := range opts.header {
 			req.Header.Set(key, value)
 		}
 		resp, err := http.DefaultClient.Do(req)

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/config"
@@ -26,7 +24,6 @@ import (
 type httpOpts struct {
 	reader io.Reader
 	header map[string]string
-	form   map[string]string
 }
 
 func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path string, opts httpOpts, f func(*testing.T, *http.Response))) {
@@ -54,13 +51,6 @@ func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path
 	return srv, func(t *testing.T, method, pa string, opts httpOpts, f func(*testing.T, *http.Response)) {
 		if pa[0] != '/' {
 			pa = "/" + pa
-		}
-		if len(opts.form) > 0 {
-			form := url.Values{}
-			for key, value := range opts.form {
-				form.Add(key, value)
-			}
-			opts.reader = strings.NewReader(form.Encode())
 		}
 		req, err := http.NewRequest(method, fmt.Sprintf("%s%s", addr, pa), opts.reader)
 		require.NoError(t, err)

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -22,8 +22,8 @@ func (h *Server) registerTraffic(group *gin.RouterGroup) {
 
 func (h *Server) TrafficCapture(c *gin.Context) {
 	cfg := capture.CaptureConfig{}
-	cfg.Output = c.Query("output")
-	if durationStr := c.Query("duration"); durationStr != "" {
+	cfg.Output = c.PostForm("output")
+	if durationStr := c.PostForm("duration"); durationStr != "" {
 		duration, err := time.ParseDuration(durationStr)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
@@ -41,8 +41,8 @@ func (h *Server) TrafficCapture(c *gin.Context) {
 
 func (h *Server) TrafficReplay(c *gin.Context) {
 	cfg := replay.ReplayConfig{}
-	cfg.Input = c.Query("input")
-	if speedStr := c.Query("speed"); speedStr != "" {
+	cfg.Input = c.PostForm("input")
+	if speedStr := c.PostForm("speed"); speedStr != "" {
 		speed, err := strconv.ParseFloat(speedStr, 64)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -1,0 +1,71 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
+)
+
+func (h *Server) registerTraffic(group *gin.RouterGroup) {
+	group.POST("/capture", h.TrafficCapture)
+	group.POST("/replay", h.TrafficReplay)
+	group.POST("/cancel", h.TrafficStop)
+	group.GET("/show", h.TrafficShow)
+}
+
+func (h *Server) TrafficCapture(c *gin.Context) {
+	cfg := capture.CaptureConfig{}
+	cfg.Output = c.Query("output")
+	if durationStr := c.Query("duration"); durationStr != "" {
+		duration, err := time.ParseDuration(durationStr)
+		if err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		cfg.Duration = duration
+	}
+
+	if err := h.mgr.ReplayJobMgr.StartCapture(cfg); err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.String(http.StatusOK, "capture started")
+}
+
+func (h *Server) TrafficReplay(c *gin.Context) {
+	cfg := replay.ReplayConfig{}
+	cfg.Input = c.Query("input")
+	if speedStr := c.Query("speed"); speedStr != "" {
+		speed, err := strconv.ParseFloat(speedStr, 64)
+		if err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		cfg.Speed = speed
+	}
+	cfg.Username = c.PostForm("username")
+	cfg.Password = c.PostForm("password")
+
+	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
+		c.String(http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.String(http.StatusOK, "replay started")
+}
+
+func (h *Server) TrafficStop(c *gin.Context) {
+	result := h.mgr.ReplayJobMgr.Stop()
+	c.String(http.StatusOK, result)
+}
+
+func (h *Server) TrafficShow(c *gin.Context) {
+	result := h.mgr.ReplayJobMgr.Jobs()
+	c.String(http.StatusOK, result)
+}

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tiproxy/lib/cli"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/manager"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
@@ -21,7 +22,7 @@ func TestTraffic(t *testing.T) {
 	mgr := server.mgr.ReplayJobMgr.(*mockReplayJobManager)
 
 	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
-		form:   map[string]string{"output": "/tmp", "duration": "10"},
+		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "10"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadRequest, r.StatusCode)
@@ -30,7 +31,7 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, "time: missing unit in duration \"10\"", string(all))
 	})
 	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
-		form:   map[string]string{"output": "/tmp", "duration": "1h"},
+		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
@@ -41,7 +42,7 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp"}, mgr.captureCfg)
 	})
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
-		form:   map[string]string{"input": "/tmp"},
+		reader: cli.GetFormReader(map[string]string{"input": "/tmp"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
@@ -57,7 +58,7 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, "", mgr.curJob)
 	})
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
-		form:   map[string]string{"input": "/tmp", "speed": "abc"},
+		reader: cli.GetFormReader(map[string]string{"input": "/tmp", "speed": "abc"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadRequest, r.StatusCode)
@@ -66,7 +67,7 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, "strconv.ParseFloat: parsing \"abc\": invalid syntax", string(all))
 	})
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
-		form:   map[string]string{"input": "/tmp", "speed": "2.0", "username": "u1", "password": "p1"},
+		reader: cli.GetFormReader(map[string]string{"input": "/tmp", "speed": "2.0", "username": "u1", "password": "p1"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -1,0 +1,103 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/manager"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraffic(t *testing.T) {
+	server, doHTTP := createServer(t)
+	mgr := server.mgr.ReplayJobMgr.(*mockReplayJobManager)
+
+	doHTTP(t, http.MethodPost, "/api/traffic/capture?duration=1h&output=/tmp", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "capture started", string(all))
+		require.Equal(t, "capture", mgr.curJob)
+		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp"}, mgr.captureCfg)
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/replay?input=/tmp", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "job is running", string(all))
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "stopped", string(all))
+		require.Equal(t, "", mgr.curJob)
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/replay?input=/tmp&speed=2.0", httpOpts{form: map[string]string{"username": "u1"}, header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"}}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "replay started", string(all))
+		require.Equal(t, "replay", mgr.curJob)
+		require.Equal(t, replay.ReplayConfig{Input: "/tmp", Username: "u1", Speed: 2.0}, mgr.replayCfg)
+	})
+	doHTTP(t, http.MethodGet, "/api/traffic/show", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "replay", string(all))
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+}
+
+var _ manager.JobManager = (*mockReplayJobManager)(nil)
+
+type mockReplayJobManager struct {
+	curJob     string
+	captureCfg capture.CaptureConfig
+	replayCfg  replay.ReplayConfig
+}
+
+func (m *mockReplayJobManager) Close() {
+}
+
+func (m *mockReplayJobManager) GetCapture() capture.Capture {
+	return nil
+}
+
+func (m *mockReplayJobManager) Jobs() string {
+	return m.curJob
+}
+
+func (m *mockReplayJobManager) StartCapture(captureCfg capture.CaptureConfig) error {
+	if m.curJob != "" {
+		return errors.New("job is running")
+	}
+	m.captureCfg = captureCfg
+	m.curJob = "capture"
+	return nil
+}
+
+func (m *mockReplayJobManager) StartReplay(replayCfg replay.ReplayConfig) error {
+	if m.curJob != "" {
+		return errors.New("job is running")
+	}
+	m.replayCfg = replayCfg
+	m.curJob = "replay"
+	return nil
+}
+
+func (m *mockReplayJobManager) Stop() string {
+	m.curJob = ""
+	return "stopped"
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #667 

Problem Summary:
add http api for capturing and replaying traffic

What is changed and how it works:
- Add http api for capturing and replaying traffic
- Create `JobManager` in `Server`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
