### PR TITLE
backend, capture: write quit command to traffic files

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -775,7 +775,7 @@ func (mgr *BackendConnManager) Close() error {
 			}
 		}
 	}
-	// Maybe it's unexpectedly closing without a QUIT command, explictly add one.
+	// Maybe it's unexpectedly closing without a QUIT command, explicitly add one.
 	if mgr.cpt != nil && !reflect.ValueOf(mgr.cpt).IsNil() {
 		mgr.cpt.Capture([]byte{pnet.ComQuit.Byte()}, time.Now(), mgr.connectionID, nil)
 	}

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -775,6 +775,10 @@ func (mgr *BackendConnManager) Close() error {
 			}
 		}
 	}
+	// Maybe it's unexpectedly closing without a QUIT command, explictly add one.
+	if mgr.cpt != nil && !reflect.ValueOf(mgr.cpt).IsNil() {
+		mgr.cpt.Capture([]byte{pnet.ComQuit.Byte()}, time.Now(), mgr.connectionID, nil)
+	}
 	mgr.closeStatus.Store(statusClosed)
 	return errors.Collect(ErrCloseConnMgr, connErr, handErr)
 }

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -1484,6 +1484,15 @@ func TestCapture(t *testing.T) {
 				return ts.mb.respond(packetIO)
 			},
 		},
+		{
+			proxy: func(clientIO, backendIO pnet.PacketIO) error {
+				_ = ts.mp.Close()
+				ts.closed = true
+				cpt := ts.mp.cpt.(*mockCapture)
+				require.Equal(t, []byte{pnet.ComQuit.Byte()}, cpt.packet)
+				return nil
+			},
+		},
 	}
 	ts.runTests(runners)
 }

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -140,7 +140,9 @@ func (mc *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64
 	mc.packet = packet
 	mc.startTime = startTime
 	mc.connID = connID
-	mc.initSql, _ = initSession()
+	if initSession != nil {
+		mc.initSql, _ = initSession()
+	}
 }
 
 func (mc *mockCapture) Progress() (float64, error) {

--- a/pkg/proxy/net/command.go
+++ b/pkg/proxy/net/command.go
@@ -105,3 +105,12 @@ func (f *Command) UnmarshalText(o []byte) error {
 	}
 	return nil
 }
+
+func CommandFromString(str string) Command {
+	for e, c := range commandStrs {
+		if c == str {
+			return Command(e)
+		}
+	}
+	return ComEnd
+}

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -225,17 +225,3 @@ func writeString(key, value string, writer *bytes.Buffer) error {
 	}
 	return nil
 }
-
-func writeByte(key string, value byte, writer *bytes.Buffer) error {
-	var err error
-	if _, err = writer.WriteString(key); err != nil {
-		return errors.WithStack(err)
-	}
-	if err = writer.WriteByte(value); err != nil {
-		return errors.WithStack(err)
-	}
-	if err = writer.WriteByte('\n'); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -89,7 +89,7 @@ func (c *Command) Encode(writer *bytes.Buffer) error {
 		return err
 	}
 	if c.Type != pnet.ComQuery {
-		if err = writeByte(keyType, c.Type.Byte(), writer); err != nil {
+		if err = writeString(keyType, c.Type.String(), writer); err != nil {
 			return err
 		}
 	}
@@ -156,7 +156,7 @@ func (c *Command) Decode(reader LineReader) error {
 			if c.Type != pnet.ComQuery {
 				return errors.Errorf("%s, line %d: redundant Cmd_type: %s, Cmd_type was %v", filename, lineIdx, line, c.Type)
 			}
-			c.Type = pnet.Command(value[0])
+			c.Type = pnet.CommandFromString(value)
 		case keySuccess:
 			c.Succeess = value == "true"
 		case keyPayloadLen:


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #676

Problem Summary:
Some clients are disconnected unexpectedly, the QUIT commands should still be outputted to traffic files.

What is changed and how it works:
- Call `Capture` when `BackendConnManager` closes
- `Capture` handles duplicated `QUIT` commands

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
