### PR TITLE
cli: add traffic commands for tiproxyctl

### DIFF
--- a/lib/cli/main.go
+++ b/lib/cli/main.go
@@ -86,5 +86,6 @@ func GetRootCmd(tlsConfig *tls.Config) *cobra.Command {
 	rootCmd.AddCommand(GetNamespaceCmd(ctx))
 	rootCmd.AddCommand(GetConfigCmd(ctx))
 	rootCmd.AddCommand(GetHealthCmd(ctx))
+	rootCmd.AddCommand(GetTrafficCmd(ctx))
 	return rootCmd
 }

--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -1,0 +1,99 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+func GetTrafficCmd(ctx *Context) *cobra.Command {
+	trafficCmd := &cobra.Command{
+		Use:   "traffic [command]",
+		Short: "",
+	}
+	trafficCmd.AddCommand(GetTrafficCaptureCmd(ctx))
+	trafficCmd.AddCommand(GetTrafficReplayCmd(ctx))
+	trafficCmd.AddCommand(GetTrafficCancelCmd(ctx))
+	trafficCmd.AddCommand(GetTrafficShowCmd(ctx))
+	return trafficCmd
+}
+
+func GetTrafficCaptureCmd(ctx *Context) *cobra.Command {
+	captureCmd := &cobra.Command{
+		Use:   "capture [flags]",
+		Short: "",
+	}
+	output := captureCmd.PersistentFlags().String("output", "", "output directory for traffic files")
+	duration := captureCmd.PersistentFlags().String("duration", "", "the duration of traffic capture")
+	captureCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		reader := GetFormReader(map[string]string{"output": *output, "duration": *duration})
+		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/capture", reader)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(resp)
+		return nil
+	}
+	return captureCmd
+}
+
+func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
+	replayCmd := &cobra.Command{
+		Use:   "replay [flags]",
+		Short: "",
+	}
+	input := replayCmd.PersistentFlags().String("input", "", "directory for traffic files")
+	speed := replayCmd.PersistentFlags().Float64("speed", 1, "replay speed")
+	username := replayCmd.PersistentFlags().String("username", "", "the username to connect to TiDB for replay")
+	password := replayCmd.PersistentFlags().String("password", "", "the password to connect to TiDB for replay")
+	replayCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		reader := GetFormReader(map[string]string{"input": *input, "speed": strconv.FormatFloat(*speed, 'f', -1, 64), "username": *username, "password": *password})
+		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/replay", reader)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(resp)
+		return nil
+	}
+	return replayCmd
+}
+
+func GetTrafficCancelCmd(ctx *Context) *cobra.Command {
+	cancelCmd := &cobra.Command{
+		Use:   "cancel",
+		Short: "",
+	}
+	cancelCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/cancel", nil)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(resp)
+		return nil
+	}
+	return cancelCmd
+}
+
+func GetTrafficShowCmd(ctx *Context) *cobra.Command {
+	showCmd := &cobra.Command{
+		Use:   "show",
+		Short: "",
+	}
+	showCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		resp, err := doRequest(cmd.Context(), ctx, http.MethodGet, "/api/traffic/show", nil)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(resp)
+		return nil
+	}
+	return showCmd
+}

--- a/lib/cli/util.go
+++ b/lib/cli/util.go
@@ -40,6 +40,9 @@ func doRequest(ctx context.Context, bctx *Context, method string, url string, rd
 		return "", err
 	}
 
+	if method == http.MethodPost {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
 	req.URL.Host = net.JoinHostPort(bctx.Host, fmt.Sprintf("%d", bctx.Port))
 	res, err := bctx.Client.Do(req)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #669 

Problem Summary:
Support tiproxyctl to capture, replay, and cancel traffic jobs

What is changed and how it works:
- Add sub commands on tiproxyctl

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

run `tiproxyctl traffic capture`, `tiproxyctl traffic replay`, `tiproxyctl traffic cancel`, and `tiproxyctl traffic show`.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [x] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
