### PR TITLE
sqlreplay, backend: fix bugs to make traffic replay runnable

### DIFF
--- a/pkg/proxy/client/client_conn.go
+++ b/pkg/proxy/client/client_conn.go
@@ -75,7 +75,7 @@ func (cc *ClientConnection) processMsg(ctx context.Context) error {
 			return err
 		}
 		err = cc.connMgr.ExecuteCmd(ctx, clientPkt)
-		if err != nil {
+		if err != nil && !pnet.IsMySQLError(err) {
 			return err
 		}
 		if pnet.Command(clientPkt[0]) == pnet.ComQuit {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -150,8 +150,8 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
 			return false, nil, 0, nil
 		}
 
-		connID := s.mu.connID
 		s.mu.connID++
+		connID := s.mu.connID
 		logger := s.logger.With(zap.Uint64("connID", connID), zap.String("client_addr", conn.RemoteAddr().String()),
 			zap.String("addr", addr))
 		clientConn := client.NewClientConnection(logger.Named("conn"), conn, s.certMgr.ServerSQLTLS(), s.certMgr.SQLTLS(),

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -258,7 +258,7 @@ func TestRecoverPanic(t *testing.T) {
 	require.NoError(t, err)
 	server, err := NewSQLServer(lg, &config.Config{}, certManager, nil, &mockHsHandler{
 		handshakeResp: func(ctx backend.ConnContext, _ *pnet.HandshakeResp) error {
-			if ctx.Value(backend.ConnContextKeyConnID).(uint64) == 0 {
+			if ctx.Value(backend.ConnContextKeyConnID).(uint64) == 1 {
 				panic("HandleHandshakeResp panic")
 			}
 			return nil

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -25,14 +25,16 @@ type Job interface {
 }
 
 type job struct {
+	Status    string
 	StartTime time.Time
 	Duration  time.Duration
 	Progress  float64
-	Error     error
+	// TODO: error can not be marshaled.
+	Error error
 }
 
 func (job *job) IsRunning() bool {
-	return job.Error == nil
+	return job.Error == nil && job.Progress < 1
 }
 
 // TODO: refine the output

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -11,36 +11,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestJobs(t *testing.T) {
+func TestIsRunning(t *testing.T) {
 	tests := []struct {
-		job Job
-		tp  jobType
+		job     Job
+		tp      jobType
+		running bool
 	}{
 		{
-			&captureJob{
+			job: &captureJob{
 				job: job{
 					StartTime: time.Now(),
 					Duration:  10 * time.Second,
 				},
 			},
-			Capture,
+			tp:      Capture,
+			running: true,
 		},
 		{
-			&replayJob{
+			job: &replayJob{
 				job: job{
 					StartTime: time.Now(),
 					Duration:  10 * time.Second,
 				},
 			},
-			Replay,
+			tp:      Replay,
+			running: true,
+		},
+		{
+			job: &captureJob{
+				job: job{
+					StartTime: time.Now().Add(-5 * time.Second),
+					Duration:  10 * time.Second,
+					Progress:  0.5,
+					Error:     errors.New("stopped manually"),
+				},
+			},
+			tp:      Capture,
+			running: false,
+		},
+		{
+			job: &replayJob{
+				job: job{
+					StartTime: time.Now().Add(-20 * time.Second),
+					Duration:  10 * time.Second,
+					Progress:  1.0,
+				},
+			},
+			tp:      Replay,
+			running: false,
 		},
 	}
 
 	for i, test := range tests {
 		require.Equal(t, test.tp, test.job.Type(), "case %d", i)
-		require.True(t, test.job.IsRunning(), "case %d", i)
-		test.job.SetProgress(0.5, errors.New("stopped manually"))
-		require.False(t, test.job.IsRunning(), "case %d", i)
+		require.Equal(t, test.running, test.job.IsRunning(), "case %d", i)
 		require.NotEmpty(t, test.job.String(), "case %d", i)
+	}
+}
+
+func TestSetProgress(t *testing.T) {
+	tests := []struct {
+		progress         float64
+		err              error
+		expectedProgress float64
+		running          bool
+	}{
+		{
+			progress:         0.5,
+			err:              nil,
+			expectedProgress: 0.5,
+			running:          true,
+		},
+		{
+			progress:         1.0,
+			err:              errors.New("mock error"),
+			expectedProgress: 1.0,
+			running:          false,
+		},
+	}
+
+	for i, test := range tests {
+		job := &captureJob{
+			job: job{
+				StartTime: time.Now(),
+				Duration:  10 * time.Second,
+			},
+		}
+		job.SetProgress(test.progress, test.err)
+		require.Equal(t, test.expectedProgress, job.Progress, "case %d", i)
+		require.Equal(t, test.running, job.IsRunning(), "case %d", i)
 	}
 }

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -24,6 +24,8 @@ func (mockCertMgr) SQLTLS() *tls.Config {
 var _ capture.Capture = (*mockCapture)(nil)
 
 type mockCapture struct {
+	progress float64
+	err      error
 }
 
 func (m *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64) {
@@ -33,31 +35,39 @@ func (m *mockCapture) Close() {
 }
 
 func (m *mockCapture) Progress() (float64, error) {
-	return 0, nil
+	return m.progress, m.err
 }
 
 func (m *mockCapture) Stop(err error) {
+	m.err = err
 }
 
-func (mockCapture) Start(capture.CaptureConfig) error {
+func (m *mockCapture) Start(capture.CaptureConfig) error {
+	m.progress = 0
+	m.err = nil
 	return nil
 }
 
 var _ replay.Replay = (*mockReplay)(nil)
 
 type mockReplay struct {
+	progress float64
+	err      error
 }
 
 func (m *mockReplay) Close() {
 }
 
 func (m *mockReplay) Progress() (float64, error) {
-	return 0, nil
+	return m.progress, m.err
 }
 
 func (m *mockReplay) Start(cfg replay.ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {
+	m.progress = 0
+	m.err = nil
 	return nil
 }
 
 func (m *mockReplay) Stop(err error) {
+	m.err = err
 }

--- a/pkg/sqlreplay/replay/handshake_handler.go
+++ b/pkg/sqlreplay/replay/handshake_handler.go
@@ -1,0 +1,29 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+)
+
+var _ backend.HandshakeHandler = (*handshakeHandler)(nil)
+
+type handshakeHandler struct {
+	backend.HandshakeHandler
+}
+
+func NewHandshakeHandler(hsHsHandler backend.HandshakeHandler) *handshakeHandler {
+	return &handshakeHandler{
+		HandshakeHandler: hsHsHandler,
+	}
+}
+
+func (handler *handshakeHandler) GetCapability() pnet.Capability {
+	return pnet.ClientLongPassword | pnet.ClientFoundRows |
+		pnet.ClientODBC | pnet.ClientLocalFiles | pnet.ClientInteractive | pnet.ClientLongFlag | pnet.ClientSSL |
+		pnet.ClientTransactions | pnet.ClientReserved | pnet.ClientSecureConnection |
+		pnet.ClientMultiResults | pnet.ClientPluginAuth | pnet.ClientPluginAuthLenencClientData |
+		pnet.ClientProtocol41 | pnet.ClientDeprecateEOF
+}

--- a/pkg/sqlreplay/report/tables.go
+++ b/pkg/sqlreplay/report/tables.go
@@ -22,7 +22,7 @@ const (
 	values(?, ?, ?, ?, ?, ?, ?, ?) on duplicate key update count = count + ?`
 
 	createOtherTable = `create table tiproxy_traffic_replay.other_errors(
-    err_type text primary key,
+    err_type varchar(256) primary key,
     sample_err_msg text,
     sample_replay_time timestamp,
     count bigint)`


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #642

Problem Summary:
There are some bugs when I manually test traffic capture and replay.

What is changed and how it works:
- Fix some bugs to make it runnable
- Refine logs for troubleshoot 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
