### PR TITLE
sqlreplay, api: support compress option to traffic capture

### DIFF
--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -30,8 +30,14 @@ func GetTrafficCaptureCmd(ctx *Context) *cobra.Command {
 	output := captureCmd.PersistentFlags().String("output", "", "output directory for traffic files")
 	duration := captureCmd.PersistentFlags().String("duration", "", "the duration of traffic capture")
 	encrypt := captureCmd.PersistentFlags().String("encrypt-method", "", "the encryption method used for encrypting traffic files")
+	compress := captureCmd.PersistentFlags().Bool("compress", true, "whether compress the traffic files")
 	captureCmd.RunE = func(cmd *cobra.Command, args []string) error {
-		reader := GetFormReader(map[string]string{"output": *output, "duration": *duration, "encrypt-method": *encrypt})
+		reader := GetFormReader(map[string]string{
+			"output":         *output,
+			"duration":       *duration,
+			"encrypt-method": *encrypt,
+			"compress":       strconv.FormatBool(*compress),
+		})
 		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/capture", reader)
 		if err != nil {
 			return err

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -55,6 +55,7 @@ type CaptureConfig struct {
 	EncryptMethod      string
 	KeyFile            string
 	Duration           time.Duration
+	Compress           bool
 	cmdLogger          store.Writer
 	bufferCap          int
 	flushThreshold     int
@@ -226,6 +227,7 @@ func (c *capture) flushBuffer(bufCh <-chan *bytes.Buffer) {
 			Dir:           c.cfg.Output,
 			EncryptMethod: c.cfg.EncryptMethod,
 			KeyFile:       c.cfg.KeyFile,
+			Compress:      c.cfg.Compress,
 		})
 		if err != nil {
 			c.lg.Error("failed to create capture writer", zap.Error(err))

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -22,6 +22,7 @@ type WriterCfg struct {
 	EncryptMethod string
 	KeyFile       string
 	FileSize      int
+	Compress      bool
 }
 
 func NewWriter(cfg WriterCfg) (Writer, error) {

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -38,7 +38,7 @@ func newRotateWriter(cfg WriterCfg) *rotateWriter {
 			Filename:  filepath.Join(cfg.Dir, fileName),
 			MaxSize:   cfg.FileSize,
 			LocalTime: true,
-			Compress:  true,
+			Compress:  cfg.Compress,
 		},
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #719 

Problem Summary:
Support the compress option to traffic capture because compression makes CPU jitter.

What is changed and how it works:
- Add `compress` option to tiproxyctl and HTTP API
- Pass `compress` to `rotateWriter`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [x] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Add `compress` option to traffic capture
```
