### PR TITLE
*: fix several bugs of traffic replay

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,9 @@ linters-settings:
         - io.WriteString
         - (*go.uber.org/zap/buffer.Buffer).WriteString
         - (*go.uber.org/zap/buffer.Buffer).WriteByte
+  gosec:
+    exclude-rules:
+      - id: G115
 
 issues:
   exclude-rules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,7 @@ issues:
       linters:
         - gosec
       text: "G204:"
-    - path: *
+    - path: ".*.go"
       linters:
         - gosec
       text: "G115:"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,9 +8,6 @@ linters-settings:
         - io.WriteString
         - (*go.uber.org/zap/buffer.Buffer).WriteString
         - (*go.uber.org/zap/buffer.Buffer).WriteByte
-  gosec:
-    exclude-rules:
-      - G115
 
 issues:
   exclude-rules:
@@ -33,6 +30,10 @@ issues:
       linters:
         - gosec
       text: "G204:"
+    - path: *
+      linters:
+        - gosec
+      text: "G115:"
 
 linters:
   enable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,7 @@ linters-settings:
         - (*go.uber.org/zap/buffer.Buffer).WriteByte
   gosec:
     exclude-rules:
-      - id: G115
+      - G115
 
 issues:
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ cmd_%:
 	go build $(BUILDFLAGS) -o $(OUTPUT) $(SOURCE)
 
 golangci-lint:
-	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 go-header:
 	GOBIN=$(GOBIN) go install github.com/denis-tingaikin/go-header/cmd/go-header@latest

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/j-keck/arping v1.0.3
 	github.com/klauspost/compress v1.16.6
+	github.com/pelletier/go-toml/v2 v2.0.5
 	github.com/pingcap/kvproto v0.0.0-20231018065736-c0689aded40c
 	github.com/pingcap/sysutil v1.0.0
 	github.com/pingcap/tidb v1.1.0-beta.0.20230103132820-3ccff46aa3bc
@@ -73,7 +74,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pingcap/check v0.0.0-20211026125417-57bd13f7b5f0 // indirect
 	github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32 // indirect
 	github.com/pingcap/log v1.1.1-0.20221116035753-734d527bc87c // indirect

--- a/pkg/manager/vip/network_test.go
+++ b/pkg/manager/vip/network_test.go
@@ -1,7 +1,7 @@
 // Copyright 2024 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// go:build linux
+//go:build linux
 
 package vip
 

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -763,7 +763,6 @@ func (mgr *BackendConnManager) Close() error {
 	if backendIO := mgr.backendIO.Swap(nil); backendIO != nil {
 		addr = (*backendIO).RemoteAddr().String()
 		connErr = (*backendIO).Close()
-		mgr.logger.Info("backendIO is closed")
 	}
 
 	eventReceiver := mgr.getEventReceiver()

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -763,6 +763,7 @@ func (mgr *BackendConnManager) Close() error {
 	if backendIO := mgr.backendIO.Swap(nil); backendIO != nil {
 		addr = (*backendIO).RemoteAddr().String()
 		connErr = (*backendIO).Close()
+		mgr.logger.Info("backendIO is closed")
 	}
 
 	eventReceiver := mgr.getEventReceiver()

--- a/pkg/proxy/net/capability.go
+++ b/pkg/proxy/net/capability.go
@@ -96,7 +96,7 @@ func (f Capability) String() string {
 			if cnt > 0 {
 				str.WriteByte('|')
 			}
-			fmt.Fprintf(str, c.Str)
+			fmt.Fprint(str, c.Str)
 			cnt++
 		}
 	}

--- a/pkg/proxy/net/protocol.go
+++ b/pkg/proxy/net/protocol.go
@@ -127,12 +127,10 @@ func DumpLengthEncodedInt(buffer []byte, n uint64) []byte {
 	case n <= 0xffffff:
 		return append(buffer, 0xfd, byte(n), byte(n>>8), byte(n>>16))
 
-	case n <= 0xffffffffffffffff:
+	default:
 		return append(buffer, 0xfe, byte(n), byte(n>>8), byte(n>>16), byte(n>>24),
 			byte(n>>32), byte(n>>40), byte(n>>48), byte(n>>56))
 	}
-
-	return buffer
 }
 
 // DumpLengthEncodedString dumps string<int>.

--- a/pkg/proxy/net/protocol.go
+++ b/pkg/proxy/net/protocol.go
@@ -26,6 +26,8 @@ package net
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -181,4 +183,68 @@ func Uint64ToBytes(n uint64) []byte {
 		byte(n >> 48),
 		byte(n >> 56),
 	}
+}
+
+func BinaryDate(pos int, paramValues []byte) (int, string) {
+	year := binary.LittleEndian.Uint16(paramValues[pos : pos+2])
+	pos += 2
+	month := paramValues[pos]
+	pos++
+	day := paramValues[pos]
+	pos++
+	return pos, fmt.Sprintf("%04d-%02d-%02d", year, month, day)
+}
+
+func BinaryDateTime(pos int, paramValues []byte) (int, string) {
+	pos, date := BinaryDate(pos, paramValues)
+	hour := paramValues[pos]
+	pos++
+	minute := paramValues[pos]
+	pos++
+	second := paramValues[pos]
+	pos++
+	return pos, fmt.Sprintf("%s %02d:%02d:%02d", date, hour, minute, second)
+}
+
+func BinaryTimestamp(pos int, paramValues []byte) (int, string) {
+	pos, dateTime := BinaryDateTime(pos, paramValues)
+	microSecond := binary.LittleEndian.Uint32(paramValues[pos : pos+4])
+	pos += 4
+	return pos, fmt.Sprintf("%s.%06d", dateTime, microSecond)
+}
+
+func BinaryTimestampWithTZ(pos int, paramValues []byte) (int, string) {
+	pos, timestamp := BinaryTimestamp(pos, paramValues)
+	tzShiftInMin := int16(binary.LittleEndian.Uint16(paramValues[pos : pos+2]))
+	tzShiftHour := tzShiftInMin / 60
+	tzShiftAbsMin := tzShiftInMin % 60
+	if tzShiftAbsMin < 0 {
+		tzShiftAbsMin = -tzShiftAbsMin
+	}
+	pos += 2
+	return pos, fmt.Sprintf("%s%+02d:%02d", timestamp, tzShiftHour, tzShiftAbsMin)
+}
+
+func BinaryDuration(pos int, paramValues []byte, isNegative uint8) (int, string) {
+	sign := ""
+	if isNegative >= 1 {
+		sign = "-"
+	}
+	days := binary.LittleEndian.Uint32(paramValues[pos : pos+4])
+	pos += 4
+	hours := paramValues[pos]
+	pos++
+	minutes := paramValues[pos]
+	pos++
+	seconds := paramValues[pos]
+	pos++
+	return pos, fmt.Sprintf("%s%d %02d:%02d:%02d", sign, days, hours, minutes, seconds)
+}
+
+func BinaryDurationWithMS(pos int, paramValues []byte,
+	isNegative uint8) (int, string) {
+	pos, dur := BinaryDuration(pos, paramValues, isNegative)
+	microSecond := binary.LittleEndian.Uint32(paramValues[pos : pos+4])
+	pos += 4
+	return pos, fmt.Sprintf("%s.%06d", dur, microSecond)
 }

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -277,7 +277,8 @@ func (c *capture) Capture(packet []byte, startTime time.Time, connID uint64, ini
 		// initSession is slow, do not call it in the lock.
 		sql, err := initSession()
 		if err != nil {
-			c.lg.Warn("failed to init session", zap.Error(err))
+			// Maybe the connection is in transaction or closing.
+			c.lg.Debug("failed to init session", zap.Uint64("connID", connID), zap.Error(err))
 			return
 		}
 		initPacket := make([]byte, 0, len(sql)+1)

--- a/pkg/sqlreplay/cmd/cmd_test.go
+++ b/pkg/sqlreplay/cmd/cmd_test.go
@@ -139,7 +139,7 @@ func TestDigest(t *testing.T) {
 	require.Equal(t, cmd1.Digest(), cmd4.Digest())
 	require.Equal(t, "select ?", cmd4.QueryText())
 
-	data, err := pnet.MakeExecuteStmtRequest(1, []any{1})
+	data, err := pnet.MakeExecuteStmtRequest(1, []any{1}, true)
 	require.NoError(t, err)
 	cmd5 := NewCommand(data, time.Now(), 100)
 	cmd5.PreparedStmt = "select ?"

--- a/pkg/sqlreplay/conn/backend_conn.go
+++ b/pkg/sqlreplay/conn/backend_conn.go
@@ -107,7 +107,7 @@ func (bc *backendConn) updatePreparedStmts(request, response []byte) {
 				bc.lg.Warn("failed to unmarshal session states", zap.Error(err))
 			}
 			for stmtID, stmt := range sessionStates.PreparedStmts {
-				bc.preparedStmts[stmtID] = preparedStmt{text: stmt.StmtText, paramNum: len(stmt.ParamTypes)}
+				bc.preparedStmts[stmtID] = preparedStmt{text: stmt.StmtText, paramNum: len(stmt.ParamTypes) >> 1}
 			}
 		}
 	}

--- a/pkg/sqlreplay/conn/backend_conn.go
+++ b/pkg/sqlreplay/conn/backend_conn.go
@@ -74,10 +74,10 @@ func (bc *backendConn) ConnID() uint64 {
 
 func (bc *backendConn) ExecuteCmd(ctx context.Context, request []byte) error {
 	err := bc.backendConnMgr.ExecuteCmd(ctx, request)
-	bc.clientIO.Reset()
 	if err == nil {
 		bc.updatePreparedStmts(request, bc.clientIO.GetResp())
 	}
+	bc.clientIO.Reset()
 	return err
 }
 

--- a/pkg/sqlreplay/conn/backend_conn.go
+++ b/pkg/sqlreplay/conn/backend_conn.go
@@ -146,4 +146,7 @@ func (bc *backendConn) Close() {
 	if err := bc.clientIO.Close(); err != nil {
 		bc.lg.Warn("failed to close client connection", zap.Error(err))
 	}
+	if err := bc.backendConnMgr.Close(); err != nil {
+		bc.lg.Warn("failed to close backend connection", zap.Error(err))
+	}
 }

--- a/pkg/sqlreplay/conn/backend_conn_test.go
+++ b/pkg/sqlreplay/conn/backend_conn_test.go
@@ -30,6 +30,7 @@ func TestBackendConn(t *testing.T) {
 	require.NoError(t, backendConn.ExecuteStmt(context.Background(), 1, []any{uint64(1), "abc", float64(1.0)}))
 	backendConn.ConnID()
 	backendConn.Close()
+	require.True(t, backendConnMgr.closed)
 }
 
 func TestPreparedStmt(t *testing.T) {

--- a/pkg/sqlreplay/conn/backend_conn_test.go
+++ b/pkg/sqlreplay/conn/backend_conn_test.go
@@ -38,7 +38,7 @@ func TestPreparedStmt(t *testing.T) {
 		PreparedStmts: map[uint32]*preparedStmtInfo{
 			1: {
 				StmtText:   "select ?",
-				ParamTypes: []byte{0x08},
+				ParamTypes: []byte{0x08, 0x00},
 			},
 		},
 	}
@@ -60,8 +60,9 @@ func TestPreparedStmt(t *testing.T) {
 			response: pnet.MakeOKPacket(0, pnet.OKHeader),
 			preparedStmts: map[uint32]preparedStmt{
 				1: {
-					text:     "select ?",
-					paramNum: 1,
+					text:       "select ?",
+					paramNum:   1,
+					paramTypes: []byte{0x08, 0x00},
 				},
 			},
 		},
@@ -70,8 +71,9 @@ func TestPreparedStmt(t *testing.T) {
 			response: pnet.MakePrepareStmtResp(2, 2),
 			preparedStmts: map[uint32]preparedStmt{
 				1: {
-					text:     "select ?",
-					paramNum: 1,
+					text:       "select ?",
+					paramNum:   1,
+					paramTypes: []byte{0x08, 0x00},
 				},
 				2: {
 					text:     "insert into t values(?), (?)",

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -72,6 +72,9 @@ func (c *conn) Run(ctx context.Context) {
 					return
 				}
 			}
+			if command.Type == pnet.ComQuit {
+				return
+			}
 		}
 	}
 }

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -109,7 +109,6 @@ func (c *conn) ExecuteCmd(command *cmd.Command) {
 }
 
 func (c *conn) close() {
-	c.lg.Info("close connection", zap.Uint64("captureID", c.connID))
 	c.backendConn.Close()
 	c.closeCh <- c.connID
 }

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -61,6 +61,7 @@ func (c *conn) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			// ctx is canceled when the replay is finished
 			return
 		case command := <-c.cmdCh:
 			if err := c.backendConn.ExecuteCmd(ctx, command.Payload); err != nil {

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -109,6 +109,7 @@ func (c *conn) ExecuteCmd(command *cmd.Command) {
 }
 
 func (c *conn) close() {
+	c.lg.Info("close connection", zap.Uint64("captureID", c.connID))
 	c.backendConn.Close()
 	c.closeCh <- c.connID
 }

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
-	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/pkg/manager/id"
@@ -103,9 +102,8 @@ func (c *conn) updateCmdForExecuteStmt(command *cmd.Command) bool {
 func (c *conn) ExecuteCmd(command *cmd.Command) {
 	select {
 	case c.cmdCh <- command:
-	case <-time.After(3 * time.Second):
-		// If the replay is slower, wait until it catches up, otherwise too many transactions are broken.
-		// But if it's blocked due to a bug, discard the command to avoid block the whole replay.
+	default:
+		// Discard this command to avoid block due to a bug.
 		// If the discarded command is a COMMIT, let the next COMMIT finish the transaction.
 		select {
 		case c.exceptionCh <- NewOtherException(errors.New("too many pending commands, discard command"), c.connID):

--- a/pkg/sqlreplay/conn/conn_test.go
+++ b/pkg/sqlreplay/conn/conn_test.go
@@ -31,7 +31,7 @@ func TestConnectError(t *testing.T) {
 		},
 		{
 			execErr: io.EOF,
-			tp:      Fail,
+			tp:      Other,
 		},
 	}
 
@@ -92,7 +92,7 @@ func TestExecuteError(t *testing.T) {
 		},
 		{
 			prepare: func(bc *mockBackendConn) []byte {
-				request, err := pnet.MakeExecuteStmtRequest(1, []any{uint64(100), "abc", nil})
+				request, err := pnet.MakeExecuteStmtRequest(1, []any{uint64(100), "abc", nil}, true)
 				require.NoError(t, err)
 				bc.prepareStmt = "select ?"
 				bc.paramNum = 3

--- a/pkg/sqlreplay/conn/exception.go
+++ b/pkg/sqlreplay/conn/exception.go
@@ -34,17 +34,20 @@ type Exception interface {
 	Type() ExceptionType
 	Key() string
 	ConnID() uint64
+	Time() time.Time
 }
 
 type OtherException struct {
 	err    error
 	connID uint64
+	ts     time.Time
 }
 
 func NewOtherException(err error, connID uint64) *OtherException {
 	return &OtherException{
 		err:    err,
 		connID: connID,
+		ts:     time.Now(),
 	}
 }
 
@@ -66,6 +69,10 @@ func (oe *OtherException) ConnID() uint64 {
 
 func (oe *OtherException) Error() string {
 	return oe.err.Error()
+}
+
+func (oe *OtherException) Time() time.Time {
+	return oe.ts
 }
 
 type FailException struct {

--- a/pkg/sqlreplay/conn/exception_test.go
+++ b/pkg/sqlreplay/conn/exception_test.go
@@ -57,5 +57,6 @@ func TestOtherException(t *testing.T) {
 		require.Equal(t, Other, exception.Type(), "case %d", i)
 		require.Equal(t, uint64(1), exception.ConnID(), "case %d", i)
 		require.Equal(t, "mock error", exception.Key(), "case %d", i)
+		require.Greater(t, exception.Time(), time.Time{}, "case %d", i)
 	}
 }

--- a/pkg/sqlreplay/conn/mock_test.go
+++ b/pkg/sqlreplay/conn/mock_test.go
@@ -75,8 +75,8 @@ func (c *mockBackendConn) ExecuteStmt(ctx context.Context, stmtID uint32, args [
 	return c.execErr
 }
 
-func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int) {
-	return c.prepareStmt, c.paramNum
+func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int, []byte) {
+	return c.prepareStmt, c.paramNum, nil
 }
 
 func (c *mockBackendConn) Close() {

--- a/pkg/sqlreplay/conn/mock_test.go
+++ b/pkg/sqlreplay/conn/mock_test.go
@@ -15,6 +15,7 @@ var _ BackendConnManager = (*mockBackendConnMgr)(nil)
 
 type mockBackendConnMgr struct {
 	clientIO net.PacketIO
+	closed   bool
 }
 
 func (m *mockBackendConnMgr) Connect(ctx context.Context, clientIO net.PacketIO, frontendTLSConfig *tls.Config, backendTLSConfig *tls.Config, username string, password string) error {
@@ -31,6 +32,7 @@ func (m *mockBackendConnMgr) ExecuteCmd(ctx context.Context, request []byte) err
 }
 
 func (m *mockBackendConnMgr) Close() error {
+	m.closed = true
 	return m.clientIO.Close()
 }
 

--- a/pkg/sqlreplay/conn/prepared_stmt.go
+++ b/pkg/sqlreplay/conn/prepared_stmt.go
@@ -4,7 +4,7 @@
 package conn
 
 const (
-	setSessionStates = "set session_states "
+	setSessionStates = "SET SESSION_STATES "
 )
 
 type sessionStates struct {

--- a/pkg/sqlreplay/conn/prepared_stmt.go
+++ b/pkg/sqlreplay/conn/prepared_stmt.go
@@ -19,6 +19,7 @@ type preparedStmtInfo struct {
 
 // Used for parsing prepared stmt.
 type preparedStmt struct {
-	text     string
-	paramNum int
+	text       string
+	paramTypes []byte
+	paramNum   int
 }

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -116,6 +116,9 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.startTime = time.Now()
 	r.endTime = time.Time{}
 	r.progress = 0
+	r.replayedCmds = 0
+	r.filteredCmds = 0
+	r.connCount = 0
 	r.conns = make(map[uint64]conn.Conn)
 	r.exceptionCh = make(chan conn.Exception, maxPendingExceptions)
 	r.closeCh = make(chan uint64, maxPendingExceptions)
@@ -229,6 +232,7 @@ func (r *replay) readCloseCh(ctx context.Context) {
 		select {
 		case c, ok := <-r.closeCh:
 			if !ok {
+				// impossible
 				return
 			}
 			// Keep the disconnected connections in the map to reject subsequent commands with the same connID,

--- a/pkg/sqlreplay/report/mock_test.go
+++ b/pkg/sqlreplay/report/mock_test.go
@@ -35,7 +35,7 @@ func (db *mockReportDB) clear() {
 	db.exceptions = exceptions
 }
 
-func (db *mockReportDB) InsertExceptions(ctx context.Context, tp conn.ExceptionType, m map[string]*expCollection) error {
+func (db *mockReportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error {
 	db.Lock()
 	defer db.Unlock()
 	exps := db.exceptions[tp]

--- a/pkg/sqlreplay/report/mock_test.go
+++ b/pkg/sqlreplay/report/mock_test.go
@@ -86,8 +86,8 @@ func (c *mockBackendConn) ExecuteStmt(ctx context.Context, stmtID uint32, args [
 	return c.execErr
 }
 
-func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int) {
-	return "", 0
+func (c *mockBackendConn) GetPreparedStmt(stmtID uint32) (string, int, []byte) {
+	return "", 0, nil
 }
 
 func (c *mockBackendConn) clear() {

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -102,7 +102,7 @@ func (rdb *reportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCo
 		}
 		// retry in case of disconnection
 		ctx := context.Background()
-		return retry.Retry(func() error {
+		err := retry.Retry(func() error {
 			err := rdb.conn.ExecuteStmt(ctx, rdb.stmtIDs[tp], args)
 			if err == nil {
 				return nil
@@ -114,6 +114,9 @@ func (rdb *reportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCo
 			}
 			return err
 		}, ctx, 100*time.Millisecond, 3)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -5,8 +5,11 @@ package report
 
 import (
 	"context"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/lib/util/retry"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
 	"go.uber.org/zap"
@@ -16,7 +19,7 @@ type BackendConnCreator func() conn.BackendConn
 
 type ReportDB interface {
 	Init(ctx context.Context) error
-	InsertExceptions(ctx context.Context, tp conn.ExceptionType, m map[string]*expCollection) error
+	InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error
 	Close()
 }
 
@@ -82,7 +85,7 @@ func (rdb *reportDB) initStmts(ctx context.Context) (err error) {
 	return
 }
 
-func (rdb *reportDB) InsertExceptions(ctx context.Context, tp conn.ExceptionType, m map[string]*expCollection) error {
+func (rdb *reportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error {
 	for _, value := range m {
 		var args []any
 		switch tp {
@@ -98,19 +101,19 @@ func (rdb *reportDB) InsertExceptions(ctx context.Context, tp conn.ExceptionType
 			return errors.WithStack(errors.New("unknown exception type"))
 		}
 		// retry in case of disconnection
-		for i := 0; i < 3; i++ {
+		ctx := context.Background()
+		return retry.Retry(func() error {
 			err := rdb.conn.ExecuteStmt(ctx, rdb.stmtIDs[tp], args)
 			if err == nil {
-				break
+				return nil
 			}
 			if pnet.IsDisconnectError(err) {
-				if err = rdb.reconnect(ctx); err != nil {
-					return err
+				if err := rdb.reconnect(ctx); err != nil {
+					return backoff.Permanent(err)
 				}
-				continue
 			}
 			return err
-		}
+		}, ctx, 100*time.Millisecond, 3)
 	}
 	return nil
 }

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -96,7 +96,7 @@ func (rdb *reportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCo
 				command.StartTs.String(), sample.Time().String(), value.count, value.count}
 		case conn.Other:
 			sample := value.sample.(*conn.OtherException)
-			args = []any{sample.Key(), sample.Error(), nil, value.count, value.count}
+			args = []any{sample.Key(), sample.Error(), sample.Time().String(), value.count, value.count}
 		default:
 			return errors.WithStack(errors.New("unknown exception type"))
 		}

--- a/pkg/sqlreplay/report/report_db_test.go
+++ b/pkg/sqlreplay/report/report_db_test.go
@@ -111,7 +111,7 @@ func TestInsertExceptions(t *testing.T) {
 		err := db.Init(context.Background())
 		require.NoErrorf(t, err, "case %d", i)
 		cn.clear()
-		err = db.InsertExceptions(context.Background(), test.tp, test.colls)
+		err = db.InsertExceptions(test.tp, test.colls)
 		require.NoErrorf(t, err, "case %d", i)
 		require.Equal(t, test.stmtID, cn.stmtID, "case %d", i)
 		if len(test.args) > 1 {

--- a/pkg/sqlreplay/report/report_db_test.go
+++ b/pkg/sqlreplay/report/report_db_test.go
@@ -55,6 +55,9 @@ func TestInsertExceptions(t *testing.T) {
 	now := time.Now()
 	failSample := conn.NewFailException(errors.New("mock error"),
 		cmd.NewCommand(append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...), now, 1))
+	otherSample1 := conn.NewOtherException(errors.Wrapf(errors.New("mock error"), "wrap"), 1)
+	otherSample2 := conn.NewOtherException(errors.New("mock error"), 1)
+	otherSample3 := conn.NewOtherException(errors.New("another error"), 2)
 	tests := []struct {
 		tp     conn.ExceptionType
 		colls  map[string]*expCollection
@@ -66,26 +69,27 @@ func TestInsertExceptions(t *testing.T) {
 			colls: map[string]*expCollection{
 				"mock error": {
 					count:  1,
-					sample: conn.NewOtherException(errors.Wrapf(errors.New("mock error"), "wrap"), 1),
+					sample: otherSample1,
 				},
 			},
 			stmtID: []uint32{2},
-			args:   [][]any{{"mock error", "wrap: mock error", nil, uint64(1), uint64(1)}},
+			args:   [][]any{{"mock error", "wrap: mock error", otherSample1.Time().String(), uint64(1), uint64(1)}},
 		},
 		{
 			tp: conn.Other,
 			colls: map[string]*expCollection{
 				"mock error": {
 					count:  2,
-					sample: conn.NewOtherException(errors.New("mock error"), 1),
+					sample: otherSample2,
 				},
 				"another error": {
 					count:  2,
-					sample: conn.NewOtherException(errors.New("another error"), 2),
+					sample: otherSample3,
 				},
 			},
 			stmtID: []uint32{2, 2},
-			args:   [][]any{{"mock error", "mock error", nil, uint64(2), uint64(2)}, {"another error", "another error", nil, uint64(2), uint64(2)}},
+			args: [][]any{{"mock error", "mock error", otherSample2.Time().String(), uint64(2), uint64(2)},
+				{"another error", "another error", otherSample3.Time().String(), uint64(2), uint64(2)}},
 		},
 		{
 			tp: conn.Fail,

--- a/pkg/sqlreplay/report/report_test.go
+++ b/pkg/sqlreplay/report/report_test.go
@@ -21,19 +21,21 @@ func TestReadExceptions(t *testing.T) {
 	now := time.Now()
 	failSample := conn.NewFailException(errors.New("another error"), cmd.NewCommand(append([]byte{pnet.ComQuery.Byte()},
 		[]byte("select 1")...), now, 1))
+	otherSample1 := conn.NewOtherException(errors.New("mock error"), 1)
+	otherSample2 := conn.NewOtherException(errors.New("another error"), 1)
 	tests := []struct {
 		exceptions []conn.Exception
 		finalExps  map[conn.ExceptionType]map[string]*expCollection
 	}{
 		{
 			exceptions: []conn.Exception{
-				conn.NewOtherException(errors.New("mock error"), 1),
+				otherSample1,
 			},
 			finalExps: map[conn.ExceptionType]map[string]*expCollection{
 				conn.Other: {
 					"mock error": &expCollection{
 						count:  1,
-						sample: conn.NewOtherException(errors.New("mock error"), 1),
+						sample: otherSample1,
 					},
 				},
 				conn.Fail: {},
@@ -48,7 +50,7 @@ func TestReadExceptions(t *testing.T) {
 				conn.Other: {
 					"mock error": &expCollection{
 						count:  3,
-						sample: conn.NewOtherException(errors.New("mock error"), 1),
+						sample: otherSample1,
 					},
 				},
 				conn.Fail: {},
@@ -56,17 +58,17 @@ func TestReadExceptions(t *testing.T) {
 		},
 		{
 			exceptions: []conn.Exception{
-				conn.NewOtherException(errors.New("another error"), 1),
+				otherSample2,
 			},
 			finalExps: map[conn.ExceptionType]map[string]*expCollection{
 				conn.Other: {
 					"mock error": &expCollection{
 						count:  3,
-						sample: conn.NewOtherException(errors.New("mock error"), 1),
+						sample: otherSample1,
 					},
 					"another error": &expCollection{
 						count:  1,
-						sample: conn.NewOtherException(errors.New("another error"), 1),
+						sample: otherSample2,
 					},
 				},
 				conn.Fail: {},
@@ -80,11 +82,11 @@ func TestReadExceptions(t *testing.T) {
 				conn.Other: {
 					"mock error": &expCollection{
 						count:  3,
-						sample: conn.NewOtherException(errors.New("mock error"), 1),
+						sample: otherSample1,
 					},
 					"another error": &expCollection{
 						count:  1,
-						sample: conn.NewOtherException(errors.New("another error"), 1),
+						sample: otherSample2,
 					},
 				},
 				conn.Fail: {

--- a/pkg/sqlreplay/store/loader.go
+++ b/pkg/sqlreplay/store/loader.go
@@ -163,8 +163,9 @@ func (l *loader) nextReader() error {
 			return errors.WithStack(err)
 		}
 		l.reader = bufio.NewReader(gr)
+	} else {
+		l.reader = bufio.NewReader(r)
 	}
-	l.reader = bufio.NewReader(r)
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #642 

Problem Summary:
- Reading data from gzip files fails because the reader is overwritten
- fd number is not recovered after replay because backend connections are not closed
- Paring ComPrepareStmt fails because the buffer is reset before fetching the data
- The connections are not closed immediately because the ComQuit is not checked
- The progress is wrong at the second replay because the replayedCmds is not reset
- Prepared statements are not found because unmarshaling session states fails
- Execution errors in the last 5 seconds may be not flushed
- The parsed param num in session states is wrong
- Paring ComExecuteStmt request is wrong
- `sample_replay_time` in `other_errors` is NULL

What is changed and how it works:
Fix all the above bugs

Enhancements:
- Disconnection errors during executions are summarized in table `other_errors`
- Wait for 3 seconds before discarding a command
- Upgrade golangci-lint version to support go 1.23 and fix some lint problems

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
