### PR TITLE
Do not log config when the config is not changed

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"bytes"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -168,6 +169,7 @@ func NewConfig() *Config {
 
 func (cfg *Config) Clone() *Config {
 	newCfg := *cfg
+	newCfg.Labels = maps.Clone(cfg.Labels)
 	return &newCfg
 }
 

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -170,3 +170,12 @@ func TestGetIPPort(t *testing.T) {
 		require.Equal(t, cas.port, statusPort)
 	}
 }
+
+func TestCloneConfig(t *testing.T) {
+	cfg := testProxyConfig
+	cfg.Labels = map[string]string{"a": "b"}
+	clone := cfg.Clone()
+	require.Equal(t, cfg, *clone)
+	cfg.Labels["c"] = "d"
+	require.NotContains(t, clone.Labels, "c")
+}

--- a/pkg/manager/config/manager.go
+++ b/pkg/manager/config/manager.go
@@ -42,11 +42,12 @@ type ConfigManager struct {
 	kv *btree.BTreeG[KVValue]
 
 	checkFileInterval time.Duration
-	fileContent       []byte
+	fileContent       []byte // used to compare whether the config file has changed
 	sts               struct {
 		sync.Mutex
 		listeners []chan<- *config.Config
 		current   *config.Config
+		data      []byte // used to strictly compare whether the config has changed
 		checksum  uint32 // checksum of the unmarshalled toml
 	}
 }

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -174,10 +174,8 @@ func (h *Server) attachLogger(c *gin.Context) {
 	switch {
 	case len(c.Errors) > 0:
 		h.lg.Warn(path, fields...)
-	case strings.Contains(path, "/debug"), strings.Contains(path, "/metrics"):
-		h.lg.Debug(path, fields...)
 	default:
-		h.lg.Info(path, fields...)
+		h.lg.Debug(path, fields...)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #680 

Problem Summary:
When the operator sets the label periodically, TiProxy keeps reporting the same config. Logs are too many.

What is changed and how it works:
- Keep a byte format of the current config in the memory
- Compare the latest config bytes with the original one, only log it, calculate

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
