### PR TITLE
sqlreplay: do not write traffic files if meta exists

### DIFF
--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -72,6 +72,7 @@ func (cfg *CaptureConfig) Validate() error {
 		if !st.IsDir() {
 			return errors.New("output should be a directory")
 		}
+		err = store.PreCheckMeta(cfg.Output)
 	} else if os.IsNotExist(err) {
 		err = os.MkdirAll(cfg.Output, 0755)
 	}

--- a/pkg/sqlreplay/store/meta.go
+++ b/pkg/sqlreplay/store/meta.go
@@ -58,3 +58,12 @@ func (m *Meta) Read(path string) error {
 	}
 	return nil
 }
+
+func PreCheckMeta(path string) error {
+	filePath := filepath.Join(path, metaFile)
+	_, err := os.Stat(filePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return errors.Errorf("file %s already exists, please remove it before capture", filePath)
+}

--- a/pkg/sqlreplay/store/meta_test.go
+++ b/pkg/sqlreplay/store/meta_test.go
@@ -29,3 +29,12 @@ func TestMeta(t *testing.T) {
 	require.NoError(t, os.Remove(filepath.Join(dir, metaFile)))
 	require.Error(t, m3.Read(dir))
 }
+
+func TestPrecheckMeta(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, PreCheckMeta(dir))
+	f, err := os.Create(filepath.Join(dir, metaFile))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.Error(t, PreCheckMeta(dir))
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #716 

Problem Summary:
Writing `meta` may overwrite a system file with the same name, which can be used by attackers, so a precheck is needed before capturing.

What is changed and how it works:
Precheck the file `meta` before traffic capture. If the file exists, quit.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [x] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Do not start traffic capture if the file meta exists
```
