### PR TITLE
sqlreplay, api: add job start time to the report and API parameters

### DIFF
--- a/pkg/server/api/server_test.go
+++ b/pkg/server/api/server_test.go
@@ -25,7 +25,9 @@ type httpOpts struct {
 	header map[string]string
 }
 
-func createServer(t *testing.T) (*Server, func(t *testing.T, method string, path string, opts httpOpts, f func(*testing.T, *http.Response))) {
+type doHTTPFunc func(t *testing.T, method string, path string, opts httpOpts, f func(*testing.T, *http.Response))
+
+func createServer(t *testing.T) (*Server, doHTTPFunc) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	ready := atomic.NewBool(true)
 	cfgmgr := mgrcfg.NewConfigManager()

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -45,6 +45,16 @@ func (h *Server) TrafficCapture(c *gin.Context) {
 	}
 	cfg.Compress = compress
 	cfg.KeyFile = h.mgr.CfgMgr.GetConfig().Security.Encryption.KeyPath
+	if startTimeStr := c.PostForm("start-time"); startTimeStr != "" {
+		startTime, err := time.Parse(time.RFC3339, startTimeStr)
+		if err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		cfg.StartTime = startTime
+	} else {
+		cfg.StartTime = time.Now()
+	}
 
 	if err := h.mgr.ReplayJobMgr.StartCapture(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
@@ -63,6 +73,16 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 			return
 		}
 		cfg.Speed = speed
+	}
+	if startTimeStr := c.PostForm("start-time"); startTimeStr != "" {
+		startTime, err := time.Parse(time.RFC3339, startTimeStr)
+		if err != nil {
+			c.String(http.StatusBadRequest, err.Error())
+			return
+		}
+		cfg.StartTime = startTime
+	} else {
+		cfg.StartTime = time.Now()
 	}
 	cfg.Username = c.PostForm("username")
 	cfg.Password = c.PostForm("password")

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -21,6 +21,7 @@ func TestTraffic(t *testing.T) {
 	server, doHTTP := createServer(t)
 	mgr := server.mgr.ReplayJobMgr.(*mockReplayJobManager)
 
+	// parse duration error
 	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
 		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "10"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -30,6 +31,17 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "time: missing unit in duration \"10\"", string(all))
 	})
+	// parse start time error
+	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
+		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h", "start-time": "2023-01-01"}),
+		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+	}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadRequest, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(all), "cannot parse \"\" as \"T\"")
+	})
+	// capture succeeds
 	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
 		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -39,8 +51,11 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "capture started", string(all))
 		require.Equal(t, "capture", mgr.curJob)
-		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp", Compress: true}, mgr.captureCfg)
+		startTime := mgr.captureCfg.StartTime
+		require.False(t, startTime.IsZero())
+		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp", Compress: true, StartTime: startTime}, mgr.captureCfg)
 	})
+	// cancel succeeds
 	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 		all, err := io.ReadAll(r.Body)
@@ -48,8 +63,10 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, "stopped", string(all))
 		require.Equal(t, "", mgr.curJob)
 	})
+	// capture succeeds with more options
 	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
-		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h", "encrypt-method": "aes256-ctr", "compress": "false"}),
+		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h", "encrypt-method": "aes256-ctr",
+			"compress": "false", "start-time": time.Now().Format(time.RFC3339)}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
@@ -57,8 +74,10 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "capture started", string(all))
 		require.Equal(t, "capture", mgr.curJob)
-		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp", EncryptMethod: "aes256-ctr", Compress: false}, mgr.captureCfg)
+		require.Equal(t, capture.CaptureConfig{Duration: time.Hour, Output: "/tmp", EncryptMethod: "aes256-ctr", Compress: false,
+			StartTime: mgr.captureCfg.StartTime}, mgr.captureCfg)
 	})
+	// job is running error
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
 		reader: cli.GetFormReader(map[string]string{"input": "/tmp"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -68,9 +87,8 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "job is running", string(all))
 	})
-	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusOK, r.StatusCode)
-	})
+	cancelJob(t, doHTTP)
+	// parse speed error
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
 		reader: cli.GetFormReader(map[string]string{"input": "/tmp", "speed": "abc"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -80,6 +98,7 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "strconv.ParseFloat: parsing \"abc\": invalid syntax", string(all))
 	})
+	// replay succeeds
 	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
 		reader: cli.GetFormReader(map[string]string{"input": "/tmp", "speed": "2.0", "username": "u1", "password": "p1"}),
 		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
@@ -89,14 +108,21 @@ func TestTraffic(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "replay started", string(all))
 		require.Equal(t, "replay", mgr.curJob)
-		require.Equal(t, replay.ReplayConfig{Input: "/tmp", Username: "u1", Password: "p1", Speed: 2.0}, mgr.replayCfg)
+		startTime := mgr.replayCfg.StartTime
+		require.False(t, startTime.IsZero())
+		require.Equal(t, replay.ReplayConfig{Input: "/tmp", Username: "u1", Password: "p1", Speed: 2.0, StartTime: startTime}, mgr.replayCfg)
 	})
+	// show succeeds
 	doHTTP(t, http.MethodGet, "/api/traffic/show", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 		all, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, "replay", string(all))
 	})
+	cancelJob(t, doHTTP)
+}
+
+func cancelJob(t *testing.T, doHTTP doHTTPFunc) {
 	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})

--- a/pkg/sqlreplay/capture/capture_test.go
+++ b/pkg/sqlreplay/capture/capture_test.go
@@ -32,6 +32,7 @@ func TestStartAndStop(t *testing.T) {
 		Output:    dir,
 		Duration:  10 * time.Second,
 		cmdLogger: writer,
+		StartTime: time.Now(),
 	}
 
 	// start capture and the traffic should be outputted
@@ -72,6 +73,7 @@ func TestConcurrency(t *testing.T) {
 	cfg := CaptureConfig{
 		Output:         dir,
 		Duration:       10 * time.Second,
+		StartTime:      time.Now(),
 		bufferCap:      12 * 1024,
 		flushThreshold: 8 * 1024,
 		cmdLogger:      writer,
@@ -125,19 +127,37 @@ func TestConcurrency(t *testing.T) {
 }
 
 func TestCaptureCfgError(t *testing.T) {
+	now := time.Now()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "traffic.log")
 	require.NoError(t, os.WriteFile(path, []byte{}, 0666))
 	cfgs := []CaptureConfig{
 		{
-			Duration: 10 * time.Second,
+			Duration:  10 * time.Second,
+			StartTime: now,
 		},
 		{
-			Output: dir,
+			Output:    dir,
+			StartTime: now,
 		},
 		{
 			Duration: 10 * time.Second,
-			Output:   path,
+			Output:   dir,
+		},
+		{
+			Duration:  10 * time.Second,
+			Output:    path,
+			StartTime: now.Add(time.Hour),
+		},
+		{
+			Duration:  10 * time.Second,
+			Output:    path,
+			StartTime: now.Add(-time.Hour),
+		},
+		{
+			Duration:  10 * time.Second,
+			Output:    path,
+			StartTime: now,
 		},
 	}
 
@@ -147,8 +167,9 @@ func TestCaptureCfgError(t *testing.T) {
 	}
 
 	cfg := CaptureConfig{
-		Output:   dir,
-		Duration: 10 * time.Second,
+		Output:    dir,
+		Duration:  10 * time.Second,
+		StartTime: now,
 	}
 	require.NoError(t, cfg.Validate())
 	require.Equal(t, bufferCap, cfg.bufferCap)
@@ -166,6 +187,7 @@ func TestProgress(t *testing.T) {
 		Output:    t.TempDir(),
 		Duration:  10 * time.Second,
 		cmdLogger: writer,
+		StartTime: time.Now(),
 	}
 	setStartTime := func(t time.Time) {
 		cpt.Lock()
@@ -212,6 +234,7 @@ func TestInitConn(t *testing.T) {
 		Output:    t.TempDir(),
 		Duration:  10 * time.Second,
 		cmdLogger: writer,
+		StartTime: time.Now(),
 	}
 
 	require.NoError(t, cpt.Start(cfg))
@@ -246,6 +269,7 @@ func TestQuit(t *testing.T) {
 		Output:    t.TempDir(),
 		Duration:  10 * time.Second,
 		cmdLogger: writer,
+		StartTime: time.Now(),
 	}
 
 	require.NoError(t, cpt.Start(cfg))
@@ -299,8 +323,9 @@ func TestFilterCmds(t *testing.T) {
 
 	dir := t.TempDir()
 	cfg := CaptureConfig{
-		Output:   dir,
-		Duration: 10 * time.Second,
+		Output:    dir,
+		Duration:  10 * time.Second,
+		StartTime: time.Now(),
 	}
 	for i, test := range tests {
 		cpt := NewCapture(zap.NewNop())

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -65,11 +65,11 @@ func (job *job) SetProgress(progress float64, endTime time.Time, done bool, err 
 
 func (job *job) getJob4Marshal() *job4Marshal {
 	jm := &job4Marshal{
-		StartTime: job.startTime.String(),
+		StartTime: job.startTime.Format(time.RFC3339),
 		Progress:  fmt.Sprintf("%d%%", int(job.progress*100)),
 	}
 	if !job.endTime.IsZero() {
-		jm.EndTime = job.endTime.String()
+		jm.EndTime = job.endTime.Format(time.RFC3339)
 	}
 	if job.err != nil {
 		jm.Status = "canceled"

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -127,7 +127,7 @@ func TestMarshalJob(t *testing.T) {
 					Duration: 2 * time.Hour,
 				},
 			},
-			marshal: `{"type":"capture","status":"canceled","start_time":"2020-01-01 00:00:00 +0000 UTC","end_time":"2020-01-01 02:01:01 +0000 UTC","duration":"2h0m0s","output":"/tmp/traffic","progress":"50%","error":"mock error"}`,
+			marshal: `{"type":"capture","status":"canceled","start_time":"2020-01-01T00:00:00Z","end_time":"2020-01-01T02:01:01Z","duration":"2h0m0s","output":"/tmp/traffic","progress":"50%","error":"mock error"}`,
 		},
 		{
 			job: &replayJob{
@@ -140,7 +140,7 @@ func TestMarshalJob(t *testing.T) {
 					Username: "root",
 				},
 			},
-			marshal: `{"type":"replay","status":"running","start_time":"2020-01-01 00:00:00 +0000 UTC","input":"/tmp/traffic","username":"root","speed":1,"progress":"0%"}`,
+			marshal: `{"type":"replay","status":"running","start_time":"2020-01-01T00:00:00Z","input":"/tmp/traffic","username":"root","speed":1,"progress":"0%"}`,
 		},
 		{
 			job: &replayJob{
@@ -156,7 +156,7 @@ func TestMarshalJob(t *testing.T) {
 					Speed:    0.5,
 				},
 			},
-			marshal: `{"type":"replay","status":"done","start_time":"2020-01-01 00:00:00 +0000 UTC","end_time":"2020-01-01 02:01:01 +0000 UTC","input":"/tmp/traffic","username":"root","speed":0.5,"progress":"100%"}`,
+			marshal: `{"type":"replay","status":"done","start_time":"2020-01-01T00:00:00Z","end_time":"2020-01-01T02:01:01Z","input":"/tmp/traffic","username":"root","speed":0.5,"progress":"100%"}`,
 		},
 	}
 

--- a/pkg/sqlreplay/manager/manager.go
+++ b/pkg/sqlreplay/manager/manager.go
@@ -6,7 +6,6 @@ package manager
 import (
 	"crypto/tls"
 	"encoding/json"
-	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -98,7 +97,8 @@ func (jm *jobManager) StartCapture(cfg capture.CaptureConfig) error {
 	}
 	newJob := &captureJob{
 		job: job{
-			startTime: time.Now(),
+			// cfg.StartTime may act as the job ID in a TiProxy cluster.
+			startTime: cfg.StartTime,
 		},
 		cfg: cfg,
 	}
@@ -126,7 +126,8 @@ func (jm *jobManager) StartReplay(cfg replay.ReplayConfig) error {
 	}
 	newJob := &replayJob{
 		job: job{
-			startTime: time.Now(),
+			// cfg.StartTime may act as the job ID in a TiProxy cluster.
+			startTime: cfg.StartTime,
 		},
 		cfg: cfg,
 	}

--- a/pkg/sqlreplay/manager/manager_test.go
+++ b/pkg/sqlreplay/manager/manager_test.go
@@ -106,8 +106,8 @@ func TestMarshalJobHistory(t *testing.T) {
   {
     "type": "capture",
     "status": "canceled",
-    "start_time": "2020-01-01 00:00:00 +0000 UTC",
-    "end_time": "2020-01-01 02:01:01 +0000 UTC",
+    "start_time": "2020-01-01T00:00:00Z",
+    "end_time": "2020-01-01T02:01:01Z",
     "duration": "2h0m0s",
     "output": "/tmp/traffic",
     "progress": "50%",
@@ -116,7 +116,7 @@ func TestMarshalJobHistory(t *testing.T) {
   {
     "type": "replay",
     "status": "running",
-    "start_time": "2020-01-01 00:00:00 +0000 UTC",
+    "start_time": "2020-01-01T00:00:00Z",
     "input": "/tmp/traffic",
     "username": "root",
     "speed": 1,
@@ -125,8 +125,8 @@ func TestMarshalJobHistory(t *testing.T) {
   {
     "type": "replay",
     "status": "done",
-    "start_time": "2020-01-01 00:00:00 +0000 UTC",
-    "end_time": "2020-01-01 02:01:01 +0000 UTC",
+    "start_time": "2020-01-01T00:00:00Z",
+    "end_time": "2020-01-01T02:01:01Z",
     "input": "/tmp/traffic",
     "username": "root",
     "speed": 0.5,

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -173,6 +173,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	childCtx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	if err := r.report.Start(childCtx, report.ReportConfig{
+		StartTime: r.startTime,
 		TlsConfig: r.backendTLSConfig,
 	}); err != nil {
 		return err

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -54,8 +54,11 @@ type ReplayConfig struct {
 	Username string
 	Password string
 	KeyFile  string
-	Speed    float64
-	ReadOnly bool
+	// It's specified when executing with the statement `TRAFFIC REPLAY` so that all TiProxy instances
+	// use the same start time and the time acts as the job ID.
+	StartTime time.Time
+	Speed     float64
+	ReadOnly  bool
 	// the following fields are for testing
 	reader            cmd.LineReader
 	report            report.Report
@@ -84,6 +87,15 @@ func (cfg *ReplayConfig) Validate() error {
 		cfg.Speed = 1
 	} else if cfg.Speed < minSpeed || cfg.Speed > maxSpeed {
 		return errors.Errorf("speed should be between %f and %f", minSpeed, maxSpeed)
+	}
+	// Maybe there's a time bias between TiDB and TiProxy, so add one minute.
+	now := time.Now()
+	if cfg.StartTime.IsZero() {
+		return errors.New("start time is not specified")
+	} else if now.Add(time.Minute).Before(cfg.StartTime) {
+		return errors.New("start time should not be in the future")
+	} else if cfg.StartTime.Add(time.Minute).Before(now) {
+		return errors.New("start time should not be in the past")
 	}
 	if cfg.abortThreshold == 0 {
 		cfg.abortThreshold = abortThreshold
@@ -134,7 +146,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	defer r.Unlock()
 	r.cfg = cfg
 	r.meta = *r.readMeta()
-	r.startTime = time.Now()
+	r.startTime = cfg.StartTime
 	r.endTime = time.Time{}
 	r.progress = 0
 	r.decodedCmds.Store(0)

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -25,9 +25,10 @@ func TestManageConns(t *testing.T) {
 	loader := newMockChLoader()
 	connCount := 0
 	cfg := ReplayConfig{
-		Input:    t.TempDir(),
-		Username: "u1",
-		reader:   loader,
+		Input:     t.TempDir(),
+		Username:  "u1",
+		StartTime: time.Now(),
+		reader:    loader,
 		connCreator: func(connID uint64) conn.Conn {
 			connCount++
 			return &mockConn{
@@ -68,26 +69,42 @@ func TestManageConns(t *testing.T) {
 
 func TestValidateCfg(t *testing.T) {
 	dir := t.TempDir()
+	now := time.Now()
 	cfgs := []ReplayConfig{
 		{
-			Username: "u1",
+			Username:  "u1",
+			StartTime: now,
 		},
 		{
-			Input: dir,
+			Input:     dir,
+			StartTime: now,
 		},
 		{
-			Input:    filepath.Join(dir, "input"),
-			Username: "u1",
+			Input:     filepath.Join(dir, "input"),
+			Username:  "u1",
+			StartTime: now,
 		},
 		{
-			Input:    dir,
-			Username: "u1",
-			Speed:    0.01,
+			Input:     dir,
+			Username:  "u1",
+			Speed:     0.01,
+			StartTime: now,
 		},
 		{
-			Input:    dir,
-			Username: "u1",
-			Speed:    100,
+			Input:     dir,
+			Username:  "u1",
+			Speed:     100,
+			StartTime: now,
+		},
+		{
+			Input:     dir,
+			Username:  "u1",
+			StartTime: now.Add(time.Hour),
+		},
+		{
+			Input:     dir,
+			Username:  "u1",
+			StartTime: now.Add(-time.Hour),
 		},
 	}
 
@@ -105,11 +122,12 @@ func TestReplaySpeed(t *testing.T) {
 		cmdCh := make(chan *cmd.Command, 10)
 		loader := newMockNormalLoader()
 		cfg := ReplayConfig{
-			Input:    t.TempDir(),
-			Username: "u1",
-			Speed:    speed,
-			reader:   loader,
-			report:   newMockReport(replay.exceptionCh),
+			Input:     t.TempDir(),
+			Username:  "u1",
+			Speed:     speed,
+			StartTime: time.Now(),
+			reader:    loader,
+			report:    newMockReport(replay.exceptionCh),
 			connCreator: func(connID uint64) conn.Conn {
 				return &mockConn{
 					connID:  connID,
@@ -166,10 +184,11 @@ func TestProgress(t *testing.T) {
 	replay := NewReplay(zap.NewNop(), id.NewIDManager())
 	defer replay.Close()
 	cfg := ReplayConfig{
-		Input:    dir,
-		Username: "u1",
-		reader:   loader,
-		report:   newMockReport(replay.exceptionCh),
+		Input:     dir,
+		Username:  "u1",
+		StartTime: time.Now(),
+		reader:    loader,
+		report:    newMockReport(replay.exceptionCh),
 		connCreator: func(connID uint64) conn.Conn {
 			return &mockConn{
 				connID:  connID,
@@ -211,10 +230,11 @@ func TestPendingCmds(t *testing.T) {
 	replay := NewReplay(lg, id.NewIDManager())
 	defer replay.Close()
 	cfg := ReplayConfig{
-		Input:    dir,
-		Username: "u1",
-		reader:   loader,
-		report:   newMockReport(replay.exceptionCh),
+		Input:     dir,
+		Username:  "u1",
+		StartTime: time.Now(),
+		reader:    loader,
+		report:    newMockReport(replay.exceptionCh),
 		connCreator: func(connID uint64) conn.Conn {
 			return &mockPendingConn{
 				connID:  connID,

--- a/pkg/sqlreplay/report/mock_test.go
+++ b/pkg/sqlreplay/report/mock_test.go
@@ -6,6 +6,7 @@ package report
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
 )
@@ -35,7 +36,7 @@ func (db *mockReportDB) clear() {
 	db.exceptions = exceptions
 }
 
-func (db *mockReportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error {
+func (db *mockReportDB) InsertExceptions(startTime time.Time, tp conn.ExceptionType, m map[string]*expCollection) error {
 	db.Lock()
 	defer db.Unlock()
 	exps := db.exceptions[tp]

--- a/pkg/sqlreplay/report/report.go
+++ b/pkg/sqlreplay/report/report.go
@@ -34,6 +34,7 @@ func (c *expCollection) inc() {
 }
 
 type ReportConfig struct {
+	StartTime     time.Time
 	TlsConfig     *tls.Config
 	flushInterval time.Duration
 }
@@ -120,7 +121,7 @@ func (r *report) readExceptions(ctx context.Context) {
 // exceptions are flushed even when the context is canceled, so do not pass the canceled context in.
 func (r *report) flush() {
 	for tp, m := range r.exceptions {
-		if err := r.db.InsertExceptions(tp, m); err != nil {
+		if err := r.db.InsertExceptions(r.cfg.StartTime, tp, m); err != nil {
 			r.lg.Error("insert exceptions failed", zap.Stringer("type", tp), zap.Int("exceptions", len(m)), zap.Error(err))
 		}
 		for k := range m {

--- a/pkg/sqlreplay/report/report_db.go
+++ b/pkg/sqlreplay/report/report_db.go
@@ -20,7 +20,7 @@ type BackendConnCreator func() conn.BackendConn
 
 type ReportDB interface {
 	Init(ctx context.Context) error
-	InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error
+	InsertExceptions(startTime time.Time, tp conn.ExceptionType, m map[string]*expCollection) error
 	Close()
 }
 
@@ -93,18 +93,18 @@ func (rdb *reportDB) initStmts(ctx context.Context) (err error) {
 	return
 }
 
-func (rdb *reportDB) InsertExceptions(tp conn.ExceptionType, m map[string]*expCollection) error {
+func (rdb *reportDB) InsertExceptions(startTime time.Time, tp conn.ExceptionType, m map[string]*expCollection) error {
 	for _, value := range m {
 		var args []any
 		switch tp {
 		case conn.Fail:
 			sample := value.sample.(*conn.FailException)
 			command := sample.Command()
-			args = []any{command.Type.String(), command.Digest(), command.QueryText(), sample.Error(), sample.ConnID(),
+			args = []any{startTime.String(), command.Type.String(), command.Digest(), command.QueryText(), sample.Error(), sample.ConnID(),
 				command.StartTs.String(), sample.Time().String(), value.count, value.count}
 		case conn.Other:
 			sample := value.sample.(*conn.OtherException)
-			args = []any{sample.Key(), sample.Error(), sample.Time().String(), value.count, value.count}
+			args = []any{startTime.String(), sample.Key(), sample.Error(), sample.Time().String(), value.count, value.count}
 		default:
 			return errors.WithStack(errors.New("unknown exception type"))
 		}

--- a/pkg/sqlreplay/report/report_db_test.go
+++ b/pkg/sqlreplay/report/report_db_test.go
@@ -73,7 +73,7 @@ func TestInsertExceptions(t *testing.T) {
 				},
 			},
 			stmtID: []uint32{2},
-			args:   [][]any{{"mock error", "wrap: mock error", otherSample1.Time().String(), uint64(1), uint64(1)}},
+			args:   [][]any{{now.String(), "mock error", "wrap: mock error", otherSample1.Time().String(), uint64(1), uint64(1)}},
 		},
 		{
 			tp: conn.Other,
@@ -88,8 +88,8 @@ func TestInsertExceptions(t *testing.T) {
 				},
 			},
 			stmtID: []uint32{2, 2},
-			args: [][]any{{"mock error", "mock error", otherSample2.Time().String(), uint64(2), uint64(2)},
-				{"another error", "another error", otherSample3.Time().String(), uint64(2), uint64(2)}},
+			args: [][]any{{now.String(), "mock error", "mock error", otherSample2.Time().String(), uint64(2), uint64(2)},
+				{now.String(), "another error", "another error", otherSample3.Time().String(), uint64(2), uint64(2)}},
 		},
 		{
 			tp: conn.Fail,
@@ -100,7 +100,7 @@ func TestInsertExceptions(t *testing.T) {
 				},
 			},
 			stmtID: []uint32{1},
-			args: [][]any{{"Query", "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471", "select 1", "mock error",
+			args: [][]any{{now.String(), "Query", "e1c71d1661ae46e09b7aaec1c390957f0d6260410df4e4bc71b9c8d681021471", "select 1", "mock error",
 				uint64(1), now.String(), failSample.Time().String(), uint64(1), uint64(1)}},
 		},
 	}
@@ -115,12 +115,12 @@ func TestInsertExceptions(t *testing.T) {
 		err := db.Init(context.Background())
 		require.NoErrorf(t, err, "case %d", i)
 		cn.clear()
-		err = db.InsertExceptions(test.tp, test.colls)
+		err = db.InsertExceptions(now, test.tp, test.colls)
 		require.NoErrorf(t, err, "case %d", i)
 		require.Equal(t, test.stmtID, cn.stmtID, "case %d", i)
 		if len(test.args) > 1 {
-			sort.Slice(test.args, func(i, j int) bool { return test.args[i][0].(string) < test.args[j][0].(string) })
-			sort.Slice(cn.args, func(i, j int) bool { return cn.args[i][0].(string) < cn.args[j][0].(string) })
+			sort.Slice(test.args, func(i, j int) bool { return test.args[i][1].(string) < test.args[j][1].(string) })
+			sort.Slice(cn.args, func(i, j int) bool { return cn.args[i][1].(string) < cn.args[j][1].(string) })
 		}
 		require.Equal(t, test.args, cn.args, "case %d", i)
 		db.Close()

--- a/pkg/sqlreplay/report/tables.go
+++ b/pkg/sqlreplay/report/tables.go
@@ -7,6 +7,7 @@ const (
 	createDatabase = `create database if not exists tiproxy_traffic_replay`
 
 	createFailTable = `create table if not exists tiproxy_traffic_replay.fail(
+    replay_start_time timestamp,
     cmd_type varchar(32),
     digest varchar(128),
     sample_stmt text,
@@ -15,17 +16,45 @@ const (
     sample_capture_time timestamp,
     sample_replay_time timestamp,
     count bigint,
-    primary key(cmd_type, digest))`
+    primary key(replay_start_time, cmd_type, digest))`
 	insertFailTable = `insert into tiproxy_traffic_replay.fail(
-	cmd_type, digest, sample_stmt, sample_err_msg, sample_conn_id, sample_capture_time, sample_replay_time, count)
-	values(?, ?, ?, ?, ?, ?, ?, ?) on duplicate key update count = count + ?`
+	replay_start_time,
+    cmd_type,
+    digest,
+    sample_stmt,
+    sample_err_msg,
+    sample_conn_id,
+    sample_capture_time,
+    sample_replay_time,
+    count)
+	values(?, ?, ?, ?, ?, ?, ?, ?, ?) on duplicate key update count = count + ?`
+	checkFailTable = `select replay_start_time,
+    cmd_type,
+    digest,
+    sample_stmt,
+    sample_err_msg,
+    sample_conn_id,
+    sample_capture_time,
+    sample_replay_time,
+    count from tiproxy_traffic_replay.fail limit 0`
 
 	createOtherTable = `create table if not exists tiproxy_traffic_replay.other_errors(
-    err_type varchar(256) primary key,
+    replay_start_time timestamp,
+    err_type varchar(256),
     sample_err_msg text,
     sample_replay_time timestamp,
-    count bigint)`
+    count bigint,
+    primary key(replay_start_time, err_type))`
 	insertOtherTable = `insert into tiproxy_traffic_replay.other_errors(
-	err_type, sample_err_msg, sample_replay_time, count)
-	values(?, ?, ?, ?) on duplicate key update count = count + ?`
+	replay_start_time,
+    err_type,
+    sample_err_msg,
+    sample_replay_time,
+    count)
+	values(?, ?, ?, ?, ?) on duplicate key update count = count + ?`
+	checkOtherTable = `select replay_start_time,
+    err_type,
+    sample_err_msg,
+    sample_replay_time,
+    count from tiproxy_traffic_replay.other_errors limit 0`
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #723

Problem Summary:
If a user executes the SQL `TRAFFIC CAPTURE` or `TRAFFIC REPLAY` on TiDB, TiDB needs to query the job status from TiProxy instances. However, the jobs are executed independently on each TiProxy, so the job should have an ID to be queried.

What is changed and how it works:
- Add `start-time` to the capture and replay API so that the `start-time` can be specified by TiDB as the job ID
- Add a column `replay_start_time` to the report tables so that the reports of all jobs can coexist
- Check the report table definitions to ensure the tables are well-defined

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```shell
curl -X POST "localhost:3080/api/traffic/capture" -d "duration=1m&output=/tmp/traffic&start-time=2024-12-11T12:23:00Z"
capture started%
curl -X POST "localhost:3080/api/traffic/replay" -d "input=/tmp/traffic&speed=1.0&username=root&start-time=2024-12-11T12:30:00Z"
replay started%
curl -X GET "localhost:3080/api/traffic/show"
[
  {
    "type": "capture",
    "status": "done",
    "start_time": "2024-12-11T12:23:00Z",
    "end_time": "2024-12-11T20:23:54+08:00",
    "duration": "1m0s",
    "output": "/tmp/traffic",
    "progress": "100%"
  },
  {
    "type": "replay",
    "status": "done",
    "start_time": "2024-12-11T12:30:00Z",
    "end_time": "2024-12-11T20:30:30+08:00",
    "input": "/tmp/traffic",
    "username": "root",
    "speed": 1,
    "progress": "0%"
  }
]
```

```sql
mysql> select * from fail;
+---------------------+----------+------------------------------------------------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------------------+---------------------+-------+
| replay_start_time   | cmd_type | digest                                                           | sample_stmt | sample_err_msg                                                                                                                                                          | sample_conn_id | sample_capture_time | sample_replay_time  | count |
+---------------------+----------+------------------------------------------------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------------------+---------------------+-------+
| 2024-12-12 16:43:15 | Query    | 32c079f2c22dad448b27c3ea7bd10e9a4aa9e7276e3e43c23bcf4c99c379695a | select @@   | ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use line 1 column 9 near "@@"  |              1 | 2024-12-12 16:36:59 | 2024-12-12 16:43:17 |     2 |
| 2024-12-12 16:43:15 | Query    | b4f126c134a4830e06b3e040158d2dc52c6e13ac66555bec9a23e8fd52ce7f94 | select $$   | ERROR 1054 (42S22): Unknown column '$$' in 'field list'                                                                                                                 |              1 | 2024-12-12 16:36:56 | 2024-12-12 16:43:15 |     1 |
+---------------------+----------+------------------------------------------------------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------+---------------------+---------------------+-------+
2 rows in set (0.01 sec)
```

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
