### PR TITLE
sqlreplay, net: maintain the mapping of prepared statement ID and text

### DIFF
--- a/pkg/proxy/net/mysql_test.go
+++ b/pkg/proxy/net/mysql_test.go
@@ -113,15 +113,32 @@ func TestCheckSqlPort(t *testing.T) {
 
 func TestPrepareStmts(t *testing.T) {
 	args := []any{
+		nil,
 		"hello",
-		uint64(1),
-		int64(1),
-		float64(1),
+		byte(10),
+		int16(-100),
+		int32(-200),
+		int64(-300),
+		uint16(100),
+		uint32(200),
+		uint64(300),
+		float32(1.1),
+		float64(1.2),
+		nil,
 	}
 
-	b := MakePrepareStmtPacket("select ?")
+	b := MakePrepareStmtRequest("select ?")
 	require.Len(t, b, len("select ?")+1)
 
-	_, err := MakeExecuteStmtPacket(1, args)
+	data1, err := MakeExecuteStmtRequest(1, args)
 	require.NoError(t, err)
+
+	stmtID, pArgs, err := ParseExecuteStmtRequest(data1, len(args))
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), stmtID)
+	require.EqualValues(t, args, pArgs)
+
+	data2, err := MakeExecuteStmtRequest(1, pArgs)
+	require.NoError(t, err)
+	require.Equal(t, data1, data2)
 }

--- a/pkg/proxy/net/protocol.go
+++ b/pkg/proxy/net/protocol.go
@@ -154,6 +154,22 @@ func DumpUint16(buffer []byte, n uint16) []byte {
 	return buffer
 }
 
+func Uint16ToBytes(n uint16) []byte {
+	return []byte{
+		byte(n),
+		byte(n >> 8),
+	}
+}
+
+func Uint32ToBytes(n uint32) []byte {
+	return []byte{
+		byte(n),
+		byte(n >> 8),
+		byte(n >> 16),
+		byte(n >> 24),
+	}
+}
+
 func Uint64ToBytes(n uint64) []byte {
 	return []byte{
 		byte(n),

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -33,8 +34,10 @@ type LineReader interface {
 }
 
 type Command struct {
+	PreparedStmt string
+	Params       []any
+	digest       string
 	// Payload starts with command type so that replay can reuse this byte array.
-	digest   string
 	Payload  []byte
 	StartTs  time.Time
 	ConnID   uint64
@@ -191,12 +194,14 @@ func (c *Command) Decode(reader LineReader) error {
 }
 
 func (c *Command) Digest() string {
-	if c.digest == "" {
-		// TODO: ComStmtExecute
+	if len(c.digest) == 0 {
 		switch c.Type {
 		case pnet.ComQuery, pnet.ComStmtPrepare:
 			stmt := hack.String(c.Payload[1:])
 			_, digest := parser.NormalizeDigest(stmt)
+			c.digest = digest.String()
+		case pnet.ComStmtExecute:
+			_, digest := parser.NormalizeDigest(c.PreparedStmt)
 			c.digest = digest.String()
 		}
 	}
@@ -204,10 +209,11 @@ func (c *Command) Digest() string {
 }
 
 func (c *Command) QueryText() string {
-	// TODO: ComStmtExecute
 	switch c.Type {
 	case pnet.ComQuery, pnet.ComStmtPrepare:
 		return hack.String(c.Payload[1:])
+	case pnet.ComStmtExecute:
+		return fmt.Sprintf("%s params=%v", c.PreparedStmt, c.Params)
 	}
 	return ""
 }

--- a/pkg/sqlreplay/cmd/cmd_test.go
+++ b/pkg/sqlreplay/cmd/cmd_test.go
@@ -134,4 +134,16 @@ func TestDigest(t *testing.T) {
 
 	cmd3 := NewCommand(append([]byte{pnet.ComFieldList.Byte()}, []byte("xxx")...), time.Now(), 100)
 	require.Empty(t, cmd3.Digest())
+
+	cmd4 := NewCommand(append([]byte{pnet.ComStmtPrepare.Byte()}, []byte("select ?")...), time.Now(), 100)
+	require.Equal(t, cmd1.Digest(), cmd4.Digest())
+	require.Equal(t, "select ?", cmd4.QueryText())
+
+	data, err := pnet.MakeExecuteStmtRequest(1, []any{1})
+	require.NoError(t, err)
+	cmd5 := NewCommand(data, time.Now(), 100)
+	cmd5.PreparedStmt = "select ?"
+	cmd5.Params = []any{1}
+	require.Equal(t, cmd1.Digest(), cmd5.Digest())
+	require.Equal(t, "select ? params=[1]", cmd5.QueryText())
 }

--- a/pkg/sqlreplay/conn/conn_test.go
+++ b/pkg/sqlreplay/conn/conn_test.go
@@ -75,3 +75,52 @@ func TestExecuteCmd(t *testing.T) {
 	cancel()
 	wg.Wait()
 }
+
+func TestExecuteError(t *testing.T) {
+	tests := []struct {
+		prepare   func(*mockBackendConn) []byte
+		digest    string
+		queryText string
+	}{
+		{
+			prepare: func(bc *mockBackendConn) []byte {
+				return append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...)
+			},
+			digest:    "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471",
+			queryText: "select 1",
+		},
+		{
+			prepare: func(bc *mockBackendConn) []byte {
+				request, err := pnet.MakeExecuteStmtRequest(1, []any{uint64(100), "abc", nil})
+				require.NoError(t, err)
+				bc.prepareStmt = "select ?"
+				bc.paramNum = 3
+				return request
+			},
+			digest:    "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471",
+			queryText: "select ? params=[100 abc <nil>]",
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	var wg waitgroup.WaitGroup
+	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
+	conn := NewConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	backendConn := &mockBackendConn{execErr: errors.New("mock error")}
+	conn.backendConn = backendConn
+	childCtx, cancel := context.WithCancel(context.Background())
+	wg.RunWithRecover(func() {
+		conn.Run(childCtx)
+	}, nil, lg)
+	for i, test := range tests {
+		request := test.prepare(backendConn)
+		conn.ExecuteCmd(cmd.NewCommand(request, time.Now(), 100))
+		exp := <-exceptionCh
+		require.Equal(t, Fail, exp.Type(), "case %d", i)
+		require.Equal(t, "mock error", exp.(*FailException).Error(), "case %d", i)
+		require.Equal(t, test.digest, exp.(*FailException).command.Digest(), "case %d", i)
+		require.Equal(t, test.queryText, exp.(*FailException).command.QueryText(), "case %d", i)
+	}
+	cancel()
+	wg.Wait()
+}

--- a/pkg/sqlreplay/conn/exception.go
+++ b/pkg/sqlreplay/conn/exception.go
@@ -80,7 +80,7 @@ func NewFailException(err error, command *cmd.Command) *FailException {
 	}
 	var b []byte
 	switch command.Type {
-	case pnet.ComQuery, pnet.ComStmtPrepare:
+	case pnet.ComQuery, pnet.ComStmtPrepare, pnet.ComStmtExecute:
 		digest := command.Digest()
 		b = make([]byte, 1+len(digest))
 		b[0] = command.Type.Byte()

--- a/pkg/sqlreplay/conn/mock_test.go
+++ b/pkg/sqlreplay/conn/mock_test.go
@@ -37,10 +37,12 @@ func (m *mockBackendConnMgr) Close() error {
 var _ BackendConn = (*mockBackendConn)(nil)
 
 type mockBackendConn struct {
-	cmds    atomic.Int32
-	connErr error
-	execErr error
-	close   atomic.Bool
+	cmds        atomic.Int32
+	connErr     error
+	execErr     error
+	close       atomic.Bool
+	prepareStmt string
+	paramNum    int
 }
 
 func (c *mockBackendConn) Connect(ctx context.Context) error {
@@ -69,6 +71,10 @@ func (c *mockBackendConn) PrepareStmt(ctx context.Context, stmt string) (uint32,
 func (c *mockBackendConn) ExecuteStmt(ctx context.Context, stmtID uint32, args []any) error {
 	c.cmds.Add(1)
 	return c.execErr
+}
+
+func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int) {
+	return c.prepareStmt, c.paramNum
 }
 
 func (c *mockBackendConn) Close() {

--- a/pkg/sqlreplay/conn/prepared_stmt.go
+++ b/pkg/sqlreplay/conn/prepared_stmt.go
@@ -1,0 +1,24 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package conn
+
+const (
+	setSessionStates = "set session_states "
+)
+
+type sessionStates struct {
+	PreparedStmts map[uint32]*preparedStmtInfo `json:"prepared-stmts,omitempty"`
+}
+
+// Prepared stmt in the session states. Used for unmarshal.
+type preparedStmtInfo struct {
+	StmtText   string `json:"text"`
+	ParamTypes []byte `json:"types,omitempty"`
+}
+
+// Used for parsing prepared stmt.
+type preparedStmt struct {
+	text     string
+	paramNum int
+}

--- a/pkg/sqlreplay/report/mock_test.go
+++ b/pkg/sqlreplay/report/mock_test.go
@@ -86,6 +86,10 @@ func (c *mockBackendConn) ExecuteStmt(ctx context.Context, stmtID uint32, args [
 	return c.execErr
 }
 
+func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int) {
+	return "", 0
+}
+
 func (c *mockBackendConn) clear() {
 	c.stmtID = nil
 	c.args = nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #678

Problem Summary:
When replaying `ComStmtExecute` fails, thes text and args can not be reported.

What is changed and how it works:
- Maintain a mapping of prepared statement ID and text+paramNum in `backendConn`
- When `ComStmtExecute` fails, query the text and parse the args in the request

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
