### PR TITLE
report, conn: output capture time and replay time to the report

### DIFF
--- a/pkg/sqlreplay/conn/exception.go
+++ b/pkg/sqlreplay/conn/exception.go
@@ -5,6 +5,7 @@ package conn
 
 import (
 	"errors"
+	"time"
 
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
@@ -70,6 +71,7 @@ func (oe *OtherException) Error() string {
 type FailException struct {
 	key     string
 	err     error
+	ts      time.Time
 	command *cmd.Command
 }
 
@@ -77,6 +79,7 @@ func NewFailException(err error, command *cmd.Command) *FailException {
 	fail := &FailException{
 		err:     err,
 		command: command,
+		ts:      time.Now(),
 	}
 	var b []byte
 	switch command.Type {
@@ -102,6 +105,10 @@ func (fe *FailException) Key() string {
 
 func (fe *FailException) ConnID() uint64 {
 	return fe.command.ConnID
+}
+
+func (fe *FailException) Time() time.Time {
+	return fe.ts
 }
 
 func (fe *FailException) Command() *cmd.Command {

--- a/pkg/sqlreplay/conn/exception_test.go
+++ b/pkg/sqlreplay/conn/exception_test.go
@@ -5,6 +5,7 @@ package conn
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
@@ -40,6 +41,7 @@ func TestFailException(t *testing.T) {
 		require.Equal(t, uint64(1), exception.ConnID(), "case %d", i)
 		require.Equal(t, "mock error", exception.Error(), "case %d", i)
 		require.Equal(t, test.key, exception.Key(), "case %d", i)
+		require.Greater(t, exception.Time(), time.Time{}, "case %d", i)
 	}
 }
 

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -89,8 +89,8 @@ func (rdb *reportDB) InsertExceptions(ctx context.Context, tp conn.ExceptionType
 		case conn.Fail:
 			sample := value.sample.(*conn.FailException)
 			command := sample.Command()
-			// TODO: fill capture and replay time
-			args = []any{command.Type.String(), command.Digest(), command.QueryText(), sample.Error(), sample.ConnID(), nil, nil, value.count, value.count}
+			args = []any{command.Type.String(), command.Digest(), command.QueryText(), sample.Error(), sample.ConnID(),
+				command.StartTs.String(), sample.Time().String(), value.count, value.count}
 		case conn.Other:
 			sample := value.sample.(*conn.OtherException)
 			args = []any{sample.Key(), sample.Error(), nil, value.count, value.count}

--- a/pkg/sqlreplay/report/report_db_test.go
+++ b/pkg/sqlreplay/report/report_db_test.go
@@ -53,6 +53,8 @@ func TestInitDB(t *testing.T) {
 
 func TestInsertExceptions(t *testing.T) {
 	now := time.Now()
+	failSample := conn.NewFailException(errors.New("mock error"),
+		cmd.NewCommand(append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...), now, 1))
 	tests := []struct {
 		tp     conn.ExceptionType
 		colls  map[string]*expCollection
@@ -89,13 +91,13 @@ func TestInsertExceptions(t *testing.T) {
 			tp: conn.Fail,
 			colls: map[string]*expCollection{
 				"\x03e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471": {
-					count: 1,
-					sample: conn.NewFailException(errors.New("mock error"), cmd.NewCommand(
-						append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...), now, 1)),
+					count:  1,
+					sample: failSample,
 				},
 			},
 			stmtID: []uint32{1},
-			args:   [][]any{{"Query", "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471", "select 1", "mock error", uint64(1), nil, nil, uint64(1), uint64(1)}},
+			args: [][]any{{"Query", "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471", "select 1", "mock error",
+				uint64(1), now.String(), failSample.Time().String(), uint64(1), uint64(1)}},
 		},
 	}
 

--- a/pkg/sqlreplay/report/report_test.go
+++ b/pkg/sqlreplay/report/report_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestReadExceptions(t *testing.T) {
 	now := time.Now()
+	failSample := conn.NewFailException(errors.New("another error"), cmd.NewCommand(append([]byte{pnet.ComQuery.Byte()},
+		[]byte("select 1")...), now, 1))
 	tests := []struct {
 		exceptions []conn.Exception
 		finalExps  map[conn.ExceptionType]map[string]*expCollection
@@ -72,7 +74,7 @@ func TestReadExceptions(t *testing.T) {
 		},
 		{
 			exceptions: []conn.Exception{
-				conn.NewFailException(errors.New("another error"), cmd.NewCommand(append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...), now, 1)),
+				failSample,
 			},
 			finalExps: map[conn.ExceptionType]map[string]*expCollection{
 				conn.Other: {
@@ -87,9 +89,8 @@ func TestReadExceptions(t *testing.T) {
 				},
 				conn.Fail: {
 					"\x03e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471": &expCollection{
-						count: 1,
-						sample: conn.NewFailException(errors.New("another error"), cmd.NewCommand(
-							append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...), now, 1)),
+						count:  1,
+						sample: failSample,
 					},
 				},
 			},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #683

Problem Summary:
Output capture time and replay time to the report table `fail`.

What is changed and how it works:
Output capture time and replay time to the report table `fail`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
mysql> select * from fail;
+----------+------------------------------------------------------------------+-------------+---------------------------------------------------------+----------------+---------------------+---------------------+-------+
| cmd_type | digest                                                           | sample_stmt | sample_err_msg                                          | sample_conn_id | sample_capture_time | sample_replay_time  | count |
+----------+------------------------------------------------------------------+-------------+---------------------------------------------------------+----------------+---------------------+---------------------+-------+
| Query    | b4f126c134a4830e06b3e040158d2dc52c6e13ac66555bec9a23e8fd52ce7f94 | select $$   | ERROR 1054 (42S22): Unknown column '$$' in 'field list' |              1 | 2024-09-24 14:34:34 | 2024-09-24 15:05:37 |     1 |
+----------+------------------------------------------------------------------+-------------+---------------------------------------------------------+----------------+---------------------+---------------------+-------+
1 row in set (0.01 sec)
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
