### PR TITLE
id, replay: add id allocator for SQL server and replayer

### DIFF
--- a/pkg/manager/id/manager.go
+++ b/pkg/manager/id/manager.go
@@ -1,0 +1,20 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package id
+
+import "sync/atomic"
+
+// IDManager is used to generate unique ID concurrently.
+// SQLServer and Replay allocate backend connection ID conrrently, but the ID cannot overlap.
+type IDManager struct {
+	id atomic.Uint64
+}
+
+func NewIDManager() *IDManager {
+	return &IDManager{}
+}
+
+func (m *IDManager) NewID() uint64 {
+	return m.id.Add(1)
+}

--- a/pkg/manager/id/manager_test.go
+++ b/pkg/manager/id/manager_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package id
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDValue(t *testing.T) {
+	var lock sync.Mutex
+	var wg waitgroup.WaitGroup
+	mgr := NewIDManager()
+	m := make(map[uint64]struct{}, 1000)
+	for i := 0; i < 10; i++ {
+		wg.Run(func() {
+			for j := 0; j < 100; j++ {
+				id := mgr.NewID()
+				lock.Lock()
+				m[id] = struct{}{}
+				lock.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, 1000, len(m))
+	for i := 1; i <= 1000; i++ {
+		require.Contains(t, m, uint64(i), "missing id: %d", i)
+	}
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
 	"github.com/pingcap/tiproxy/pkg/balance/router"
 	"github.com/pingcap/tiproxy/pkg/manager/cert"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	"github.com/pingcap/tiproxy/pkg/proxy/client"
@@ -31,7 +32,7 @@ func TestCreateConn(t *testing.T) {
 	cfg := &config.Config{}
 	certManager := cert.NewCertManager()
 	require.NoError(t, certManager.Init(cfg, lg, nil))
-	server, err := NewSQLServer(lg, cfg, certManager, nil, &mockHsHandler{})
+	server, err := NewSQLServer(lg, cfg, certManager, id.NewIDManager(), nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 	defer func() {
@@ -79,7 +80,7 @@ func TestGracefulCloseConn(t *testing.T) {
 			},
 		},
 	}
-	server, err := NewSQLServer(lg, cfg, nil, nil, hsHandler)
+	server, err := NewSQLServer(lg, cfg, nil, id.NewIDManager(), nil, hsHandler)
 	require.NoError(t, err)
 	finish := make(chan struct{})
 	go func() {
@@ -109,7 +110,7 @@ func TestGracefulCloseConn(t *testing.T) {
 	}
 
 	// Graceful shutdown will be blocked if there are alive connections.
-	server, err = NewSQLServer(lg, cfg, nil, nil, hsHandler)
+	server, err = NewSQLServer(lg, cfg, nil, id.NewIDManager(), nil, hsHandler)
 	require.NoError(t, err)
 	clientConn := createClientConn()
 	go func() {
@@ -135,7 +136,7 @@ func TestGracefulCloseConn(t *testing.T) {
 
 	// Graceful shutdown will shut down after GracefulCloseConnTimeout.
 	cfg.Proxy.GracefulCloseConnTimeout = 1
-	server, err = NewSQLServer(lg, cfg, nil, nil, hsHandler)
+	server, err = NewSQLServer(lg, cfg, nil, id.NewIDManager(), nil, hsHandler)
 	require.NoError(t, err)
 	createClientConn()
 	go func() {
@@ -163,7 +164,7 @@ func TestGracefulShutDown(t *testing.T) {
 			},
 		},
 	}
-	server, err := NewSQLServer(lg, cfg, certManager, nil, &mockHsHandler{})
+	server, err := NewSQLServer(lg, cfg, certManager, id.NewIDManager(), nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 
@@ -201,7 +202,7 @@ func TestMultiAddr(t *testing.T) {
 		Proxy: config.ProxyServer{
 			Addr: "0.0.0.0:0,0.0.0.0:0",
 		},
-	}, certManager, nil, &mockHsHandler{})
+	}, certManager, id.NewIDManager(), nil, &mockHsHandler{})
 	require.NoError(t, err)
 	server.Run(context.Background(), nil)
 
@@ -221,7 +222,7 @@ func TestWatchCfg(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	hsHandler := backend.NewDefaultHandshakeHandler(nil)
 	cfgch := make(chan *config.Config)
-	server, err := NewSQLServer(lg, &config.Config{}, nil, nil, hsHandler)
+	server, err := NewSQLServer(lg, &config.Config{}, nil, id.NewIDManager(), nil, hsHandler)
 	require.NoError(t, err)
 	server.Run(context.Background(), cfgch)
 	cfg := &config.Config{
@@ -256,7 +257,7 @@ func TestRecoverPanic(t *testing.T) {
 	certManager := cert.NewCertManager()
 	err := certManager.Init(&config.Config{}, lg, nil)
 	require.NoError(t, err)
-	server, err := NewSQLServer(lg, &config.Config{}, certManager, nil, &mockHsHandler{
+	server, err := NewSQLServer(lg, &config.Config{}, certManager, id.NewIDManager(), nil, &mockHsHandler{
 		handshakeResp: func(ctx backend.ConnContext, _ *pnet.HandshakeResp) error {
 			if ctx.Value(backend.ConnContextKeyConnID).(uint64) == 1 {
 				panic("HandleHandshakeResp panic")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/manager/cert"
 	mgrcfg "github.com/pingcap/tiproxy/pkg/manager/config"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/manager/logger"
 	mgrns "github.com/pingcap/tiproxy/pkg/manager/namespace"
@@ -161,16 +162,16 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	} else {
 		hsHandler = backend.NewDefaultHandshakeHandler(srv.namespaceManager)
 	}
+	idMgr := id.NewIDManager()
 
 	// setup capture and replay job manager
 	{
-		srv.replay = mgrrp.NewJobManager(lg.Named("replay"), srv.configManager.GetConfig(), srv.certManager, hsHandler)
+		srv.replay = mgrrp.NewJobManager(lg.Named("replay"), srv.configManager.GetConfig(), srv.certManager, idMgr, hsHandler)
 	}
 
 	// setup proxy server
 	{
-
-		srv.proxy, err = proxy.NewSQLServer(lg.Named("proxy"), cfg, srv.certManager, srv.replay.GetCapture(), hsHandler)
+		srv.proxy, err = proxy.NewSQLServer(lg.Named("proxy"), cfg, srv.certManager, idMgr, srv.replay.GetCapture(), hsHandler)
 		if err != nil {
 			return
 		}

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -35,14 +35,14 @@ type conn struct {
 	closeCh     chan<- uint64
 	lg          *zap.Logger
 	backendConn BackendConn
-	connID      uint64 // frontend connection id
+	connID      uint64 // capture ID, not replay ID
 }
 
 func NewConn(lg *zap.Logger, username, password string, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler,
 	idMgr *id.IDManager, connID uint64, bcConfig *backend.BCConfig, exceptionCh chan<- Exception, closeCh chan<- uint64) *conn {
 	backendConnID := idMgr.NewID()
 	return &conn{
-		lg:          lg.With(zap.Uint64("captureID", connID), zap.Uint64("backendID", backendConnID)),
+		lg:          lg.With(zap.Uint64("captureID", connID), zap.Uint64("replayID", backendConnID)),
 		connID:      connID,
 		cmdCh:       make(chan *cmd.Command, maxPendingCommands),
 		exceptionCh: exceptionCh,

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -41,8 +41,9 @@ type conn struct {
 func NewConn(lg *zap.Logger, username, password string, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler,
 	idMgr *id.IDManager, connID uint64, bcConfig *backend.BCConfig, exceptionCh chan<- Exception, closeCh chan<- uint64) *conn {
 	backendConnID := idMgr.NewID()
+	lg = lg.With(zap.Uint64("captureID", connID), zap.Uint64("replayID", backendConnID))
 	return &conn{
-		lg:          lg.With(zap.Uint64("captureID", connID), zap.Uint64("replayID", backendConnID)),
+		lg:          lg,
 		connID:      connID,
 		cmdCh:       make(chan *cmd.Command, maxPendingCommands),
 		exceptionCh: exceptionCh,

--- a/pkg/sqlreplay/conn/conn_test.go
+++ b/pkg/sqlreplay/conn/conn_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
@@ -38,7 +39,7 @@ func TestConnectError(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	for i, test := range tests {
 		exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-		conn := NewConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+		conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
 		backendConn := &mockBackendConn{connErr: test.connErr, execErr: test.execErr}
 		conn.backendConn = backendConn
 		wg.RunWithRecover(func() {
@@ -59,7 +60,7 @@ func TestExecuteCmd(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	var wg waitgroup.WaitGroup
 	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-	conn := NewConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
 	backendConn := &mockBackendConn{}
 	conn.backendConn = backendConn
 	childCtx, cancel := context.WithCancel(context.Background())
@@ -105,7 +106,7 @@ func TestExecuteError(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	var wg waitgroup.WaitGroup
 	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-	conn := NewConn(lg, "u1", "", nil, nil, 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
 	backendConn := &mockBackendConn{execErr: errors.New("mock error")}
 	conn.backendConn = backendConn
 	childCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/sqlreplay/manager/manager.go
+++ b/pkg/sqlreplay/manager/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
@@ -42,11 +43,11 @@ type jobManager struct {
 	lg          *zap.Logger
 }
 
-func NewJobManager(lg *zap.Logger, cfg *config.Config, certMgr CertManager, hsHandler backend.HandshakeHandler) *jobManager {
+func NewJobManager(lg *zap.Logger, cfg *config.Config, certMgr CertManager, idMgr *id.IDManager, hsHandler backend.HandshakeHandler) *jobManager {
 	return &jobManager{
 		lg:          lg,
 		capture:     capture.NewCapture(lg.Named("capture")),
-		replay:      replay.NewReplay(lg.Named("replay")),
+		replay:      replay.NewReplay(lg.Named("replay"), idMgr),
 		hsHandler:   hsHandler,
 		cfg:         cfg,
 		certManager: certMgr,

--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,7 @@ import (
 )
 
 func TestStartAndStop(t *testing.T) {
-	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, nil)
+	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, id.NewIDManager(), nil)
 	defer mgr.Close()
 	cpt, rep := &mockCapture{}, &mockReplay{}
 	mgr.capture, mgr.replay = cpt, rep
@@ -60,7 +61,7 @@ func TestMarshalJobHistory(t *testing.T) {
 	require.NoError(t, err)
 	endTime, err := time.Parse("2006-01-02 15:04:05", "2020-01-01 02:01:01")
 	require.NoError(t, err)
-	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, nil)
+	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, id.NewIDManager(), nil)
 	mgr.jobHistory = []Job{
 		&captureJob{
 			job: job{

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestManageConns(t *testing.T) {
-	replay := NewReplay(zap.NewNop())
+	replay := NewReplay(zap.NewNop(), id.NewIDManager())
 	defer replay.Close()
 
 	loader := newMockChLoader()
@@ -99,7 +100,7 @@ func TestValidateCfg(t *testing.T) {
 func TestReplaySpeed(t *testing.T) {
 	speeds := []float64{10, 1, 0.1}
 	var lastTotalTime time.Duration
-	replay := NewReplay(zap.NewNop())
+	replay := NewReplay(zap.NewNop(), id.NewIDManager())
 	defer replay.Close()
 	for _, speed := range speeds {
 		cmdCh := make(chan *cmd.Command, 10)
@@ -171,7 +172,7 @@ func TestProgress(t *testing.T) {
 	// If the channel size is too small, there may be a deadlock.
 	// ExecuteCmd waits for cmdCh <- data in a lock, while Progress() waits for the lock.
 	cmdCh := make(chan *cmd.Command, 10)
-	replay := NewReplay(zap.NewNop())
+	replay := NewReplay(zap.NewNop(), id.NewIDManager())
 	defer replay.Close()
 	cfg := ReplayConfig{
 		Input:    dir,


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #687 

Problem Summary:
SQL server and replayer allocate backend ID concurrently, but the ID can't overlap.

What is changed and how it works:
- Create a `IDManager`
- SQLServer and Replay allocate ID from IDManager

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
