### PR TITLE
sqlreplay: write meta to the output directory

### DIFF
--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -28,7 +28,7 @@ const (
 const (
 	statusIdle = iota
 	statusRunning
-	// capture is stopped but data is writting
+	// capture is stopped but data is writing
 	statusStopping
 )
 

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -62,7 +62,8 @@ func (rdb *reportDB) connect(ctx context.Context) error {
 }
 
 func (rdb *reportDB) initTables(ctx context.Context) error {
-	for _, stmt := range []string{dropDatabase, createDatabase, createFailTable, createOtherTable} {
+	// Do not truncate database in case that multiple TiProxy instances are running.
+	for _, stmt := range []string{createDatabase, createFailTable, createOtherTable} {
 		if err := rdb.conn.Query(ctx, stmt); err != nil {
 			return errors.Wrapf(err, "initialize report database and tables failed")
 		}

--- a/pkg/sqlreplay/report/tables.go
+++ b/pkg/sqlreplay/report/tables.go
@@ -4,10 +4,9 @@
 package report
 
 const (
-	dropDatabase   = "drop database if exists tiproxy_traffic_replay"
-	createDatabase = `create database tiproxy_traffic_replay`
+	createDatabase = `create database if not exists tiproxy_traffic_replay`
 
-	createFailTable = `create table tiproxy_traffic_replay.fail(
+	createFailTable = `create table if not exists tiproxy_traffic_replay.fail(
     cmd_type varchar(32),
     digest varchar(128),
     sample_stmt text,
@@ -21,7 +20,7 @@ const (
 	cmd_type, digest, sample_stmt, sample_err_msg, sample_conn_id, sample_capture_time, sample_replay_time, count)
 	values(?, ?, ?, ?, ?, ?, ?, ?) on duplicate key update count = count + ?`
 
-	createOtherTable = `create table tiproxy_traffic_replay.other_errors(
+	createOtherTable = `create table if not exists tiproxy_traffic_replay.other_errors(
     err_type varchar(256) primary key,
     sample_err_msg text,
     sample_replay_time timestamp,

--- a/pkg/sqlreplay/store/meta.go
+++ b/pkg/sqlreplay/store/meta.go
@@ -1,0 +1,46 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+)
+
+const (
+	metaFile = "meta"
+)
+
+type Meta struct {
+	Duration time.Duration
+	Cmds     uint64
+}
+
+func (m *Meta) Write(path string) error {
+	filePath := filepath.Join(path, metaFile)
+	b, err := json.Marshal(m)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err = os.WriteFile(filePath, b, 0666); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (m *Meta) Read(path string) error {
+	filePath := filepath.Join(path, metaFile)
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err = json.Unmarshal(b, m); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/pkg/sqlreplay/store/meta.go
+++ b/pkg/sqlreplay/store/meta.go
@@ -27,7 +27,7 @@ func (m *Meta) Write(path string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if err = os.WriteFile(filePath, b, 0666); err != nil {
+	if err = os.WriteFile(filePath, b, 0600); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil

--- a/pkg/sqlreplay/store/meta_test.go
+++ b/pkg/sqlreplay/store/meta_test.go
@@ -1,0 +1,31 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeta(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 2; i++ {
+		m1 := Meta{
+			Duration: 10 * time.Second,
+			Cmds:     100,
+		}
+		require.NoError(t, m1.Write(dir))
+		m2 := Meta{}
+		require.NoError(t, m2.Read(dir))
+		require.Equal(t, m1, m2)
+	}
+
+	m3 := Meta{}
+	require.NoError(t, os.Remove(filepath.Join(dir, metaFile)))
+	require.Error(t, m3.Read(dir))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #672 

Problem Summary:
To output the progress of replay, replay needs to know the total duration or commands.

What is changed and how it works:
- `capture` writes duration and command count to `meta`
- `replay` reads the duration and command count to know the progress

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
