### PR TITLE
manager, replay: show the history of traffic jobs

### DIFF
--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -145,8 +145,8 @@ func (mc *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64
 	}
 }
 
-func (mc *mockCapture) Progress() (float64, error) {
-	return 0, nil
+func (mc *mockCapture) Progress() (float64, time.Time, error) {
+	return 0, time.Time{}, nil
 }
 
 func (mc *mockCapture) Close() {

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -44,7 +44,7 @@ type Capture interface {
 	// Capture captures traffic
 	Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error))
 	// Progress returns the progress of the capture job
-	Progress() (float64, error)
+	Progress() (float64, time.Time, error)
 	// Close closes the capture
 	Close()
 }
@@ -340,17 +340,17 @@ func (c *capture) writeMeta(duration time.Duration, cmds uint64) {
 	}
 }
 
-func (c *capture) Progress() (float64, error) {
+func (c *capture) Progress() (float64, time.Time, error) {
 	c.Lock()
 	defer c.Unlock()
 	if c.status == statusIdle || c.cfg.Duration == 0 {
-		return c.progress, c.err
+		return c.progress, c.endTime, c.err
 	}
 	progress := float64(time.Since(c.startTime)) / float64(c.cfg.Duration)
 	if progress > 1 {
 		progress = 1
 	}
-	return progress, c.err
+	return progress, c.endTime, c.err
 }
 
 // stopNoLock must be called after holding a lock.

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -170,12 +170,12 @@ func TestProgress(t *testing.T) {
 
 	now := time.Now()
 	require.NoError(t, cpt.Start(cfg))
-	progress, err := cpt.Progress()
+	progress, _, err := cpt.Progress()
 	require.NoError(t, err)
 	require.Less(t, progress, 0.3)
 
 	setStartTime(now.Add(-5 * time.Second))
-	progress, err = cpt.Progress()
+	progress, _, err = cpt.Progress()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, progress, 0.5)
 
@@ -183,7 +183,7 @@ func TestProgress(t *testing.T) {
 	cpt.Capture(packet, time.Now(), 100, mockInitSession)
 	cpt.Stop(errors.Errorf("mock error"))
 	cpt.wg.Wait()
-	progress, err = cpt.Progress()
+	progress, _, err = cpt.Progress()
 	require.ErrorContains(t, err, "mock error")
 	require.GreaterOrEqual(t, progress, 0.5)
 	require.Less(t, progress, 1.0)

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -5,8 +5,11 @@ package manager
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
 	"github.com/siddontang/go/hack"
 )
 
@@ -20,55 +23,117 @@ const (
 type Job interface {
 	Type() jobType
 	String() string
-	SetProgress(progress float64, err error)
+	MarshalJSON() ([]byte, error)
+	SetProgress(progress float64, endTime time.Time, err error)
 	IsRunning() bool
 }
 
 type job struct {
-	Status    string
-	StartTime time.Time
-	Duration  time.Duration
-	Progress  float64
-	// TODO: error can not be marshaled.
-	Error error
+	startTime time.Time
+	endTime   time.Time
+	progress  float64
+	err       error
+}
+
+type job4Marshal struct {
+	Type      string  `json:"type"`
+	Status    string  `json:"status"`
+	StartTime string  `json:"start_time"`
+	EndTime   string  `json:"end_time,omitempty"`
+	Duration  string  `json:"duration,omitempty"`
+	Output    string  `json:"output,omitempty"`
+	Input     string  `json:"input,omitempty"`
+	Username  string  `json:"username,omitempty"`
+	Speed     float64 `json:"speed,omitempty"`
+	Progress  string  `json:"progress"`
+	Err       string  `json:"error,omitempty"`
 }
 
 func (job *job) IsRunning() bool {
-	return job.Error == nil && job.Progress < 1
+	return job.err == nil && job.progress < 1
 }
 
-// TODO: refine the output
-func (job *job) String() string {
-	b, err := json.Marshal(job)
-	if err != nil {
-		return err.Error()
+func (job *job) SetProgress(progress float64, endTime time.Time, err error) {
+	if progress > job.progress {
+		job.progress = progress
 	}
-	return hack.String(b)
+	job.endTime = endTime
+	job.err = err
 }
 
-func (job *job) SetProgress(progress float64, err error) {
-	if progress > job.Progress {
-		job.Progress = progress
+func (job *job) getJob4Marshal() *job4Marshal {
+	jm := &job4Marshal{
+		StartTime: job.startTime.String(),
+		Progress:  fmt.Sprintf("%d%%", int(job.progress*100)),
 	}
-	job.Error = err
+	if !job.endTime.IsZero() {
+		jm.EndTime = job.endTime.String()
+	}
+	if job.err != nil {
+		jm.Status = "canceled"
+		jm.Err = job.err.Error()
+	} else if job.progress >= 1.0 {
+		jm.Status = "done"
+	} else {
+		jm.Status = "running"
+	}
+	return jm
 }
 
 var _ Job = (*captureJob)(nil)
 
 type captureJob struct {
 	job
+	cfg capture.CaptureConfig
 }
 
 func (job *captureJob) Type() jobType {
 	return Capture
 }
 
+func (job *captureJob) MarshalJSON() ([]byte, error) {
+	job4Marshal := job.getJob4Marshal()
+	job4Marshal.Type = "capture"
+	job4Marshal.Output = job.cfg.Output
+	job4Marshal.Duration = job.cfg.Duration.String()
+	return json.Marshal(job4Marshal)
+}
+
+func (job *captureJob) String() string {
+	b, err := json.Marshal(job)
+	if err != nil {
+		return ""
+	}
+	return hack.String(b)
+}
+
 var _ Job = (*replayJob)(nil)
 
 type replayJob struct {
 	job
+	cfg replay.ReplayConfig
 }
 
 func (job *replayJob) Type() jobType {
 	return Replay
+}
+
+func (job *replayJob) MarshalJSON() ([]byte, error) {
+	job4Marshal := job.getJob4Marshal()
+	job4Marshal.Type = "replay"
+	job4Marshal.Input = job.cfg.Input
+	job4Marshal.Username = job.cfg.Username
+	job4Marshal.Speed = job.cfg.Speed
+	if job4Marshal.Speed == 0 {
+		job4Marshal.Speed = 1
+	}
+	return json.Marshal(job4Marshal)
+}
+
+func (job *replayJob) String() string {
+	b, err := json.Marshal(job)
+	if err != nil {
+		return ""
+	}
+	return hack.String(b)
 }

--- a/pkg/sqlreplay/manager/manager.go
+++ b/pkg/sqlreplay/manager/manager.go
@@ -61,11 +61,11 @@ func (jm *jobManager) updateProgress() {
 	if job.IsRunning() {
 		switch job.Type() {
 		case Capture:
-			progress, err := jm.capture.Progress()
-			job.SetProgress(progress, err)
+			progress, endTime, err := jm.capture.Progress()
+			job.SetProgress(progress, endTime, err)
 		case Replay:
-			progress, err := jm.replay.Progress()
-			job.SetProgress(progress, err)
+			progress, endTime, err := jm.replay.Progress()
+			job.SetProgress(progress, endTime, err)
 		}
 	}
 }
@@ -93,9 +93,9 @@ func (jm *jobManager) StartCapture(cfg capture.CaptureConfig) error {
 	}
 	newJob := &captureJob{
 		job: job{
-			StartTime: time.Now(),
-			Duration:  cfg.Duration,
+			startTime: time.Now(),
 		},
+		cfg: cfg,
 	}
 	jm.lg.Info("start capture", zap.String("job", newJob.String()))
 	jm.jobHistory = append(jm.jobHistory, newJob)
@@ -121,8 +121,9 @@ func (jm *jobManager) StartReplay(cfg replay.ReplayConfig) error {
 	}
 	newJob := &replayJob{
 		job: job{
-			StartTime: time.Now(),
+			startTime: time.Now(),
 		},
+		cfg: cfg,
 	}
 	jm.lg.Info("start replay", zap.String("job", newJob.String()))
 	jm.jobHistory = append(jm.jobHistory, newJob)
@@ -135,7 +136,7 @@ func (jm *jobManager) GetCapture() capture.Capture {
 
 func (jm *jobManager) Jobs() string {
 	jm.updateProgress()
-	b, err := json.Marshal(jm.jobHistory)
+	b, err := json.MarshalIndent(jm.jobHistory, "", "  ")
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -5,6 +5,7 @@ package manager
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -45,11 +46,87 @@ func TestStartAndStop(t *testing.T) {
 	rep.progress = 1.0
 	mgr.Jobs()
 	job := mgr.jobHistory[len(mgr.jobHistory)-1]
-	require.Equal(t, 1.0, job.(*replayJob).Progress)
+	require.Equal(t, 1.0, job.(*replayJob).progress)
 	require.NoError(t, mgr.StartCapture(capture.CaptureConfig{}))
 	cpt.err = errors.Errorf("mock error")
 	mgr.Jobs()
 	job = mgr.jobHistory[len(mgr.jobHistory)-1]
 	require.NotNil(t, job)
-	require.ErrorContains(t, job.(*captureJob).Error, "mock error")
+	require.ErrorContains(t, job.(*captureJob).err, "mock error")
+}
+
+func TestMarshalJobHistory(t *testing.T) {
+	startTime, err := time.Parse("2006-01-02 15:04:05", "2020-01-01 00:00:00")
+	require.NoError(t, err)
+	endTime, err := time.Parse("2006-01-02 15:04:05", "2020-01-01 02:01:01")
+	require.NoError(t, err)
+	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, nil)
+	mgr.jobHistory = []Job{
+		&captureJob{
+			job: job{
+				startTime: startTime,
+				endTime:   endTime,
+				progress:  0.5,
+				err:       errors.New("mock error"),
+			},
+			cfg: capture.CaptureConfig{
+				Output:   "/tmp/traffic",
+				Duration: 2 * time.Hour,
+			},
+		},
+		&replayJob{
+			job: job{
+				startTime: startTime,
+				progress:  0,
+			},
+			cfg: replay.ReplayConfig{
+				Input:    "/tmp/traffic",
+				Username: "root",
+			},
+		},
+		&replayJob{
+			job: job{
+				startTime: startTime,
+				endTime:   endTime,
+				progress:  1,
+			},
+			cfg: replay.ReplayConfig{
+				Input:    "/tmp/traffic",
+				Username: "root",
+				Speed:    0.5,
+			},
+		},
+	}
+	t.Log(mgr.Jobs())
+	require.Equal(t, `[
+  {
+    "type": "capture",
+    "status": "canceled",
+    "start_time": "2020-01-01 00:00:00 +0000 UTC",
+    "end_time": "2020-01-01 02:01:01 +0000 UTC",
+    "duration": "2h0m0s",
+    "output": "/tmp/traffic",
+    "progress": "50%",
+    "error": "mock error"
+  },
+  {
+    "type": "replay",
+    "status": "running",
+    "start_time": "2020-01-01 00:00:00 +0000 UTC",
+    "input": "/tmp/traffic",
+    "username": "root",
+    "speed": 1,
+    "progress": "0%"
+  },
+  {
+    "type": "replay",
+    "status": "done",
+    "start_time": "2020-01-01 00:00:00 +0000 UTC",
+    "end_time": "2020-01-01 02:01:01 +0000 UTC",
+    "input": "/tmp/traffic",
+    "username": "root",
+    "speed": 0.5,
+    "progress": "100%"
+  }
+]`, mgr.Jobs())
 }

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -37,8 +37,8 @@ func (m *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64,
 func (m *mockCapture) Close() {
 }
 
-func (m *mockCapture) Progress() (float64, error) {
-	return m.progress, m.err
+func (m *mockCapture) Progress() (float64, time.Time, error) {
+	return m.progress, time.Time{}, m.err
 }
 
 func (m *mockCapture) Stop(err error) {
@@ -61,8 +61,8 @@ type mockReplay struct {
 func (m *mockReplay) Close() {
 }
 
-func (m *mockReplay) Progress() (float64, error) {
-	return m.progress, m.err
+func (m *mockReplay) Progress() (float64, time.Time, error) {
+	return m.progress, time.Time{}, m.err
 }
 
 func (m *mockReplay) Start(cfg replay.ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -34,7 +34,7 @@ type Replay interface {
 	// Stop stops the replay
 	Stop(err error)
 	// Progress returns the progress of the replay job
-	Progress() (float64, error)
+	Progress() (float64, time.Time, error)
 	// Close closes the replay
 	Close()
 }
@@ -243,13 +243,13 @@ func (r *replay) readCloseCh(ctx context.Context) {
 	}
 }
 
-func (r *replay) Progress() (float64, error) {
+func (r *replay) Progress() (float64, time.Time, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.meta.Cmds > 0 {
 		r.progress = float64(r.replayedCmds+r.filteredCmds) / float64(r.meta.Cmds)
 	}
-	return r.progress, r.err
+	return r.progress, r.endTime, r.err
 }
 
 func (r *replay) readMeta() *store.Meta {

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -190,7 +190,7 @@ func TestProgress(t *testing.T) {
 	require.NoError(t, replay.Start(cfg, nil, nil, &backend.BCConfig{}))
 	for i := 0; i < 10; i++ {
 		<-cmdCh
-		progress, err := replay.Progress()
+		progress, _, err := replay.Progress()
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, progress, float64(i)/10)
 		// Maybe unstable due to goroutine schedule.


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #685

Problem Summary:
Users may want to check the history of traffic jobs.

What is changed and how it works:
- Add more fields to the jobs.
- Marshal the jobs and return the string.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
