### PR TITLE
capture: do not capture sensitive commands

### DIFF
--- a/pkg/sqlreplay/capture/filter.go
+++ b/pkg/sqlreplay/capture/filter.go
@@ -8,6 +8,7 @@ import (
 )
 
 var sensitiveKeywords = [][]string{
+	// contain passwords
 	{
 		"CREATE", "USER",
 	},
@@ -20,6 +21,7 @@ var sensitiveKeywords = [][]string{
 	{
 		"GRANT",
 	},
+	// contain cloud storage url
 	{
 		"BACKUP",
 	},
@@ -28,6 +30,10 @@ var sensitiveKeywords = [][]string{
 	},
 	{
 		"IMPORT",
+	},
+	// not supported yet
+	{
+		"LOAD", "DATA",
 	},
 }
 

--- a/pkg/sqlreplay/capture/filter.go
+++ b/pkg/sqlreplay/capture/filter.go
@@ -1,0 +1,53 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"github.com/pingcap/tiproxy/pkg/util/lex"
+)
+
+var sensitiveKeywords = [][]string{
+	{
+		"CREATE", "USER",
+	},
+	{
+		"ALTER", "USER",
+	},
+	{
+		"SET", "PASSWORD",
+	},
+	{
+		"GRANT",
+	},
+	{
+		"BACKUP",
+	},
+	{
+		"RESTORE",
+	},
+	{
+		"IMPORT",
+	},
+}
+
+func IsSensitiveSQL(sql string) bool {
+	lexer := lex.NewLexer(sql)
+	keyword := lexer.NextToken()
+	if len(keyword) == 0 {
+		return false
+	}
+	for _, kw := range sensitiveKeywords {
+		if keyword != kw[0] {
+			continue
+		}
+		if len(kw) <= 1 {
+			return true
+		}
+		keyword = lexer.NextToken()
+		if keyword == kw[1] {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sqlreplay/capture/filter_test.go
+++ b/pkg/sqlreplay/capture/filter_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSenstiveSQL(t *testing.T) {
+	tests := []struct {
+		sql       string
+		sensitive bool
+	}{
+		{`SELECT * FROM table_name`, false},
+		{`grant ALL PRIVILEGES ON database_name.* TO 'username'@'localhost' IDENTIFIED BY 'password'`, true},
+		{`CREATE USER 'new_user'@'localhost' IDENTIFIED BY 'secure_password';`, true},
+		{` ALTER USER 'existing_user'@'localhost' IDENTIFIED BY 'new_password'`, true},
+		{`/*hello */set PASSWORD FOR 'username'@'localhost' = PASSWORD('new_password');`, true},
+		{`set global anything = 'hello' `, false},
+		{``, false},
+		{`set`, false},
+	}
+
+	for i, test := range tests {
+		require.Equal(t, test.sensitive, IsSensitiveSQL(test.sql), "case %d", i)
+	}
+}

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
-	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/report"
@@ -168,12 +167,6 @@ func (r *replay) readCommands(ctx context.Context) {
 			}
 			r.Stop(err)
 			break
-		}
-		// Replayer always uses the same username. It has no passwords for other users.
-		// TODO: clear the session states.
-		if command.Type == pnet.ComChangeUser {
-			r.filteredCmds++
-			continue
 		}
 		if captureStartTs.IsZero() {
 			// first command

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -168,7 +168,7 @@ func TestProgress(t *testing.T) {
 	}
 	defer loader.Close()
 
-	cmdCh := make(chan *cmd.Command, 10)
+	cmdCh := make(chan *cmd.Command)
 	replay := NewReplay(zap.NewNop())
 	defer replay.Close()
 	cfg := ReplayConfig{

--- a/pkg/util/lex/lex.go
+++ b/pkg/util/lex/lex.go
@@ -1,0 +1,76 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package lex
+
+type Lexer struct {
+	sql      string
+	curToken []byte
+	curIdx   int
+}
+
+func NewLexer(sql string) *Lexer {
+	return &Lexer{
+		sql:      sql,
+		curToken: make([]byte, 0, 100),
+	}
+}
+
+// It only returns uppercased identifiers and keywords. It's used to search for some specified keywords.
+// It doesn't need to strict but it needs to be fast enough.
+func (l *Lexer) NextToken() string {
+	l.curToken = l.curToken[:0]
+	inSingleLineComment, inMultiLineComment, inSingleQuote, inDoubleQuote := false, false, false, false
+	for ; l.curIdx < len(l.sql); l.curIdx++ {
+		char := l.sql[l.curIdx]
+		switch {
+		case inSingleLineComment:
+			if char == '\n' {
+				inSingleLineComment = false
+			}
+		case inMultiLineComment:
+			if char == '*' {
+				if l.curIdx+1 < len(l.sql) && l.sql[l.curIdx+1] == '/' {
+					inMultiLineComment = false
+					l.curIdx++
+				}
+			}
+		case inSingleQuote:
+			if char == '\\' {
+				l.curIdx++
+			} else if char == '\'' {
+				inSingleQuote = false
+			}
+		case inDoubleQuote:
+			if char == '\\' {
+				l.curIdx++
+			} else if char == '"' {
+				inDoubleQuote = false
+			}
+		case char == '-' && l.curIdx+1 < len(l.sql) && l.sql[l.curIdx+1] == '-':
+			l.curIdx++
+			inSingleLineComment = true
+		case char == '/' && l.curIdx+1 < len(l.sql) && l.sql[l.curIdx+1] == '*':
+			l.curIdx++
+			inMultiLineComment = true
+		case char == '\'':
+			inSingleQuote = true
+		case char == '"':
+			inDoubleQuote = true
+		case char >= 'a' && char <= 'z':
+			l.curToken = append(l.curToken, char-'a'+'A')
+		case char >= 'A' && char <= 'Z' || char == '_':
+			l.curToken = append(l.curToken, char)
+		default:
+			if len(l.curToken) > 0 {
+				l.curIdx++
+				return string(l.curToken)
+			}
+		}
+	}
+
+	if len(l.curToken) > 0 {
+		return string(l.curToken)
+	}
+	return ""
+}

--- a/pkg/util/lex/lex_test.go
+++ b/pkg/util/lex/lex_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package lex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextToken(t *testing.T) {
+	tests := []struct {
+		sql    string
+		tokens []string
+	}{
+		{
+			sql:    `SELECT * FROM table_name`,
+			tokens: []string{"SELECT", "FROM", "TABLE_NAME"},
+		},
+		{
+			sql: `-- comment
+			/* comment * / "
+			*/ SELECT
+	  		-- comment
+			(*)
+			FROM table_name`,
+			tokens: []string{"SELECT", "FROM", "TABLE_NAME"},
+		},
+		{
+			sql: ` SELECT
+			"string /* */
+			" * 'string'
+			FROM '"' "'" '\\' '\'' (table_name)`,
+			tokens: []string{"SELECT", "FROM", "TABLE_NAME"},
+		},
+		{
+			sql:    ` select 123.4e-5 / (1 - 0.9) + @@hello_world 中文`,
+			tokens: []string{"SELECT", "E", "HELLO_WORLD"},
+		},
+		{
+			sql:    `sEleCt ** from; t5ble_name`,
+			tokens: []string{"SELECT", "FROM", "T", "BLE_NAME"},
+		},
+	}
+
+	for i, test := range tests {
+		l := NewLexer(test.sql)
+		tokens := make([]string, 0, len(test.tokens))
+		for {
+			token := l.NextToken()
+			if len(token) == 0 {
+				break
+			}
+			tokens = append(tokens, token)
+		}
+		require.Equal(t, test.tokens, tokens, "case %d", i)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #681

Problem Summary:
Some commands contain passwords or object storage URI, do not capture them.

What is changed and how it works:
- Add a simple `Lexer` to parse keywords.
- Do not capture some specific queries or commands.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
