### PR TITLE
manager: add a limit to the capture and replay job history

### DIFF
--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -131,3 +131,21 @@ func TestMarshalJobHistory(t *testing.T) {
   }
 ]`, mgr.Jobs())
 }
+
+func TestHistoryLen(t *testing.T) {
+	mgr := NewJobManager(zap.NewNop(), &config.Config{}, &mockCertMgr{}, nil, nil)
+	defer mgr.Close()
+	cpt, rep := &mockCapture{}, &mockReplay{}
+	mgr.capture, mgr.replay = cpt, rep
+	require.Len(t, mgr.jobHistory, 0)
+
+	for i := 0; i < maxJobHistoryCount+1; i++ {
+		require.NoError(t, mgr.StartCapture(capture.CaptureConfig{}))
+		require.Contains(t, mgr.Stop(), "stopped")
+		expectedLen := i + 1
+		if expectedLen > maxJobHistoryCount {
+			expectedLen = maxJobHistoryCount
+		}
+		require.Len(t, mgr.jobHistory, expectedLen)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #693 

Problem Summary:
The job history length is unlimited, which may consume much memory if the proxy runs for years.

What is changed and how it works:
Set the length limit to 10.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
