### PR TITLE
vip: support multiple VIP

### DIFF
--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -1297,8 +1297,7 @@ func TestElection(t *testing.T) {
 	// test owner
 	suite.delKV(ownerKey)
 	require.Eventually(t, func() bool {
-		kvs := suite.getKV(ownerKey)
-		return len(kvs) == 1 && strings.HasSuffix(string(kvs[0].Value), "3080")
+		return br.isOwner.Load()
 	}, 3*time.Second, 10*time.Millisecond)
 	err = br.ReadMetrics(context.Background())
 	require.NoError(t, err)

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -123,7 +123,7 @@ func TestNetworkOperation(t *testing.T) {
 	operation := newMockNetworkOperation()
 	vm := &vipManager{
 		lg:        lg,
-		cfgGetter: newMockConfigGetter(&config.Config{HA: config.HA{VirtualIP: "10.10.10.10/24", Interface: "eth0"}}),
+		cfgGetter: newMockConfigGetter(newMockConfig()),
 		operation: operation,
 	}
 	vm.delOnRetire.Store(true)
@@ -149,11 +149,7 @@ func TestNetworkOperation(t *testing.T) {
 
 func TestStartAndClose(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
-	vm, err := NewVIPManager(lg, newMockConfigGetter(&config.Config{
-		Proxy: config.ProxyServer{Addr: "0.0.0.0:6000"},
-		API:   config.API{Addr: "0.0.0.0:3080"},
-		HA:    config.HA{VirtualIP: "127.0.0.2/24", Interface: "lo"},
-	}))
+	vm, err := NewVIPManager(lg, newMockConfigGetter(newMockConfig()))
 	if runtime.GOOS != "linux" {
 		require.Error(t, err)
 	} else {
@@ -177,4 +173,44 @@ func TestStartAndClose(t *testing.T) {
 		vm.PreClose()
 		vm.Close()
 	}
+}
+
+func TestMultiVIP(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+	config1, config2 := newMockConfig(), newMockConfig()
+	config1.HA.VirtualIP = "127.0.0.2/24"
+	config2.HA.VirtualIP = "127.0.0.3/24"
+	lg, text := logger.CreateLoggerForTest(t)
+	vm1, err := NewVIPManager(lg, newMockConfigGetter(config1))
+	// Maybe interface doesn't exist or lack of permission.
+	if err != nil {
+		return
+	}
+	vm2, err := NewVIPManager(lg, newMockConfigGetter(config2))
+	require.NoError(t, err)
+
+	server, err := etcd.CreateEtcdServer("0.0.0.0:0", t.TempDir(), lg)
+	require.NoError(t, err)
+	endpoint := server.Clients[0].Addr().String()
+	cfg := etcd.ConfigForEtcdTest(endpoint)
+
+	certMgr := cert.NewCertManager()
+	err = certMgr.Init(cfg, lg, nil)
+	require.NoError(t, err)
+	client, err := etcd.InitEtcdClient(lg, cfg, certMgr)
+	require.NoError(t, err)
+
+	err = vm1.Start(context.Background(), client)
+	require.NoError(t, err)
+	err = vm2.Start(context.Background(), client)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return strings.Contains(text.String(), "adding VIP success")
+	}, 3*time.Second, 10*time.Millisecond)
+	vm1.PreClose()
+	vm2.PreClose()
+	vm1.Close()
+	vm2.Close()
 }

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -207,7 +207,7 @@ func TestMultiVIP(t *testing.T) {
 	err = vm2.Start(context.Background(), client)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		return strings.Contains(text.String(), "adding VIP success")
+		return strings.Count(text.String(), "adding VIP success") >= 2
 	}, 3*time.Second, 10*time.Millisecond)
 	vm1.PreClose()
 	vm2.PreClose()

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -207,7 +207,8 @@ func TestMultiVIP(t *testing.T) {
 	err = vm2.Start(context.Background(), client)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		return strings.Count(text.String(), "adding VIP success") >= 2
+		return strings.Count(text.String(), "adding VIP success") >= 2 ||
+			strings.Count(text.String(), "ip: command not found") >= 2
 	}, 3*time.Second, 10*time.Millisecond)
 	vm1.PreClose()
 	vm2.PreClose()

--- a/pkg/manager/vip/mock_test.go
+++ b/pkg/manager/vip/mock_test.go
@@ -121,3 +121,15 @@ func (mno *mockNetworkOperation) SendARP() error {
 	}
 	return nil
 }
+
+func (mno *mockNetworkOperation) Addr() string {
+	return ""
+}
+
+func newMockConfig() *config.Config {
+	return &config.Config{
+		Proxy: config.ProxyServer{Addr: "0.0.0.0:6000"},
+		API:   config.API{Addr: "0.0.0.0:3080"},
+		HA:    config.HA{VirtualIP: "127.0.0.2/24", Interface: "lo"},
+	}
+}

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -20,6 +20,7 @@ type NetworkOperation interface {
 	AddIP() error
 	DeleteIP() error
 	SendARP() error
+	Addr() string
 }
 
 var _ NetworkOperation = (*networkOperation)(nil)
@@ -92,4 +93,11 @@ func (no *networkOperation) SendARP() error {
 		err = cmd.ExecCmd("sudo", "arping", "-c", "1", "-U", "-I", no.link.Attrs().Name, no.address.IP.String())
 	}
 	return errors.WithStack(err)
+}
+
+func (no *networkOperation) Addr() string {
+	if no.address == nil {
+		return ""
+	}
+	return no.address.String()
 }

--- a/pkg/manager/vip/network.go
+++ b/pkg/manager/vip/network.go
@@ -99,5 +99,5 @@ func (no *networkOperation) Addr() string {
 	if no.address == nil {
 		return ""
 	}
-	return no.address.String()
+	return no.address.IP.String()
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #704 

Problem Summary:
Currently, only one VIP address is supported because they campaign for the same key `/tiproxy/vip/owner`.

In the resource isolation scenario, we may need multiple VIP addresses, each corresponding to a tenant. Therefore, the key should contain the VIP address so that multiple keys coexist.

What is changed and how it works:
Include the VIP address in the etcd key, such as `/tiproxy/vip/10.12.2.3/owner`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support multiple VIP addresses in one cluster
```
