### PR TITLE
Make /api/debug/health return error when no backends are available

### DIFF
--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -29,6 +29,7 @@ type Router interface {
 	ConnEventReceiver
 
 	GetBackendSelector() BackendSelector
+	HealthyBackendCount() int
 	RefreshBackend()
 	RedirectConnections() error
 	ConnCount() int

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -75,6 +75,22 @@ func (router *ScoreBasedRouter) GetBackendSelector() BackendSelector {
 	}
 }
 
+func (router *ScoreBasedRouter) HealthyBackendCount() int {
+	router.Lock()
+	defer router.Unlock()
+	if router.observeError != nil {
+		return 0
+	}
+
+	count := 0
+	for _, backend := range router.backends {
+		if backend.Healthy() {
+			count++
+		}
+	}
+	return count
+}
+
 func (router *ScoreBasedRouter) getConnWrapper(conn RedirectableConn) *glist.Element[*connWrapper] {
 	return conn.Value(_routerKey).(*glist.Element[*connWrapper])
 }

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -322,11 +322,14 @@ func TestNoBackends(t *testing.T) {
 	conn := tester.createConn()
 	backend := tester.simpleRoute(conn)
 	require.True(t, backend == nil || reflect.ValueOf(backend).IsNil())
+	require.Equal(t, 0, tester.router.HealthyBackendCount())
 	tester.addBackends(1)
+	require.Equal(t, 1, tester.router.HealthyBackendCount())
 	tester.addConnections(10)
 	tester.killBackends(1)
 	backend = tester.simpleRoute(conn)
 	require.True(t, backend == nil || reflect.ValueOf(backend).IsNil())
+	require.Equal(t, 0, tester.router.HealthyBackendCount())
 }
 
 // Test that the backends returned by the BackendSelector are complete and different.

--- a/pkg/balance/router/router_static.go
+++ b/pkg/balance/router/router_static.go
@@ -45,6 +45,10 @@ func (r *StaticRouter) GetBackendSelector() BackendSelector {
 	}
 }
 
+func (r *StaticRouter) HealthyBackendCount() int {
+	return len(r.backends)
+}
+
 func (r *StaticRouter) RefreshBackend() {}
 
 func (r *StaticRouter) RedirectConnections() error {

--- a/pkg/manager/namespace/manager_test.go
+++ b/pkg/manager/namespace/manager_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiproxy/pkg/balance/router"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestReady(t *testing.T) {
+	nsMgr := NewNamespaceManager()
+	nsMgr.Init(zap.NewNop(), nil, nil, nil, nil, nil, nil)
+	require.False(t, nsMgr.Ready())
+
+	rt := router.NewStaticRouter([]string{})
+	nsMgr.nsm = map[string]*Namespace{
+		"test": {
+			router: rt,
+		},
+	}
+	require.False(t, nsMgr.Ready())
+
+	rt = router.NewStaticRouter([]string{"127.0.0.1:4000"})
+	ns, ok := nsMgr.GetNamespace("test")
+	require.True(t, ok)
+	ns.router = rt
+	require.True(t, nsMgr.Ready())
+}

--- a/pkg/manager/namespace/manager_test.go
+++ b/pkg/manager/namespace/manager_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestReady(t *testing.T) {
 	nsMgr := NewNamespaceManager()
-	nsMgr.Init(zap.NewNop(), nil, nil, nil, nil, nil, nil)
+	require.NoError(t, nsMgr.Init(zap.NewNop(), nil, nil, nil, nil, nil, nil))
 	require.False(t, nsMgr.Ready())
 
 	rt := router.NewStaticRouter([]string{})

--- a/pkg/proxy/backend/handshake_handler.go
+++ b/pkg/proxy/backend/handshake_handler.go
@@ -52,10 +52,10 @@ type HandshakeHandler interface {
 }
 
 type DefaultHandshakeHandler struct {
-	nsManager *namespace.NamespaceManager
+	nsManager namespace.NamespaceManager
 }
 
-func NewDefaultHandshakeHandler(nsManager *namespace.NamespaceManager) *DefaultHandshakeHandler {
+func NewDefaultHandshakeHandler(nsManager namespace.NamespaceManager) *DefaultHandshakeHandler {
 	return &DefaultHandshakeHandler{
 		nsManager: nsManager,
 	}

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -13,7 +13,7 @@ import (
 
 func (h *Server) DebugHealth(c *gin.Context) {
 	status := http.StatusOK
-	if h.isClosing.Load() {
+	if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
 		status = http.StatusBadGateway
 	}
 	c.JSON(status, config.HealthInfo{

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -25,6 +25,11 @@ func TestDebug(t *testing.T) {
 	})
 
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+	})
+
+	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(true)
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -24,6 +24,7 @@ func TestDebug(t *testing.T) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 
+	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(false)
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 	})

--- a/pkg/server/api/mock_test.go
+++ b/pkg/server/api/mock_test.go
@@ -23,6 +23,12 @@ type mockNamespaceManager struct {
 	success atomic.Bool
 }
 
+func newMockNamespaceManager() *mockNamespaceManager {
+	mgr := &mockNamespaceManager{}
+	mgr.success.Store(true)
+	return mgr
+}
+
 func (m *mockNamespaceManager) Init(_ *zap.Logger, _ []*config.Namespace, _ observer.TopologyFetcher,
 	_ metricsreader.PromInfoFetcher, _ *http.Client, _ *mconfig.ConfigManager, _ metricsreader.MetricsReader) error {
 	return nil

--- a/pkg/server/api/mock_test.go
+++ b/pkg/server/api/mock_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	mconfig "github.com/pingcap/tiproxy/pkg/manager/config"
+	"github.com/pingcap/tiproxy/pkg/manager/namespace"
+	"github.com/pingcap/tiproxy/pkg/util/http"
+	"go.uber.org/zap"
+)
+
+var _ namespace.NamespaceManager = (*mockNamespaceManager)(nil)
+
+type mockNamespaceManager struct {
+	success atomic.Bool
+}
+
+func (m *mockNamespaceManager) Init(_ *zap.Logger, _ []*config.Namespace, _ observer.TopologyFetcher,
+	_ metricsreader.PromInfoFetcher, _ *http.Client, _ *mconfig.ConfigManager, _ metricsreader.MetricsReader) error {
+	return nil
+}
+
+func (m *mockNamespaceManager) GetNamespace(_ string) (*namespace.Namespace, bool) {
+	return nil, false
+}
+
+func (m *mockNamespaceManager) GetNamespaceByUser(_ string) (*namespace.Namespace, bool) {
+	return nil, false
+}
+
+func (m *mockNamespaceManager) SetNamespace(_ context.Context, _ string, _ *config.Namespace) error {
+	if m.success.Load() {
+		return nil
+	}
+	return errors.New("mock error")
+}
+
+func (m *mockNamespaceManager) GetConfigChecksum() string {
+	return ""
+}
+
+func (m *mockNamespaceManager) Ready() bool {
+	return m.success.Load()
+}
+
+func (m *mockNamespaceManager) RedirectConnections() []error {
+	if m.success.Load() {
+		return nil
+	}
+	return []error{errors.New("mock error")}
+}
+
+func (m *mockNamespaceManager) Close() error {
+	return nil
+}
+
+func (m *mockNamespaceManager) CommitNamespaces(_ []*config.Namespace, _ []bool) error {
+	if m.success.Load() {
+		return nil
+	}
+	return errors.New("mock error")
+}

--- a/pkg/server/api/namespace_test.go
+++ b/pkg/server/api/namespace_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNamespace(t *testing.T) {
-	_, doHTTP := createServer(t)
+	srv, doHTTP := createServer(t)
 
 	// test list
 	doHTTP(t, http.MethodGet, "/api/admin/namespace", httpOpts{}, func(t *testing.T, r *http.Response) {
@@ -51,7 +51,8 @@ func TestNamespace(t *testing.T) {
 	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit?namespace=xx", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
 	})
+	srv.mgr.NsMgr.(*mockNamespaceManager).success.Store(true)
 	doHTTP(t, http.MethodPost, "/api/admin/namespace/commit", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusInternalServerError, r.StatusCode)
+		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 }

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -45,7 +45,7 @@ type HTTPHandler interface {
 
 type Managers struct {
 	CfgMgr        *mgrcfg.ConfigManager
-	NsMgr         *mgrns.NamespaceManager
+	NsMgr         mgrns.NamespaceManager
 	CertMgr       *mgrcrt.CertManager
 	BackendReader BackendReader
 	ReplayJobMgr  mgrrp.JobManager

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	mgrcrt "github.com/pingcap/tiproxy/pkg/manager/cert"
 	mgrcfg "github.com/pingcap/tiproxy/pkg/manager/config"
-	mgrns "github.com/pingcap/tiproxy/pkg/manager/namespace"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
@@ -37,7 +36,7 @@ func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path
 		Addr: "0.0.0.0:0",
 	}, lg, Managers{
 		CfgMgr:        cfgmgr,
-		NsMgr:         mgrns.NewNamespaceManager(),
+		NsMgr:         &mockNamespaceManager{},
 		CertMgr:       crtmgr,
 		BackendReader: &mockBackendReader{},
 		ReplayJobMgr:  &mockReplayJobManager{},

--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -32,11 +32,12 @@ func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path
 	require.NoError(t, cfgmgr.Init(context.Background(), lg, "", ""))
 	crtmgr := mgrcrt.NewCertManager()
 	require.NoError(t, crtmgr.Init(cfgmgr.GetConfig(), lg, cfgmgr.WatchConfig()))
+	nsMgr := newMockNamespaceManager()
 	srv, err := NewServer(config.API{
 		Addr: "0.0.0.0:0",
 	}, lg, Managers{
 		CfgMgr:        cfgmgr,
-		NsMgr:         &mockNamespaceManager{},
+		NsMgr:         nsMgr,
 		CertMgr:       crtmgr,
 		BackendReader: &mockBackendReader{},
 		ReplayJobMgr:  &mockReplayJobManager{},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,7 +37,7 @@ type Server struct {
 	wg waitgroup.WaitGroup
 	// managers
 	configManager    *mgrcfg.ConfigManager
-	namespaceManager *mgrns.NamespaceManager
+	namespaceManager mgrns.NamespaceManager
 	metricsManager   *metrics.MetricsManager
 	loggerManager    *logger.LoggerManager
 	certManager      *cert.CertManager


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #689 

Problem Summary:
When TiProxy starts, it may take some time to connect to PD and update the backend status. During this phase, no connections should be routed to this instance. So the HTTP API `/api/debug/health` should report an error when there's no available backends.

What is changed and how it works:
- Add an interface `NamespaceManager` and test `/api/debug/health` with a mocked one.
- `NamespaceManager.Ready()` returns true only when all the routers have at least one healthy backend.
- `/api/debug/health` returns OK only when `NamespaceManager.Ready()` and the server is not closing.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Make /api/debug/health return error when no backends are available
```
