### PR TITLE
replay: slow down decoding when there are too many pending commands

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,12 @@
 FROM alpine:edge as builder
 
-RUN apk add --no-cache --progress git make go
+RUN apt-get -y -q update && \
+     apt-get -y -q install software-properties-common && \
+     apt-get install -qqy \
+         dos2unix \
+         default-mysql-client \
+         psmisc \
+         vim
 ARG VERSION
 ARG BRANCH
 ARG COMMIT
@@ -9,7 +15,7 @@ ADD . /proxy
 RUN export GOPROXY=${GOPROXY} && cd /proxy && go mod download -x
 RUN export VERSION=${VERSION} && export BRANCH=${BRANCH} && export COMMIT=${COMMIT} && export GOPROXY=${GOPROXY} && cd /proxy && make cmd
 
-FROM alpine:latest
+FROM golang:1.22-bullseye
 
 COPY --from=builder /proxy/bin/* /bin/
 COPY --from=builder /proxy/conf/* /etc/proxy/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,6 @@
 FROM alpine:edge as builder
 
-RUN apt-get -y -q update && \
-     apt-get -y -q install software-properties-common && \
-     apt-get install -qqy \
-         dos2unix \
-         default-mysql-client \
-         psmisc \
-         vim
+RUN apk add --no-cache --progress git make go
 ARG VERSION
 ARG BRANCH
 ARG COMMIT
@@ -15,7 +9,7 @@ ADD . /proxy
 RUN export GOPROXY=${GOPROXY} && cd /proxy && go mod download -x
 RUN export VERSION=${VERSION} && export BRANCH=${BRANCH} && export COMMIT=${COMMIT} && export GOPROXY=${GOPROXY} && cd /proxy && make cmd
 
-FROM golang:1.22-bullseye
+FROM alpine:latest
 
 COPY --from=builder /proxy/bin/* /bin/
 COPY --from=builder /proxy/conf/* /etc/proxy/

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,6 +32,7 @@ const (
 	LabelMonitor = "monitor"
 	LabelBackend = "backend"
 	LabelTraffic = "traffic"
+	LabelReplay  = "replay"
 )
 
 // MetricsManager manages metrics.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -121,6 +121,8 @@ func init() {
 		OutboundBytesCounter,
 		OutboundPacketsCounter,
 		CrossLocationBytesCounter,
+		ReplayPendingCmdsGauge,
+		ReplayWaitTime,
 	}
 }
 

--- a/pkg/metrics/replay.go
+++ b/pkg/metrics/replay.go
@@ -1,0 +1,24 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	ReplayPendingCmdsGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelReplay,
+			Name:      "pending_cmds",
+			Help:      "Counter of pending commands.",
+		})
+
+	ReplayWaitTime = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelReplay,
+			Name:      "wait_time",
+			Help:      "Wait time of replaying commands.",
+		})
+)

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -145,8 +145,8 @@ func (mc *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64
 	}
 }
 
-func (mc *mockCapture) Progress() (float64, time.Time, error) {
-	return 0, time.Time{}, nil
+func (mc *mockCapture) Progress() (float64, time.Time, bool, error) {
+	return 0, time.Time{}, false, nil
 }
 
 func (mc *mockCapture) Close() {

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -44,7 +44,7 @@ type Capture interface {
 	// Capture captures traffic
 	Capture(packet []byte, startTime time.Time, connID uint64, initSession func() (string, error))
 	// Progress returns the progress of the capture job
-	Progress() (float64, time.Time, error)
+	Progress() (float64, time.Time, bool, error)
 	// Close closes the capture
 	Close()
 }
@@ -342,17 +342,17 @@ func (c *capture) writeMeta(duration time.Duration, cmds, filteredCmds uint64) {
 	}
 }
 
-func (c *capture) Progress() (float64, time.Time, error) {
+func (c *capture) Progress() (float64, time.Time, bool, error) {
 	c.Lock()
 	defer c.Unlock()
 	if c.status == statusIdle || c.cfg.Duration == 0 {
-		return c.progress, c.endTime, c.err
+		return c.progress, c.endTime, true, c.err
 	}
 	progress := float64(time.Since(c.startTime)) / float64(c.cfg.Duration)
 	if progress > 1 {
 		progress = 1
 	}
-	return progress, c.endTime, c.err
+	return progress, c.endTime, false, c.err
 }
 
 // stopNoLock must be called after holding a lock.

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -170,12 +170,13 @@ func TestProgress(t *testing.T) {
 
 	now := time.Now()
 	require.NoError(t, cpt.Start(cfg))
-	progress, _, err := cpt.Progress()
+	progress, _, done, err := cpt.Progress()
 	require.NoError(t, err)
 	require.Less(t, progress, 0.3)
+	require.False(t, done)
 
 	setStartTime(now.Add(-5 * time.Second))
-	progress, _, err = cpt.Progress()
+	progress, _, _, err = cpt.Progress()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, progress, 0.5)
 
@@ -183,10 +184,11 @@ func TestProgress(t *testing.T) {
 	cpt.Capture(packet, time.Now(), 100, mockInitSession)
 	cpt.Stop(errors.Errorf("mock error"))
 	cpt.wg.Wait()
-	progress, _, err = cpt.Progress()
+	progress, _, done, err = cpt.Progress()
 	require.ErrorContains(t, err, "mock error")
 	require.GreaterOrEqual(t, progress, 0.5)
 	require.Less(t, progress, 1.0)
+	require.True(t, done)
 
 	m := store.Meta{}
 	require.NoError(t, m.Read(cfg.Output))

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -28,6 +28,7 @@ const (
 )
 
 type LineReader interface {
+	String() string
 	ReadLine() ([]byte, string, int, error)
 	Read([]byte) (string, int, error)
 	Close()

--- a/pkg/sqlreplay/cmd/mock_test.go
+++ b/pkg/sqlreplay/cmd/mock_test.go
@@ -39,3 +39,7 @@ func (mr *mockReader) Read(data []byte) (string, int, error) {
 
 func (mr *mockReader) Close() {
 }
+
+func (mr *mockReader) String() string {
+	return "mockReader"
+}

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -96,6 +96,7 @@ func (c *conn) Run(ctx context.Context) {
 				if err := c.backendConn.ExecuteCmd(ctx, command.Value.Payload); err != nil {
 					if pnet.IsDisconnectError(err) {
 						c.exceptionCh <- NewOtherException(err, c.connID)
+						c.lg.Info("backend connection disconnected", zap.Error(err))
 						return
 					}
 					if c.updateCmdForExecuteStmt(command.Value) {
@@ -158,6 +159,11 @@ func (c *conn) updatePendingCmds(pendingCmds int) {
 }
 
 func (c *conn) close() {
+	c.cmdLock.Lock()
+	if c.cmdList.Len() > 0 {
+		c.lg.Warn("backend connection closed while there are still pending commands", zap.Int("pending_cmds", c.cmdList.Len()))
+	}
+	c.cmdLock.Unlock()
 	c.updatePendingCmds(0)
 	c.backendConn.Close()
 	c.closeCh <- c.connID

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -80,6 +80,10 @@ func (c *conn) Run(ctx context.Context) {
 				if command == nil {
 					break
 				}
+				c.updateCmdForExecuteStmt(command.Value)
+				if text := command.Value.QueryText(); len(text) > 0 {
+					c.lg.Info("execute cmd", zap.String("cmd", text))
+				}
 				if err := c.backendConn.ExecuteCmd(ctx, command.Value.Payload); err != nil {
 					if pnet.IsDisconnectError(err) {
 						c.exceptionCh <- NewOtherException(err, c.connID)

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -125,7 +125,10 @@ func (c *conn) updateCmdForExecuteStmt(command *cmd.Command) bool {
 	return true
 }
 
-// ExecuteCmd executes a command asynchronously.
+// ExecuteCmd executes a command asynchronously by adding it to the list.
+// Adding commands should never block because it may cause cycle wait.
+// Conn A: wait for the lock held by conn B, and then its list becomes full and blocks the replay
+// Conn B: wait for next command, but the replay is blocked, so the lock won't be released
 func (c *conn) ExecuteCmd(command *cmd.Command) {
 	c.cmdLock.Lock()
 	c.cmdList.PushFront(command)

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -59,7 +59,7 @@ func NewConn(lg *zap.Logger, username, password string, backendTLSConfig *tls.Co
 		lg:          lg,
 		connID:      connID,
 		cmdList:     glist.New[*cmd.Command](),
-		cmdCh:       make(chan struct{}),
+		cmdCh:       make(chan struct{}, 1),
 		exceptionCh: exceptionCh,
 		closeCh:     closeCh,
 		backendConn: NewBackendConn(lg.Named("be"), backendConnID, hsHandler, bcConfig, backendTLSConfig, username, password),

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -100,7 +100,7 @@ func (c *conn) Run(ctx context.Context) {
 			if err := c.backendConn.ExecuteCmd(ctx, command.Value.Payload); err != nil {
 				if pnet.IsDisconnectError(err) {
 					c.exceptionCh <- NewOtherException(err, c.connID)
-					c.lg.Info("backend connection disconnected", zap.Error(err))
+					c.lg.Debug("backend connection disconnected", zap.Error(err))
 					return
 				}
 				if c.updateCmdForExecuteStmt(command.Value) {
@@ -164,7 +164,7 @@ func (c *conn) updatePendingCmds(pendingCmds int) {
 func (c *conn) close() {
 	c.cmdLock.Lock()
 	if c.cmdList.Len() > 0 {
-		c.lg.Warn("backend connection closed while there are still pending commands", zap.Int("pending_cmds", c.cmdList.Len()))
+		c.lg.Debug("backend connection closed while there are still pending commands", zap.Int("pending_cmds", c.cmdList.Len()))
 	}
 	c.cmdLock.Unlock()
 	c.updatePendingCmds(0)

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -7,16 +7,14 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"sync"
 
+	glist "github.com/bahlo/generic-list-go"
 	"github.com/pingcap/tiproxy/pkg/manager/id"
 	"github.com/pingcap/tiproxy/pkg/proxy/backend"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"go.uber.org/zap"
-)
-
-const (
-	maxPendingCommands = 100 // pending commands for each connection
 )
 
 type Conn interface {
@@ -29,7 +27,9 @@ type ConnCreator func(connID uint64) Conn
 var _ Conn = (*conn)(nil)
 
 type conn struct {
-	cmdCh       chan *cmd.Command
+	cmdLock     sync.Mutex
+	cmdCh       chan struct{}
+	cmdList     *glist.List[*cmd.Command]
 	exceptionCh chan<- Exception
 	closeCh     chan<- uint64
 	lg          *zap.Logger
@@ -44,7 +44,8 @@ func NewConn(lg *zap.Logger, username, password string, backendTLSConfig *tls.Co
 	return &conn{
 		lg:          lg,
 		connID:      connID,
-		cmdCh:       make(chan *cmd.Command, maxPendingCommands),
+		cmdList:     glist.New[*cmd.Command](),
+		cmdCh:       make(chan struct{}),
 		exceptionCh: exceptionCh,
 		closeCh:     closeCh,
 		backendConn: NewBackendConn(lg.Named("be"), backendConnID, hsHandler, bcConfig, backendTLSConfig, username, password),
@@ -57,27 +58,40 @@ func (c *conn) Run(ctx context.Context) {
 		c.exceptionCh <- NewOtherException(err, c.connID)
 		return
 	}
+	pendingCmdNum := 0
+	defer func() {
+		c.lg.Info("pending cmd num", zap.Int("num", pendingCmdNum))
+	}()
 	for {
 		select {
 		case <-ctx.Done():
-			// ctx is canceled when the replay is finished
 			return
-		case command := <-c.cmdCh:
-			c.updateCmdForExecuteStmt(command)
-			c.lg.Info("execute cmd", zap.String("cmd", command.QueryText()))
-			err := c.backendConn.ExecuteCmd(ctx, command.Payload)
-			if err != nil {
-				if pnet.IsDisconnectError(err) {
-					c.exceptionCh <- NewOtherException(err, c.connID)
+		case <-c.cmdCh:
+			for ctx.Err() == nil {
+				c.cmdLock.Lock()
+				if c.cmdList.Len() > pendingCmdNum {
+					pendingCmdNum = c.cmdList.Len()
+				}
+				command := c.cmdList.Back()
+				if command != nil {
+					c.cmdList.Remove(command)
+				}
+				c.cmdLock.Unlock()
+				if command == nil {
+					break
+				}
+				if err := c.backendConn.ExecuteCmd(ctx, command.Value.Payload); err != nil {
+					if pnet.IsDisconnectError(err) {
+						c.exceptionCh <- NewOtherException(err, c.connID)
+						return
+					}
+					if c.updateCmdForExecuteStmt(command.Value) {
+						c.exceptionCh <- NewFailException(err, command.Value)
+					}
+				}
+				if command.Value.Type == pnet.ComQuit {
 					return
 				}
-				if c.updateCmdForExecuteStmt(command) {
-					c.exceptionCh <- NewFailException(err, command)
-				}
-			}
-			c.lg.Info("execute cmd finished", zap.String("cmd", command.QueryText()), zap.Error(err))
-			if command.Type == pnet.ComQuit {
-				return
 			}
 		}
 	}
@@ -103,7 +117,13 @@ func (c *conn) updateCmdForExecuteStmt(command *cmd.Command) bool {
 
 // ExecuteCmd executes a command asynchronously.
 func (c *conn) ExecuteCmd(command *cmd.Command) {
-	c.cmdCh <- command
+	c.cmdLock.Lock()
+	defer c.cmdLock.Unlock()
+	c.cmdList.PushFront(command)
+	select {
+	case c.cmdCh <- struct{}{}:
+	default:
+	}
 }
 
 func (c *conn) close() {

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -89,10 +89,6 @@ func (c *conn) Run(ctx context.Context) {
 				if command == nil {
 					break
 				}
-				c.updateCmdForExecuteStmt(command.Value)
-				if text := command.Value.QueryText(); len(text) > 0 {
-					c.lg.Info("execute cmd", zap.String("cmd", text))
-				}
 				if err := c.backendConn.ExecuteCmd(ctx, command.Value.Payload); err != nil {
 					if pnet.IsDisconnectError(err) {
 						c.exceptionCh <- NewOtherException(err, c.connID)

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -63,6 +63,8 @@ func (c *conn) Run(ctx context.Context) {
 			// ctx is canceled when the replay is finished
 			return
 		case command := <-c.cmdCh:
+			c.updateCmdForExecuteStmt(command)
+			c.lg.Info("execute cmd", zap.String("cmd", command.QueryText()))
 			if err := c.backendConn.ExecuteCmd(ctx, command.Payload); err != nil {
 				if pnet.IsDisconnectError(err) {
 					c.exceptionCh <- NewOtherException(err, c.connID)

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	maxPendingCommands = 0 // pending commands for each connection
+	maxPendingCommands = 100 // pending commands for each connection
 )
 
 type Conn interface {

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -65,7 +65,8 @@ func (c *conn) Run(ctx context.Context) {
 		case command := <-c.cmdCh:
 			c.updateCmdForExecuteStmt(command)
 			c.lg.Info("execute cmd", zap.String("cmd", command.QueryText()))
-			if err := c.backendConn.ExecuteCmd(ctx, command.Payload); err != nil {
+			err := c.backendConn.ExecuteCmd(ctx, command.Payload)
+			if err != nil {
 				if pnet.IsDisconnectError(err) {
 					c.exceptionCh <- NewOtherException(err, c.connID)
 					return
@@ -74,6 +75,7 @@ func (c *conn) Run(ctx context.Context) {
 					c.exceptionCh <- NewFailException(err, command)
 				}
 			}
+			c.lg.Info("execute cmd finished", zap.String("cmd", command.QueryText()), zap.Error(err))
 			if command.Type == pnet.ComQuit {
 				return
 			}

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -95,8 +95,8 @@ func (c *conn) Run(ctx context.Context) {
 			if command != nil {
 				c.cmdList.Remove(command)
 			}
-			c.cmdLock.Unlock()
 			c.updatePendingCmds(pendingCmds)
+			c.cmdLock.Unlock()
 			if command == nil {
 				break
 			}
@@ -144,8 +144,8 @@ func (c *conn) ExecuteCmd(command *cmd.Command) {
 	c.cmdLock.Lock()
 	c.cmdList.PushFront(command)
 	pendingCmds := c.cmdList.Len()
-	c.cmdLock.Unlock()
 	c.updatePendingCmds(pendingCmds)
+	c.cmdLock.Unlock()
 	select {
 	case c.cmdCh <- struct{}{}:
 	default:
@@ -169,8 +169,8 @@ func (c *conn) close() {
 	if c.cmdList.Len() > 0 {
 		c.lg.Debug("backend connection closed while there are still pending commands", zap.Int("pending_cmds", c.cmdList.Len()))
 	}
-	c.cmdLock.Unlock()
 	c.updatePendingCmds(0)
+	c.cmdLock.Unlock()
 	c.backendConn.Close()
 	c.closeCh <- c.connID
 }

--- a/pkg/sqlreplay/conn/conn_test.go
+++ b/pkg/sqlreplay/conn/conn_test.go
@@ -39,7 +39,7 @@ func TestConnectError(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	for i, test := range tests {
 		exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-		conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
+		conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh, &ReplayStats{})
 		backendConn := &mockBackendConn{connErr: test.connErr, execErr: test.execErr}
 		conn.backendConn = backendConn
 		wg.RunWithRecover(func() {
@@ -60,7 +60,7 @@ func TestExecuteCmd(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	var wg waitgroup.WaitGroup
 	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh, &ReplayStats{})
 	backendConn := &mockBackendConn{}
 	conn.backendConn = backendConn
 	childCtx, cancel := context.WithCancel(context.Background())
@@ -106,7 +106,7 @@ func TestExecuteError(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	var wg waitgroup.WaitGroup
 	exceptionCh, closeCh := make(chan Exception, 1), make(chan uint64, 1)
-	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh)
+	conn := NewConn(lg, "u1", "", nil, nil, id.NewIDManager(), 1, &backend.BCConfig{}, exceptionCh, closeCh, &ReplayStats{})
 	backendConn := &mockBackendConn{execErr: errors.New("mock error")}
 	conn.backendConn = backendConn
 	childCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -24,7 +24,7 @@ type Job interface {
 	Type() jobType
 	String() string
 	MarshalJSON() ([]byte, error)
-	SetProgress(progress float64, endTime time.Time, err error)
+	SetProgress(progress float64, endTime time.Time, done bool, err error)
 	IsRunning() bool
 }
 
@@ -33,6 +33,7 @@ type job struct {
 	endTime   time.Time
 	progress  float64
 	err       error
+	done      bool
 }
 
 type job4Marshal struct {
@@ -53,12 +54,13 @@ func (job *job) IsRunning() bool {
 	return job.err == nil && job.progress < 1
 }
 
-func (job *job) SetProgress(progress float64, endTime time.Time, err error) {
+func (job *job) SetProgress(progress float64, endTime time.Time, done bool, err error) {
 	if progress > job.progress {
 		job.progress = progress
 	}
 	job.endTime = endTime
 	job.err = err
+	job.done = done
 }
 
 func (job *job) getJob4Marshal() *job4Marshal {
@@ -72,7 +74,7 @@ func (job *job) getJob4Marshal() *job4Marshal {
 	if job.err != nil {
 		jm.Status = "canceled"
 		jm.Err = job.err.Error()
-	} else if job.progress >= 1.0 {
+	} else if job.done {
 		jm.Status = "done"
 	} else {
 		jm.Status = "running"

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -95,7 +95,7 @@ func TestSetProgress(t *testing.T) {
 			},
 		}
 		now := time.Now()
-		job.SetProgress(test.progress, now, test.err)
+		job.SetProgress(test.progress, now, test.err != nil || test.progress >= 1.0, test.err)
 		require.Equal(t, now, job.endTime, "case %d", i)
 		require.Equal(t, test.expectedProgress, job.progress, "case %d", i)
 		require.Equal(t, test.running, job.IsRunning(), "case %d", i)
@@ -119,6 +119,7 @@ func TestMarshalJob(t *testing.T) {
 					endTime:   endTime,
 					progress:  0.5,
 					err:       errors.New("mock error"),
+					done:      true,
 				},
 				cfg: capture.CaptureConfig{
 					Output:   "/tmp/traffic",
@@ -146,6 +147,7 @@ func TestMarshalJob(t *testing.T) {
 					startTime: startTime,
 					endTime:   endTime,
 					progress:  1,
+					done:      true,
 				},
 				cfg: replay.ReplayConfig{
 					Input:    "/tmp/traffic",

--- a/pkg/sqlreplay/manager/manager.go
+++ b/pkg/sqlreplay/manager/manager.go
@@ -66,11 +66,11 @@ func (jm *jobManager) updateProgress() {
 	if job.IsRunning() {
 		switch job.Type() {
 		case Capture:
-			progress, endTime, err := jm.capture.Progress()
-			job.SetProgress(progress, endTime, err)
+			progress, endTime, done, err := jm.capture.Progress()
+			job.SetProgress(progress, endTime, done, err)
 		case Replay:
-			progress, endTime, err := jm.replay.Progress()
-			job.SetProgress(progress, endTime, err)
+			progress, endTime, done, err := jm.replay.Progress()
+			job.SetProgress(progress, endTime, done, err)
 		}
 	}
 }

--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -69,6 +69,7 @@ func TestMarshalJobHistory(t *testing.T) {
 				endTime:   endTime,
 				progress:  0.5,
 				err:       errors.New("mock error"),
+				done:      true,
 			},
 			cfg: capture.CaptureConfig{
 				Output:   "/tmp/traffic",
@@ -90,6 +91,7 @@ func TestMarshalJobHistory(t *testing.T) {
 				startTime: startTime,
 				endTime:   endTime,
 				progress:  1,
+				done:      true,
 			},
 			cfg: replay.ReplayConfig{
 				Input:    "/tmp/traffic",

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -37,8 +37,8 @@ func (m *mockCapture) Capture(packet []byte, startTime time.Time, connID uint64,
 func (m *mockCapture) Close() {
 }
 
-func (m *mockCapture) Progress() (float64, time.Time, error) {
-	return m.progress, time.Time{}, m.err
+func (m *mockCapture) Progress() (float64, time.Time, bool, error) {
+	return m.progress, time.Time{}, false, m.err
 }
 
 func (m *mockCapture) Stop(err error) {
@@ -61,8 +61,8 @@ type mockReplay struct {
 func (m *mockReplay) Close() {
 }
 
-func (m *mockReplay) Progress() (float64, time.Time, error) {
-	return m.progress, time.Time{}, m.err
+func (m *mockReplay) Progress() (float64, time.Time, bool, error) {
+	return m.progress, time.Time{}, false, m.err
 }
 
 func (m *mockReplay) Start(cfg replay.ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -36,6 +36,10 @@ func (c *mockConn) Run(ctx context.Context) {
 	c.closeCh <- c.connID
 }
 
+func (c *mockConn) Stop() {
+	close(c.cmdCh)
+}
+
 var _ cmd.LineReader = (*mockChLoader)(nil)
 
 type mockChLoader struct {

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -87,6 +87,10 @@ func (m *mockChLoader) Close() {
 	close(m.cmdCh)
 }
 
+func (m *mockChLoader) String() string {
+	return "mockChLoader"
+}
+
 var _ cmd.LineReader = (*mockNormalLoader)(nil)
 
 type mockNormalLoader struct {
@@ -115,6 +119,10 @@ func (m *mockNormalLoader) ReadLine() ([]byte, string, int, error) {
 }
 
 func (m *mockNormalLoader) Close() {
+}
+
+func (m *mockNormalLoader) String() string {
+	return "mockNormalLoader"
 }
 
 func newMockCommand(connID uint64) *cmd.Command {

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -19,10 +19,10 @@ import (
 var _ conn.Conn = (*mockConn)(nil)
 
 type mockConn struct {
-	exceptionCh chan conn.Exception
-	closeCh     chan uint64
-	cmdCh       chan *cmd.Command
-	connID      uint64
+	closeCh chan uint64
+	cmdCh   chan *cmd.Command
+	connID  uint64
+	closed  chan struct{}
 }
 
 func (c *mockConn) ExecuteCmd(command *cmd.Command) {
@@ -32,12 +32,35 @@ func (c *mockConn) ExecuteCmd(command *cmd.Command) {
 }
 
 func (c *mockConn) Run(ctx context.Context) {
-	<-ctx.Done()
+	<-c.closed
 	c.closeCh <- c.connID
 }
 
 func (c *mockConn) Stop() {
-	close(c.cmdCh)
+	c.closed <- struct{}{}
+}
+
+type mockPendingConn struct {
+	closeCh     chan uint64
+	connID      uint64
+	closed      chan struct{}
+	pendingCmds int64
+	stats       *conn.ReplayStats
+}
+
+func (c *mockPendingConn) ExecuteCmd(command *cmd.Command) {
+	c.pendingCmds++
+	c.stats.PendingCmds.Add(1)
+}
+
+func (c *mockPendingConn) Run(ctx context.Context) {
+	<-c.closed
+	c.stats.PendingCmds.Add(-c.pendingCmds)
+	c.closeCh <- c.connID
+}
+
+func (c *mockPendingConn) Stop() {
+	c.closed <- struct{}{}
 }
 
 var _ cmd.LineReader = (*mockChLoader)(nil)

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -169,6 +169,7 @@ func (r *replay) readCommands(ctx context.Context) {
 		command := &cmd.Command{}
 		if err := command.Decode(reader); err != nil {
 			if errors.Is(err, io.EOF) {
+				r.lg.Info("replay reads EOF", zap.String("reader", reader.String()))
 				err = nil
 			}
 			r.Stop(err)

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -116,6 +116,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.startTime = time.Now()
 	r.endTime = time.Time{}
 	r.progress = 0
+	r.err = nil
 	r.replayedCmds = 0
 	r.filteredCmds = 0
 	r.connCount = 0

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -236,6 +236,12 @@ func (r *replay) readCommands(ctx context.Context) {
 	r.lg.Info("finished decoding commands, waiting for connections to close", zap.Int64("max_pending_cmds", maxPendingCmds),
 		zap.Duration("total_wait_time", totalWaitTime), zap.Int("alive_conns", connCount))
 
+	for _, conn := range conns {
+		if conn != nil && !reflect.ValueOf(conn).IsNil() {
+			conn.Stop()
+		}
+	}
+
 	// Wait until all connections are closed before logging the finished message.
 	// Besides, drain all close events to avoid blocking connections at writing to channels.
 	for connCount > 0 {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -212,6 +212,7 @@ func (r *replay) readCommands(ctx context.Context) {
 			if pendingCmds > maxPendingCmds {
 				maxPendingCmds = pendingCmds
 			}
+			metrics.ReplayPendingCmdsGauge.Set(float64(pendingCmds))
 			// If slowing down still doesn't help, abort the replay to avoid OOM.
 			if pendingCmds > r.cfg.abortThreshold {
 				err = errors.Errorf("too many pending commands, quit replay")
@@ -236,7 +237,6 @@ func (r *replay) readCommands(ctx context.Context) {
 				expectedInterval += extraWait
 				metrics.ReplayWaitTime.Set(float64(totalWaitTime.Nanoseconds()))
 			}
-			metrics.ReplayPendingCmdsGauge.Set(float64(r.replayStats.PendingCmds.Load()))
 			if expectedInterval > time.Microsecond {
 				select {
 				case <-ctx.Done():

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -201,11 +201,11 @@ func (r *replay) readCommands(ctx context.Context) {
 			if r.cfg.Speed != 1 {
 				expectedInterval = time.Duration(float64(expectedInterval) / r.cfg.Speed)
 			}
-			if pendingCmds > 1<<10 {
-				extraWait := time.Duration(pendingCmds-1<<10) * 100 * time.Nanosecond
-				totalWaitTime += extraWait
-				expectedInterval += extraWait
-			}
+			// if pendingCmds > 1<<10 {
+			// 	extraWait := time.Duration(pendingCmds-1<<10) * 100 * time.Nanosecond
+			// 	totalWaitTime += extraWait
+			// 	expectedInterval += extraWait
+			// }
 			if expectedInterval > time.Microsecond {
 				select {
 				case <-ctx.Done():

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -201,6 +201,7 @@ func (r *replay) readCommands(ctx context.Context) {
 			if r.cfg.Speed != 1 {
 				expectedInterval = time.Duration(float64(expectedInterval) / r.cfg.Speed)
 			}
+			startTime := time.Now()
 			// if pendingCmds > 1<<10 {
 			// 	extraWait := time.Duration(pendingCmds-1<<10) * 100 * time.Nanosecond
 			// 	totalWaitTime += extraWait
@@ -212,6 +213,7 @@ func (r *replay) readCommands(ctx context.Context) {
 				case <-time.After(expectedInterval):
 				}
 			}
+			totalWaitTime += time.Since(startTime) - expectedInterval
 		}
 		if ctx.Err() == nil {
 			r.executeCmd(ctx, command, conns, &connCount)

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -114,6 +114,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.startTime = time.Now()
 	r.endTime = time.Time{}
 	r.progress = 0
+	r.decodedCmds = 0
 	r.err = nil
 	r.replayStats.Reset()
 	r.exceptionCh = make(chan conn.Exception, maxPendingExceptions)
@@ -200,8 +201,8 @@ func (r *replay) readCommands(ctx context.Context) {
 			if r.cfg.Speed != 1 {
 				expectedInterval = time.Duration(float64(expectedInterval) / r.cfg.Speed)
 			}
-			if pendingCmds > 100 {
-				extraWait := time.Duration(pendingCmds-100) * time.Microsecond
+			if pendingCmds > 1<<10 {
+				extraWait := time.Duration(pendingCmds-1<<10) * 100 * time.Nanosecond
 				totalWaitTime += extraWait
 				expectedInterval += extraWait
 			}

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -155,10 +155,7 @@ func TestReplaySpeed(t *testing.T) {
 
 func TestProgress(t *testing.T) {
 	dir := t.TempDir()
-	meta := &store.Meta{
-		Duration: 10 * time.Second,
-		Cmds:     10,
-	}
+	meta := store.NewMeta(10*time.Second, 10, 0)
 	require.NoError(t, meta.Write(dir))
 	loader := newMockNormalLoader()
 	now := time.Now()

--- a/pkg/sqlreplay/store/loader.go
+++ b/pkg/sqlreplay/store/loader.go
@@ -108,7 +108,7 @@ func (l *loader) ReadLine() ([]byte, string, int, error) {
 func (l *loader) nextReader() error {
 	// has read the latest file
 	if l.curFileTs == math.MaxInt64 {
-		return errors.WithStack(io.EOF)
+		return io.EOF
 	}
 	files, err := os.ReadDir(l.cfg.Dir)
 	if err != nil {
@@ -147,7 +147,7 @@ func (l *loader) nextReader() error {
 		}
 	}
 	if minFileName == "" {
-		return errors.WithStack(io.EOF)
+		return io.EOF
 	}
 	r, err := os.Open(filepath.Join(l.cfg.Dir, minFileName))
 	if err != nil {

--- a/pkg/sqlreplay/store/loader.go
+++ b/pkg/sqlreplay/store/loader.go
@@ -6,6 +6,7 @@ package store
 import (
 	"bufio"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -40,6 +41,10 @@ func NewLoader(lg *zap.Logger, cfg LoaderCfg) *loader {
 		cfg: cfg,
 		lg:  lg,
 	}
+}
+
+func (l *loader) String() string {
+	return fmt.Sprintf("curFile: %s, curLineIdx: %d", l.curFileName, l.curLineIdx)
 }
 
 func (l *loader) Read(data []byte) (string, int, error) {

--- a/pkg/sqlreplay/store/loader.go
+++ b/pkg/sqlreplay/store/loader.go
@@ -108,7 +108,7 @@ func (l *loader) ReadLine() ([]byte, string, int, error) {
 func (l *loader) nextReader() error {
 	// has read the latest file
 	if l.curFileTs == math.MaxInt64 {
-		return io.EOF
+		return errors.WithStack(io.EOF)
 	}
 	files, err := os.ReadDir(l.cfg.Dir)
 	if err != nil {
@@ -147,7 +147,7 @@ func (l *loader) nextReader() error {
 		}
 	}
 	if minFileName == "" {
-		return io.EOF
+		return errors.WithStack(io.EOF)
 	}
 	r, err := os.Open(filepath.Join(l.cfg.Dir, minFileName))
 	if err != nil {
@@ -171,6 +171,7 @@ func (l *loader) nextReader() error {
 	} else {
 		l.reader = bufio.NewReader(r)
 	}
+	l.lg.Info("reading next file", zap.String("file", minFileName))
 	return nil
 }
 

--- a/pkg/sqlreplay/store/meta.go
+++ b/pkg/sqlreplay/store/meta.go
@@ -14,11 +14,23 @@ import (
 
 const (
 	metaFile = "meta"
+	version  = "v1"
 )
 
 type Meta struct {
-	Duration time.Duration
-	Cmds     uint64
+	Version      string
+	Duration     time.Duration
+	Cmds         uint64
+	FilteredCmds uint64
+}
+
+func NewMeta(duration time.Duration, cmds, filteredCmds uint64) *Meta {
+	return &Meta{
+		Version:      version,
+		Duration:     duration,
+		Cmds:         cmds,
+		FilteredCmds: filteredCmds,
+	}
 }
 
 func (m *Meta) Write(path string) error {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #700

Problem Summary:
- Sometimes the last commands are not replayed because the connections quit before they have finished
- There are deadlocks when the command buffer of one connection is full because it's waiting for a lock while other connections wait for decoding

What is changed and how it works:
- Do not cancel the context when the commands are decoded, just close the command channel
- Replace the channel with glist to make the buffer size big enough
- Slow down decoding if there are too many pending commands and abort the replay when the commands still increase
- Add metrics to monitor the pending commands and wait time
- Do not judge the job status by the progress because the progress may be incorrect

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test: test with TPCC and check the replayed command count

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
