### PR TITLE
capture, backend: output session states to traffic files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	go.uber.org/ratelimit v0.2.0
 	go.uber.org/zap v1.26.0
 	google.golang.org/grpc v1.54.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
@@ -117,7 +118,6 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -1438,6 +1438,7 @@ func TestCapture(t *testing.T) {
 	ts := newBackendMgrTester(t, func(config *testConfig) {
 		config.clientConfig.dbName = "test"
 		config.proxyConfig.connectionID = 100
+		config.proxyConfig.capture = &mockCapture{}
 	})
 	runners := []runner{
 		// 1st handshake

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -1436,13 +1436,23 @@ func TestProcessSignalsPanic(t *testing.T) {
 
 func TestCapture(t *testing.T) {
 	ts := newBackendMgrTester(t, func(config *testConfig) {
+		config.clientConfig.dbName = "test"
 		config.proxyConfig.connectionID = 100
 	})
 	runners := []runner{
 		// 1st handshake
 		{
-			client:  ts.mc.authenticate,
-			proxy:   ts.firstHandshake4Proxy,
+			client: ts.mc.authenticate,
+			proxy: func(clientIO, backendIO pnet.PacketIO) error {
+				now := time.Now()
+				err := ts.firstHandshake4Proxy(clientIO, backendIO)
+				require.NoError(t, err)
+				cpt := ts.mp.cpt.(*mockCapture)
+				require.Equal(t, "test", cpt.db)
+				require.GreaterOrEqual(t, cpt.startTime, now)
+				require.EqualValues(t, 100, cpt.connID)
+				return nil
+			},
 			backend: ts.handshake4Backend,
 		},
 		{
@@ -1458,9 +1468,15 @@ func TestCapture(t *testing.T) {
 				require.Equal(t, packet, cpt.packet)
 				require.GreaterOrEqual(t, cpt.startTime, now)
 				require.EqualValues(t, 100, cpt.connID)
+				require.Contains(t, cpt.initSql, "SET SESSION_STATES")
 				return err
 			},
 			backend: func(packetIO pnet.PacketIO) error {
+				// respond to `SHOW SESSION STATES`
+				ts.mb.respondType = responseTypeResultSet
+				err := ts.mb.respond(packetIO)
+				require.NoError(ts.t, err)
+				// respond to `select 1`
 				ts.mb.respondType = responseTypeResultSet
 				ts.mb.columns = 1
 				ts.mb.rows = 1

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -115,6 +115,8 @@ func (mp *mockProxy) directQuery(_, backendIO pnet.PacketIO) error {
 var _ capture.Capture = (*mockCapture)(nil)
 
 type mockCapture struct {
+	db        string
+	initSql   string
 	packet    []byte
 	startTime time.Time
 	connID    uint64
@@ -127,10 +129,17 @@ func (mc *mockCapture) Start(cfg capture.CaptureConfig) error {
 func (mc *mockCapture) Stop(err error) {
 }
 
-func (mc *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64) {
+func (mc *mockCapture) InitConn(startTime time.Time, connID uint64, dbname string) {
+	mc.db = dbname
+	mc.startTime = startTime
+	mc.connID = connID
+}
+
+func (mc *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error)) {
 	mc.packet = packet
 	mc.startTime = startTime
 	mc.connID = connID
+	mc.initSql, _ = initSession()
 }
 
 func (mc *mockCapture) Progress() (float64, error) {

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -22,6 +22,7 @@ type proxyConfig struct {
 	backendTLSConfig  *tls.Config
 	handler           *CustomHandshakeHandler
 	bcConfig          *BCConfig
+	capture           capture.Capture
 	username          string
 	password          string
 	sessionToken      string
@@ -58,7 +59,7 @@ func newMockProxy(t *testing.T, cfg *proxyConfig) *mockProxy {
 		proxyConfig:        cfg,
 		logger:             lg.Named("mockProxy"),
 		text:               text,
-		BackendConnManager: NewBackendConnManager(lg, cfg.handler, &mockCapture{}, cfg.connectionID, cfg.bcConfig),
+		BackendConnManager: NewBackendConnManager(lg, cfg.handler, cfg.capture, cfg.connectionID, cfg.bcConfig),
 	}
 	mp.cmdProcessor.capability = cfg.capability
 	return mp

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -281,10 +281,8 @@ func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64, ini
 		initPacket = append(initPacket, hack.Slice(sql)...)
 		command := cmd.NewCommand(initPacket, startTime, connID)
 		c.Lock()
-		if c.status == statusRunning {
-			if c.putCommand(command) {
-				c.conns[connID] = struct{}{}
-			}
+		if c.putCommand(command) {
+			c.conns[connID] = struct{}{}
 		}
 		c.Unlock()
 	}
@@ -304,6 +302,9 @@ func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64, ini
 }
 
 func (c *capture) putCommand(command *cmd.Command) bool {
+	if c.status != statusRunning {
+		return false
+	}
 	select {
 	case c.cmdCh <- command:
 		return true

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -15,6 +15,7 @@ import (
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/store"
+	"github.com/siddontang/go/hack"
 	"go.uber.org/zap"
 )
 
@@ -38,8 +39,10 @@ type Capture interface {
 	// Stop stops the capture.
 	// err means the error that caused the capture to stop. nil means the capture stopped manually.
 	Stop(err error)
+	// InitConn is called when a new connection is created.
+	InitConn(startTime time.Time, connID uint64, db string)
 	// Capture captures traffic
-	Capture(packet []byte, startTime time.Time, connID uint64)
+	Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error))
 	// Progress returns the progress of the capture job
 	Progress() (float64, error)
 	// Close closes the capture
@@ -94,6 +97,7 @@ var _ Capture = (*capture)(nil)
 type capture struct {
 	sync.Mutex
 	cfg          CaptureConfig
+	conns        map[uint64]struct{}
 	wg           waitgroup.WaitGroup
 	cancel       context.CancelFunc
 	cmdCh        chan *cmd.Command
@@ -131,6 +135,7 @@ func (c *capture) Start(cfg CaptureConfig) error {
 	c.filteredCmds = 0
 	c.status = statusRunning
 	c.err = nil
+	c.conns = make(map[uint64]struct{})
 	childCtx, cancel := context.WithTimeout(context.Background(), c.cfg.Duration)
 	c.cancel = cancel
 	bufCh := make(chan *bytes.Buffer, cfg.maxBuffers)
@@ -235,11 +240,53 @@ func (c *capture) flushBuffer(bufCh <-chan *bytes.Buffer) {
 	c.writeMeta(time.Since(startTime), capturedCmds)
 }
 
-func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64) {
+func (c *capture) InitConn(startTime time.Time, connID uint64, db string) {
 	c.Lock()
 	defer c.Unlock()
 	if c.status != statusRunning {
 		return
+	}
+	if db != "" {
+		packet := make([]byte, 0, len(db)+1)
+		packet = append(packet, pnet.ComInitDB.Byte())
+		packet = append(packet, hack.Slice(db)...)
+		command := cmd.NewCommand(packet, startTime, connID)
+		if command == nil {
+			return
+		}
+		c.putCommand(command)
+	}
+	c.conns[connID] = struct{}{}
+}
+
+func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error)) {
+	c.Lock()
+	if c.status != statusRunning {
+		c.Unlock()
+		return
+	}
+	_, inited := c.conns[connID]
+	c.Unlock()
+
+	// If this is the first command for this connection, record a `set session_states` statement.
+	if !inited {
+		// initSession is slow, do not call it in the lock.
+		sql, err := initSession()
+		if err != nil {
+			c.lg.Warn("failed to init session", zap.Error(err))
+			return
+		}
+		initPacket := make([]byte, 0, len(sql)+1)
+		initPacket = append(initPacket, pnet.ComQuery.Byte())
+		initPacket = append(initPacket, hack.Slice(sql)...)
+		command := cmd.NewCommand(initPacket, startTime, connID)
+		c.Lock()
+		if c.status == statusRunning {
+			if c.putCommand(command) {
+				c.conns[connID] = struct{}{}
+			}
+		}
+		c.Unlock()
 	}
 
 	command := cmd.NewCommand(packet, startTime, connID)
@@ -250,12 +297,20 @@ func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64) {
 	if command.Type == pnet.ComChangeUser {
 		return
 	}
-	// TODO: handle QUIT
+	// TODO: handle QUIT and delete c.conns[connID]
+	c.Lock()
+	defer c.Unlock()
+	c.putCommand(command)
+}
+
+func (c *capture) putCommand(command *cmd.Command) bool {
 	select {
 	case c.cmdCh <- command:
+		return true
 	default:
 		// Don't wait, otherwise the QPS may be affected.
 		c.stopNoLock(errors.New("encoding traffic is too slow, buffer is full"))
+		return false
 	}
 }
 
@@ -293,6 +348,7 @@ func (c *capture) stopNoLock(err error) {
 	if c.err == nil {
 		c.err = err
 	}
+	c.conns = map[uint64]struct{}{}
 }
 
 func (c *capture) stop(err error) {

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -40,7 +40,7 @@ func TestStartAndStop(t *testing.T) {
 	data := writer.getData()
 	require.Greater(t, len(data), 0)
 	require.Contains(t, string(data), "select 1")
-	require.Equal(t, uint64(1), cpt.capturedCmds)
+	require.Equal(t, uint64(2), cpt.capturedCmds)
 
 	// stop capture and traffic should not be outputted
 	cpt.Capture(packet, time.Now(), 100, mockInitSession)
@@ -190,7 +190,7 @@ func TestProgress(t *testing.T) {
 
 	m := store.Meta{}
 	require.NoError(t, m.Read(cfg.Output))
-	require.Equal(t, uint64(1), m.Cmds)
+	require.Equal(t, uint64(2), m.Cmds)
 	require.GreaterOrEqual(t, m.Duration, 5*time.Second)
 	require.Less(t, m.Duration, 10*time.Second)
 }

--- a/pkg/sqlreplay/capture/mock_test.go
+++ b/pkg/sqlreplay/capture/mock_test.go
@@ -37,3 +37,7 @@ func (w *mockWriter) getData() []byte {
 func (w *mockWriter) Close() error {
 	return nil
 }
+
+func mockInitSession() (string, error) {
+	return "init session", nil
+}

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -28,7 +28,10 @@ type mockCapture struct {
 	err      error
 }
 
-func (m *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64) {
+func (m *mockCapture) InitConn(startTime time.Time, connID uint64, db string) {
+}
+
+func (m *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error)) {
 }
 
 func (m *mockCapture) Close() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #674 

Problem Summary:
For existing connections, the session states are not replayed.

What is changed and how it works:
- Output `SET SESSION_STATES` to traffic files for existing connections.
- Output `USE db` to traffic files for new connections.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
