### PR TITLE
sqlreplay: fix job running status

### DIFF
--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -51,7 +51,7 @@ type job4Marshal struct {
 }
 
 func (job *job) IsRunning() bool {
-	return job.err == nil && job.progress < 1
+	return job.err == nil && !job.done
 }
 
 func (job *job) SetProgress(progress float64, endTime time.Time, done bool, err error) {

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -52,7 +52,8 @@ func TestIsRunning(t *testing.T) {
 			job: &replayJob{
 				job: job{
 					startTime: time.Now().Add(-20 * time.Second),
-					progress:  1.0,
+					progress:  0.5,
+					done:      true,
 				},
 			},
 			tp:      Replay,

--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -45,6 +45,7 @@ func TestStartAndStop(t *testing.T) {
 	// Test that Jobs() also update progress.
 	require.NoError(t, mgr.StartReplay(replay.ReplayConfig{}))
 	rep.progress = 1.0
+	rep.done = true
 	mgr.Jobs()
 	job := mgr.jobHistory[len(mgr.jobHistory)-1]
 	require.Equal(t, 1.0, job.(*replayJob).progress)

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -26,6 +26,7 @@ var _ capture.Capture = (*mockCapture)(nil)
 type mockCapture struct {
 	progress float64
 	err      error
+	done     bool
 }
 
 func (m *mockCapture) InitConn(startTime time.Time, connID uint64, db string) {
@@ -38,7 +39,7 @@ func (m *mockCapture) Close() {
 }
 
 func (m *mockCapture) Progress() (float64, time.Time, bool, error) {
-	return m.progress, time.Time{}, false, m.err
+	return m.progress, time.Time{}, m.done, m.err
 }
 
 func (m *mockCapture) Stop(err error) {
@@ -48,6 +49,7 @@ func (m *mockCapture) Stop(err error) {
 func (m *mockCapture) Start(capture.CaptureConfig) error {
 	m.progress = 0
 	m.err = nil
+	m.done = false
 	return nil
 }
 
@@ -56,18 +58,20 @@ var _ replay.Replay = (*mockReplay)(nil)
 type mockReplay struct {
 	progress float64
 	err      error
+	done     bool
 }
 
 func (m *mockReplay) Close() {
 }
 
 func (m *mockReplay) Progress() (float64, time.Time, bool, error) {
-	return m.progress, time.Time{}, false, m.err
+	return m.progress, time.Time{}, m.done, m.err
 }
 
 func (m *mockReplay) Start(cfg replay.ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {
 	m.progress = 0
 	m.err = nil
+	m.done = false
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #710 

Problem Summary:
Even if the last replay is finished, the next replay may fail to start because the progress is not 100%.

What is changed and how it works:
Check the field `done` instead of `progress`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix that traffic replay may incorrectly report another job is running
```
