### PR TITLE
config, cmd: fix that the proxy configs are overwritten

### DIFF
--- a/cmd/tiproxy/main.go
+++ b/cmd/tiproxy/main.go
@@ -32,7 +32,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&sctx.ConfigFile, "config", "", "proxy config file path")
 	rootCmd.PersistentFlags().StringVar(&deprecatedStr, "log_encoder", "", "deprecated and will be removed")
 	rootCmd.PersistentFlags().StringVar(&deprecatedStr, "log_level", "", "deprecated and will be removed")
-	rootCmd.PersistentFlags().StringVar(&sctx.Overlay.Proxy.AdvertiseAddr, "advertise-addr", "", "advertise address")
+	rootCmd.PersistentFlags().StringVar(&sctx.AdvertiseAddr, "advertise-addr", "", "advertise address")
 
 	metrics.MaxProcsGauge.Set(float64(runtime.GOMAXPROCS(0)))
 

--- a/pkg/manager/config/config.go
+++ b/pkg/manager/config/config.go
@@ -52,8 +52,9 @@ func (e *ConfigManager) SetTOMLConfig(data []byte) (err error) {
 		return errors.WithStack(err)
 	}
 
-	if err = toml.Unmarshal(e.overlay, base); err != nil {
-		return errors.WithStack(err)
+	// Overwrite the config with command line args.
+	if len(e.advertiseAddr) > 0 {
+		base.Proxy.AdvertiseAddr = e.advertiseAddr
 	}
 
 	if err = base.Check(); err != nil {

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -22,9 +22,9 @@ func TestConfigReload(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	cfgmgr1, _, _ := testConfigManager(t, tmpcfg)
+	cfgmgr1, _, _ := testConfigManager(t, tmpcfg, "addr")
 
-	cfgmgr2, _, _ := testConfigManager(t, "")
+	cfgmgr2, _, _ := testConfigManager(t, "", "addr")
 
 	cases := []struct {
 		name      string
@@ -41,7 +41,7 @@ func TestConfigReload(t *testing.T) {
 			},
 			postcfg: `proxy.pd-addrs = ""`,
 			postcheck: func(c *config.Config) bool {
-				return c.Proxy.PDAddrs == ""
+				return c.Proxy.PDAddrs == "" && c.Proxy.AdvertiseAddr == "addr"
 			},
 		},
 		{
@@ -135,7 +135,7 @@ func TestConfigRemove(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	cfgmgr, _, _ := testConfigManager(t, tmpcfg)
+	cfgmgr, _, _ := testConfigManager(t, tmpcfg, "")
 
 	// remove and recreate the file in a very short time
 	require.NoError(t, os.Remove(tmpcfg))
@@ -271,7 +271,7 @@ func TestFilePath(t *testing.T) {
 				require.NoError(t, f.Close())
 			}
 
-			cfgmgr, _, _ = testConfigManager(t, test.filename)
+			cfgmgr, _, _ = testConfigManager(t, test.filename, "")
 			require.Equal(t, pdAddr1, cfgmgr.GetConfig().Proxy.PDAddrs)
 
 			// Test write.
@@ -298,7 +298,7 @@ func TestFilePath(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
-	cfgmgr, _, _ := testConfigManager(t, "")
+	cfgmgr, _, _ := testConfigManager(t, "", "")
 	c1 := cfgmgr.GetConfigChecksum()
 	require.NoError(t, cfgmgr.SetTOMLConfig([]byte(`proxy.addr = "gg"`)))
 	c2 := cfgmgr.GetConfigChecksum()

--- a/pkg/manager/config/manager_test.go
+++ b/pkg/manager/config/manager_test.go
@@ -9,12 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
 )
 
-func testConfigManager(t *testing.T, configFile string, overlays ...*config.Config) (*ConfigManager, fmt.Stringer, context.Context) {
+func testConfigManager(t *testing.T, configFile string, advertiseAddr string) (*ConfigManager, fmt.Stringer, context.Context) {
 	logger, text := logger.CreateLoggerForTest(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -24,7 +23,7 @@ func testConfigManager(t *testing.T, configFile string, overlays ...*config.Conf
 
 	cfgmgr := NewConfigManager()
 	cfgmgr.checkFileInterval = 20 * time.Millisecond
-	require.NoError(t, cfgmgr.Init(ctx, logger, configFile, nil))
+	require.NoError(t, cfgmgr.Init(ctx, logger, configFile, advertiseAddr))
 
 	t.Cleanup(func() {
 		require.NoError(t, cfgmgr.Close())

--- a/pkg/manager/config/namespace_test.go
+++ b/pkg/manager/config/namespace_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestBase(t *testing.T) {
-	cfgmgr, _, ctx := testConfigManager(t, "")
+	cfgmgr, _, ctx := testConfigManager(t, "", "")
 
 	nsNum := 10
 	valNum := 30
@@ -74,7 +74,7 @@ func TestBase(t *testing.T) {
 }
 
 func TestBaseConcurrency(t *testing.T) {
-	cfgmgr, _, ctx := testConfigManager(t, "")
+	cfgmgr, _, ctx := testConfigManager(t, "", "")
 
 	var wg waitgroup.WaitGroup
 	batchNum := 16

--- a/pkg/sctx/context.go
+++ b/pkg/sctx/context.go
@@ -5,14 +5,13 @@ package sctx
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 )
 
 type Context struct {
-	Overlay    config.Config
-	ConfigFile string
-	Handler    ServerHandler
+	AdvertiseAddr string
+	ConfigFile    string
+	Handler       ServerHandler
 }
 
 type ServerHandler interface {

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -30,7 +30,7 @@ func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path
 	lg, _ := logger.CreateLoggerForTest(t)
 	ready := atomic.NewBool(true)
 	cfgmgr := mgrcfg.NewConfigManager()
-	require.NoError(t, cfgmgr.Init(context.Background(), lg, "", nil))
+	require.NoError(t, cfgmgr.Init(context.Background(), lg, "", ""))
 	crtmgr := mgrcrt.NewCertManager()
 	require.NoError(t, crtmgr.Init(cfgmgr.GetConfig(), lg, cfgmgr.WatchConfig()))
 	srv, err := NewServer(config.API{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -68,13 +68,13 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 
 	// set up logger
 	var lg *zap.Logger
-	if srv.loggerManager, lg, err = logger.NewLoggerManager(&sctx.Overlay.Log); err != nil {
+	if srv.loggerManager, lg, err = logger.NewLoggerManager(nil); err != nil {
 		return
 	}
 	srv.loggerManager.Init(srv.configManager.WatchConfig())
 
 	// setup config manager
-	if err = srv.configManager.Init(ctx, lg.Named("config"), sctx.ConfigFile, &sctx.Overlay); err != nil {
+	if err = srv.configManager.Init(ctx, lg.Named("config"), sctx.ConfigFile, sctx.AdvertiseAddr); err != nil {
 		return
 	}
 	cfg := srv.configManager.GetConfig()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -5,8 +5,10 @@ package server
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/sctx"
 	"github.com/pingcap/tiproxy/pkg/util/etcd"
@@ -14,13 +16,21 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	dir := t.TempDir()
 	lg, _ := logger.CreateLoggerForTest(t)
-	etcdServer, err := etcd.CreateEtcdServer("0.0.0.0:0", t.TempDir(), lg)
+	etcdServer, err := etcd.CreateEtcdServer("0.0.0.0:0", dir, lg)
 	require.NoError(t, err)
+	configFile := dir + "/config.toml"
 	endpoint := etcdServer.Clients[0].Addr().String()
 	cfg := etcd.ConfigForEtcdTest(endpoint)
+	b, err := toml.Marshal(cfg)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configFile, b, 0o644))
 
-	server, err := NewServer(context.Background(), &sctx.Context{Overlay: *cfg})
+	server, err := NewServer(context.Background(), &sctx.Context{
+		ConfigFile: configFile,
+	})
 	require.NoError(t, err)
 	require.NoError(t, server.Close())
+	etcdServer.Close()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #690

Problem Summary:
When `--advertise-addr` is set, the whole `proxy` is overwritten by `toml.Unmarshal(e.overlay, base)`, which results in all the fields are empty except for `advertise-addr`.

What is changed and how it works:
- Remove `Sctx.Overlay` and add `Sctx.AdvertiseAddr`
- Only set `advertiseAddr` explicitly in `ConfigManager`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Set the `graceful-wait-before-shutdown` in the config file
2. Start TiProxy with `--advertise-addr`
3. Start TiProxy and check the log, the config shows `graceful-wait-before-shutdown` correctly

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix that the `proxy` configurations are overwritten when the command line `--advertise-addr` is set.
```
