### PR TITLE
sqlreplay: remove lumberjack to support large commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	go.uber.org/ratelimit v0.2.0
 	go.uber.org/zap v1.26.0
 	google.golang.org/grpc v1.54.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
@@ -117,6 +116,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -232,6 +232,8 @@ func (c *capture) collectCmds(bufCh chan<- *bytes.Buffer) {
 	}
 }
 
+// Writing commands requires a bytes buffer instead of a simple bufio.Writer,
+// so the buffer can not be pushed down to the store package.
 func (c *capture) flushBuffer(bufCh <-chan *bytes.Buffer) {
 	// cfg.cmdLogger is set in tests
 	cmdLogger := c.cfg.cmdLogger

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -6,6 +6,7 @@ package capture
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -59,7 +60,7 @@ type CaptureConfig struct {
 	StartTime          time.Time
 	Duration           time.Duration
 	Compress           bool
-	cmdLogger          store.Writer
+	cmdLogger          io.WriteCloser
 	bufferCap          int
 	flushThreshold     int
 	maxBuffers         int

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -236,7 +236,7 @@ func (c *capture) flushBuffer(bufCh <-chan *bytes.Buffer) {
 	cmdLogger := c.cfg.cmdLogger
 	if cmdLogger == nil {
 		var err error
-		cmdLogger, err = store.NewWriter(store.WriterCfg{
+		cmdLogger, err = store.NewWriter(c.lg.Named("writer"), store.WriterCfg{
 			Dir:           c.cfg.Output,
 			EncryptMethod: c.cfg.EncryptMethod,
 			KeyFile:       c.cfg.KeyFile,
@@ -249,8 +249,7 @@ func (c *capture) flushBuffer(bufCh <-chan *bytes.Buffer) {
 	}
 	// Flush all buffers even if the context is timeout.
 	for buf := range bufCh {
-		// TODO: each write size should be less than MaxSize.
-		if err := cmdLogger.Write(buf.Bytes()); err != nil {
+		if _, err := cmdLogger.Write(buf.Bytes()); err != nil {
 			c.stop(errors.Wrapf(err, "failed to flush traffic to disk"))
 			break
 		}

--- a/pkg/sqlreplay/capture/mock_test.go
+++ b/pkg/sqlreplay/capture/mock_test.go
@@ -21,11 +21,10 @@ func newMockWriter(store.WriterCfg) *mockWriter {
 	return &mockWriter{}
 }
 
-func (w *mockWriter) Write(p []byte) error {
+func (w *mockWriter) Write(p []byte) (int, error) {
 	w.Lock()
 	defer w.Unlock()
-	_, err := w.buf.Write(p)
-	return err
+	return w.buf.Write(p)
 }
 
 func (w *mockWriter) getData() []byte {

--- a/pkg/sqlreplay/capture/mock_test.go
+++ b/pkg/sqlreplay/capture/mock_test.go
@@ -5,12 +5,13 @@ package capture
 
 import (
 	"bytes"
+	"io"
 	"sync"
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/store"
 )
 
-var _ store.Writer = (*mockWriter)(nil)
+var _ io.WriteCloser = (*mockWriter)(nil)
 
 type mockWriter struct {
 	sync.Mutex

--- a/pkg/sqlreplay/store/compress.go
+++ b/pkg/sqlreplay/store/compress.go
@@ -1,0 +1,50 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"compress/gzip"
+	"io"
+
+	"go.uber.org/zap"
+)
+
+var _ io.WriteCloser = (*compressWriter)(nil)
+
+type compressWriter struct {
+	io.WriteCloser
+	internalWriter io.WriteCloser
+	lg             *zap.Logger
+}
+
+func newCompressWriter(lg *zap.Logger, writer io.WriteCloser) *compressWriter {
+	return &compressWriter{
+		WriteCloser:    gzip.NewWriter(writer),
+		internalWriter: writer,
+		lg:             lg,
+	}
+}
+
+func (w *compressWriter) Close() error {
+	if err := w.WriteCloser.Close(); err != nil {
+		w.lg.Warn("failed to close writer", zap.Error(err))
+	}
+	return w.internalWriter.Close()
+}
+
+var _ io.Reader = (*compressReader)(nil)
+
+type compressReader struct {
+	*gzip.Reader
+}
+
+func newCompressReader(reader io.Reader) (*compressReader, error) {
+	gr, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	return &compressReader{
+		Reader: gr,
+	}, nil
+}

--- a/pkg/sqlreplay/store/compress_test.go
+++ b/pkg/sqlreplay/store/compress_test.go
@@ -1,0 +1,38 @@
+// Copyright 2024 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCompressReadWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test")
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	writer := newCompressWriter(zap.NewNop(), file)
+	n, err := writer.Write([]byte("test"))
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	require.NoError(t, writer.Close())
+	// file is already closed
+	require.Error(t, file.Close())
+
+	file, err = os.OpenFile(path, os.O_RDONLY, 0600)
+	require.NoError(t, err)
+	reader, err := newCompressReader(file)
+	require.NoError(t, err)
+	data := make([]byte, 100)
+	n, err = io.ReadFull(reader, data)
+	require.Equal(t, 4, n)
+	require.ErrorContains(t, err, "EOF")
+}

--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -9,5 +9,5 @@ const (
 	fileName           = fileNamePrefix + fileNameSuffix
 	fileTsLayout       = "2006-01-02T15-04-05.000"
 	fileCompressFormat = ".gz"
-	fileSize           = 300 // 300MB
+	fileSize           = 300 << 20
 )

--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -4,10 +4,8 @@
 package store
 
 const (
-	fileNamePrefix     = "traffic"
+	fileNamePrefix     = "traffic-"
 	fileNameSuffix     = ".log"
-	fileName           = fileNamePrefix + fileNameSuffix
-	fileTsLayout       = "2006-01-02T15-04-05.000"
 	fileCompressFormat = ".gz"
 	fileSize           = 300 << 20
 )

--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -8,4 +8,5 @@ const (
 	fileNameSuffix     = ".log"
 	fileCompressFormat = ".gz"
 	fileSize           = 300 << 20
+	bufferSize         = 1 << 20
 )

--- a/pkg/sqlreplay/store/encrypt.go
+++ b/pkg/sqlreplay/store/encrypt.go
@@ -7,27 +7,43 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"os"
-	"reflect"
+	"strings"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 )
 
-var _ Writer = (*aesCTRWriter)(nil)
+const (
+	EncryptPlain = "plaintext"
+	EncryptAes   = "aes256-ctr"
+)
+
+var _ io.WriteCloser = (*aesCTRWriter)(nil)
 
 type aesCTRWriter struct {
-	Writer
+	io.WriteCloser
 	stream cipher.Stream
-	iv     []byte
-	inited bool
 }
 
-func newAESCTRWriter(writer Writer, keyFile string) (*aesCTRWriter, error) {
+func newWriterWithEncryptOpts(writer io.WriteCloser, encryptMethod string, keyFile string) (io.WriteCloser, error) {
+	switch strings.ToLower(encryptMethod) {
+	case "", EncryptPlain:
+		return writer, nil
+	case EncryptAes:
+	default:
+		return nil, fmt.Errorf("unsupported encrypt method: %s", encryptMethod)
+	}
+
 	key, err := readAesKey(keyFile)
 	if err != nil {
 		return nil, err
 	}
+	return newAESCTRWriter(writer, key)
+}
+
+func newAESCTRWriter(writer io.WriteCloser, key []byte) (*aesCTRWriter, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -36,95 +52,76 @@ func newAESCTRWriter(writer Writer, keyFile string) (*aesCTRWriter, error) {
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return &aesCTRWriter{
-		Writer: writer,
-		stream: cipher.NewCTR(block, iv),
-		iv:     iv,
-	}, nil
+	ctr := &aesCTRWriter{
+		WriteCloser: writer,
+		stream:      cipher.NewCTR(block, iv),
+	}
+	_, err = ctr.WriteCloser.Write(iv)
+	return ctr, err
 }
 
 func (ctr *aesCTRWriter) Write(data []byte) (int, error) {
-	if !ctr.inited {
-		if err := ctr.writeIV(); err != nil {
-			return 0, err
-		}
-		ctr.inited = true
-	}
 	ctr.stream.XORKeyStream(data, data)
-	return ctr.Writer.Write(data)
+	return ctr.WriteCloser.Write(data)
 }
 
-func (ctr *aesCTRWriter) writeIV() error {
-	_, err := ctr.Writer.Write(ctr.iv)
-	return err
-}
-
-func (ctr *aesCTRWriter) Close() error {
-	return ctr.Writer.Close()
-}
-
-var _ Reader = (*aesCTRReader)(nil)
+var _ io.Reader = (*aesCTRReader)(nil)
 
 type aesCTRReader struct {
-	Reader
+	io.Reader
 	stream cipher.Stream
-	key    []byte
 }
 
-func newAESCTRReader(reader Reader, keyFile string) (*aesCTRReader, error) {
+func newReaderWithEncryptOpts(reader io.Reader, encryptMethod string, keyFile string) (io.Reader, error) {
+	switch strings.ToLower(encryptMethod) {
+	case "", EncryptPlain:
+		return reader, nil
+	case EncryptAes:
+	default:
+		return nil, fmt.Errorf("unsupported encrypt method: %s", encryptMethod)
+	}
+
 	key, err := readAesKey(keyFile)
 	if err != nil {
 		return nil, err
 	}
+	return newAESCTRReader(reader, key)
+}
+
+func newAESCTRReader(reader io.Reader, key []byte) (*aesCTRReader, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	iv := make([]byte, aes.BlockSize)
+	for readLen := 0; readLen < len(iv); {
+		m, err := reader.Read(iv[readLen:])
+		if err != nil {
+			return nil, err
+		}
+		readLen += m
+	}
 	return &aesCTRReader{
 		Reader: reader,
-		key:    key,
+		stream: cipher.NewCTR(block, iv),
 	}, nil
 }
 
 func (ctr *aesCTRReader) Read(data []byte) (int, error) {
-	if ctr.stream == nil || reflect.ValueOf(ctr.stream).IsNil() {
-		if err := ctr.init(); err != nil {
-			return 0, err
-		}
-	}
 	n, err := ctr.Reader.Read(data)
 	if n > 0 {
 		ctr.stream.XORKeyStream(data[:n], data[:n])
 	}
 	if err != nil {
-		return n, err
+		return n, errors.WithStack(err)
 	}
 	return n, nil
 }
 
-func (ctr *aesCTRReader) init() error {
-	block, err := aes.NewCipher(ctr.key)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	iv := make([]byte, aes.BlockSize)
-	for readLen := 0; readLen < len(iv); {
-		m, err := ctr.Reader.Read(iv[readLen:])
-		if err != nil {
-			return err
-		}
-		readLen += m
-	}
-	ctr.stream = cipher.NewCTR(block, iv)
-	return nil
-}
-
-func (ctr *aesCTRReader) CurFile() string {
-	return ctr.Reader.CurFile()
-}
-
-func (ctr *aesCTRReader) Close() error {
-	ctr.Reader.Close()
-	return nil
-}
-
 func readAesKey(filename string) ([]byte, error) {
+	if len(filename) == 0 {
+		return nil, errors.New("encryption key file name is not set")
+	}
 	key, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/sqlreplay/store/encrypt.go
+++ b/pkg/sqlreplay/store/encrypt.go
@@ -43,10 +43,10 @@ func newAESCTRWriter(writer Writer, keyFile string) (*aesCTRWriter, error) {
 	}, nil
 }
 
-func (ctr *aesCTRWriter) Write(data []byte) error {
+func (ctr *aesCTRWriter) Write(data []byte) (int, error) {
 	if !ctr.inited {
 		if err := ctr.writeIV(); err != nil {
-			return err
+			return 0, err
 		}
 		ctr.inited = true
 	}
@@ -55,7 +55,8 @@ func (ctr *aesCTRWriter) Write(data []byte) error {
 }
 
 func (ctr *aesCTRWriter) writeIV() error {
-	return ctr.Writer.Write(ctr.iv)
+	_, err := ctr.Writer.Write(ctr.iv)
+	return err
 }
 
 func (ctr *aesCTRWriter) Close() error {
@@ -118,8 +119,9 @@ func (ctr *aesCTRReader) CurFile() string {
 	return ctr.Reader.CurFile()
 }
 
-func (ctr *aesCTRReader) Close() {
+func (ctr *aesCTRReader) Close() error {
 	ctr.Reader.Close()
+	return nil
 }
 
 func readAesKey(filename string) ([]byte, error) {

--- a/pkg/sqlreplay/store/encrypt_test.go
+++ b/pkg/sqlreplay/store/encrypt_test.go
@@ -7,60 +7,117 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestAes256(t *testing.T) {
+	// prepare a file
 	dir := t.TempDir()
-	rotateWriter := newRotateWriter(zap.NewNop(), WriterCfg{
-		Dir:      dir,
-		FileSize: 1000,
-	})
-	keyFile := filepath.Join(dir, "key")
-	genAesKey(t, keyFile)
-	aesWriter, err := newAESCTRWriter(rotateWriter, keyFile)
+	path := filepath.Join(dir, "test")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+
+	// write with encryption
+	key := genAesKey()
+	aesWriter, err := newAESCTRWriter(file, key)
 	require.NoError(t, err)
 	n, err := aesWriter.Write([]byte("test"))
 	require.Equal(t, 4, n)
 	require.NoError(t, err)
 	require.NoError(t, aesWriter.Close())
+	// aesWriter has closed the file
+	require.Error(t, file.Close())
 
-	rotateReader := newRotateReader(zap.NewNop(), dir)
-	aesReader, err := newAESCTRReader(rotateReader, keyFile)
+	// read directly, the data is encrypted
+	data, err := os.ReadFile(path)
 	require.NoError(t, err)
-	data := make([]byte, 100)
+	require.Greater(t, len(data), 4)
+
+	// read with decryption
+	file, err = os.OpenFile(path, os.O_RDONLY, 0600)
+	require.NoError(t, err)
+	aesReader, err := newAESCTRReader(file, key)
+	require.NoError(t, err)
+	data = make([]byte, 100)
 	n, err = io.ReadFull(aesReader, data)
 	require.Equal(t, len("test"), n)
-	require.ErrorContains(t, err, "unexpected EOF")
+	require.ErrorContains(t, err, "EOF")
 	require.Equal(t, []byte("test"), data[:n])
-	fileName := aesReader.CurFile()
-	require.True(t, strings.HasPrefix(fileName, fileNamePrefix))
-	require.NoError(t, aesReader.Close())
+}
+
+func TestEncryptOpts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test")
+	keyFile := filepath.Join(dir, "key")
+	require.NoError(t, os.WriteFile(keyFile, genAesKey(), 0600))
+
+	tests := []struct {
+		method  string
+		keyFile string
+	}{
+		{EncryptPlain, ""},
+		{"", ""},
+		{EncryptAes, keyFile},
+	}
+	for i, test := range tests {
+		// write
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+		require.NoError(t, err)
+		writer, err := newWriterWithEncryptOpts(file, test.method, test.keyFile)
+		require.NoError(t, err, "case %d", i)
+		n, err := writer.Write([]byte("test"))
+		require.NoError(t, err)
+		require.Equal(t, 4, n)
+		require.NoError(t, writer.Close())
+
+		// read
+		file, err = os.OpenFile(path, os.O_RDONLY, 0600)
+		require.NoError(t, err)
+		reader, err := newReaderWithEncryptOpts(file, test.method, test.keyFile)
+		require.NoError(t, err)
+		data := make([]byte, 100)
+		n, err = io.ReadFull(reader, data)
+		require.Equal(t, 4, n)
+		require.ErrorContains(t, err, "EOF")
+		require.Equal(t, []byte("test"), data[:n])
+	}
 }
 
 func TestAes256Error(t *testing.T) {
 	dir := t.TempDir()
-	rotateWriter := newRotateWriter(zap.NewNop(), WriterCfg{
-		Dir:      dir,
-		FileSize: 1000,
-	})
+	path := filepath.Join(dir, "test")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
+	require.NoError(t, err)
+	defer file.Close()
 	keyFile := filepath.Join(dir, "key")
-	_, err := newAESCTRWriter(rotateWriter, keyFile)
-	require.Error(t, err)
+	require.NoError(t, os.WriteFile(keyFile, genAesKey(), 0600))
+	invalidKeyFile := filepath.Join(dir, "invalid")
+	require.NoError(t, os.WriteFile(invalidKeyFile, []byte("invalid"), 0600))
+	noKeyFile := filepath.Join(dir, "nonexist")
 
-	rotateReader := newRotateReader(zap.NewNop(), dir)
-	_, err = newAESCTRReader(rotateReader, keyFile)
-	require.Error(t, err)
+	tests := []struct {
+		method  string
+		keyFile string
+	}{
+		{"unknown", keyFile},
+		{EncryptAes, ""},
+		{EncryptAes, noKeyFile},
+		{EncryptAes, invalidKeyFile},
+	}
+	for i, test := range tests {
+		_, err = newWriterWithEncryptOpts(file, test.method, test.keyFile)
+		require.Error(t, err, "case %d", i)
+		_, err = newReaderWithEncryptOpts(file, test.method, test.keyFile)
+		require.Error(t, err, "case %d", i)
+	}
 }
 
-func genAesKey(t *testing.T, keyFile string) {
+func genAesKey() []byte {
 	key := make([]byte, 32)
 	for i := range key {
 		key[i] = byte(i)
 	}
-	require.NoError(t, os.WriteFile(keyFile, key, 0600))
+	return key
 }

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -6,15 +6,10 @@ package store
 import (
 	"bufio"
 	"fmt"
-	"strings"
+	"io"
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"go.uber.org/zap"
-)
-
-const (
-	EncryptPlain = "plaintext"
-	EncryptAes   = "aes256-ctr"
 )
 
 type WriterCfg struct {
@@ -25,17 +20,8 @@ type WriterCfg struct {
 	Compress      bool
 }
 
-func NewWriter(lg *zap.Logger, cfg WriterCfg) (Writer, error) {
-	rotateWriter := newRotateWriter(lg, cfg)
-	encryptMethod := strings.ToLower(cfg.EncryptMethod)
-	switch encryptMethod {
-	case "", EncryptPlain:
-		return rotateWriter, nil
-	case EncryptAes:
-		return newAESCTRWriter(rotateWriter, cfg.KeyFile)
-	default:
-		return nil, fmt.Errorf("unsupported encrypt method: %s", encryptMethod)
-	}
+func NewWriter(lg *zap.Logger, cfg WriterCfg) (io.WriteCloser, error) {
+	return newRotateWriter(lg, cfg), nil
 }
 
 type ReaderCfg struct {
@@ -56,18 +42,7 @@ type loader struct {
 }
 
 func NewReader(lg *zap.Logger, cfg ReaderCfg) (*loader, error) {
-	var reader Reader
-	reader = newRotateReader(lg, cfg.Dir)
-	encryptMethod := strings.ToLower(cfg.EncryptMethod)
-	switch encryptMethod {
-	case "", EncryptPlain:
-	case EncryptAes:
-		var err error
-		reader, err = newAESCTRReader(reader, cfg.KeyFile)
-		if err != nil {
-			return nil, err
-		}
-	}
+	reader := newRotateReader(lg, cfg)
 	return &loader{
 		cfg:       cfg,
 		lg:        lg,

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -25,8 +25,8 @@ type WriterCfg struct {
 	Compress      bool
 }
 
-func NewWriter(cfg WriterCfg) (Writer, error) {
-	rotateWriter := newRotateWriter(cfg)
+func NewWriter(lg *zap.Logger, cfg WriterCfg) (Writer, error) {
+	rotateWriter := newRotateWriter(lg, cfg)
 	encryptMethod := strings.ToLower(cfg.EncryptMethod)
 	switch encryptMethod {
 	case "", EncryptPlain:

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -20,6 +20,8 @@ type WriterCfg struct {
 	Compress      bool
 }
 
+// NewWriter just wraps the rotate writer. It doesn't use a buffer because Capture writes data in a big batch.
+// Capture uses a bytes buffer to encode commands and the buffer can not be replaced with a bufio.Writer.
 func NewWriter(lg *zap.Logger, cfg WriterCfg) (io.WriteCloser, error) {
 	return newRotateWriter(lg, cfg), nil
 }
@@ -47,7 +49,7 @@ func NewReader(lg *zap.Logger, cfg ReaderCfg) (*loader, error) {
 		cfg:       cfg,
 		lg:        lg,
 		reader:    reader,
-		bufReader: bufio.NewReader(reader),
+		bufReader: bufio.NewReaderSize(reader, bufferSize),
 	}, nil
 }
 

--- a/pkg/sqlreplay/store/line_test.go
+++ b/pkg/sqlreplay/store/line_test.go
@@ -4,18 +4,14 @@
 package store
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestReadLine(t *testing.T) {
@@ -93,14 +89,13 @@ func TestReadLine(t *testing.T) {
 	dir := t.TempDir()
 	lg, _ := logger.CreateLoggerForTest(t)
 	cfg := ReaderCfg{Dir: dir}
-	now := time.Now()
 	for i, test := range tests {
 		require.NoError(t, os.RemoveAll(dir), "case %d", i)
 		require.NoError(t, os.MkdirAll(dir, 0777), "case %d", i)
 		fileNames := make([]string, 0, len(test.data))
 		for j, data := range test.data {
-			name := fmt.Sprintf("traffic-%s.log", now.Add(time.Duration(j)*time.Second).Format(fileTsLayout))
-			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0777)
+			name := fmt.Sprintf("%s%d%s", fileNamePrefix, j+1, fileNameSuffix)
+			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600)
 			require.NoError(t, err, "case %d", i)
 			fileNames = append(fileNames, name)
 		}
@@ -117,7 +112,7 @@ func TestReadLine(t *testing.T) {
 			}
 		}
 		_, _, _, err = l.ReadLine()
-		require.True(t, errors.Is(err, io.EOF))
+		require.ErrorIs(t, err, io.EOF, "case %d, err %v", i, err)
 		l.Close()
 	}
 }
@@ -194,14 +189,13 @@ func TestRead(t *testing.T) {
 	dir := t.TempDir()
 	lg, _ := logger.CreateLoggerForTest(t)
 	cfg := ReaderCfg{Dir: dir}
-	now := time.Now()
 	for i, test := range tests {
 		require.NoError(t, os.RemoveAll(dir), "case %d", i)
 		require.NoError(t, os.MkdirAll(dir, 0777), "case %d", i)
 		fileNames := make([]string, 0, len(test.data))
 		for j, data := range test.data {
-			name := fmt.Sprintf("traffic-%s.log", now.Add(time.Duration(j)*time.Second).Format(fileTsLayout))
-			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0777)
+			name := fmt.Sprintf("%s%d%s", fileNamePrefix, j+1, fileNameSuffix)
+			err := os.WriteFile(filepath.Join(dir, name), []byte(data), 0600)
 			require.NoError(t, err, "case %d", i)
 			fileNames = append(fileNames, name)
 		}
@@ -217,42 +211,7 @@ func TestRead(t *testing.T) {
 			require.Equal(t, test.lineIdx[j], idx, "case %d", i)
 		}
 		_, _, err = l.Read(data)
-		require.True(t, errors.Is(err, io.EOF), "case %d, err %v", i, err)
+		require.ErrorIs(t, err, io.EOF, "case %d, err %v", i, err)
 		l.Close()
-	}
-}
-
-func TestEncryptMethods(t *testing.T) {
-	dir := t.TempDir()
-	keyFile := filepath.Join(dir, "key")
-	genAesKey(t, keyFile)
-	for _, method := range []string{
-		"",
-		EncryptPlain,
-		EncryptAes,
-	} {
-		writer, err := NewWriter(zap.NewNop(), WriterCfg{
-			Dir:           dir,
-			EncryptMethod: method,
-			KeyFile:       keyFile,
-		})
-		require.NoError(t, err, method)
-		n, err := writer.Write([]byte("test"))
-		require.NoError(t, err, method)
-		require.Equal(t, 4, n, method)
-		require.NoError(t, writer.Close(), method)
-
-		reader, err := NewReader(zap.NewNop(), ReaderCfg{
-			Dir:           dir,
-			EncryptMethod: method,
-			KeyFile:       keyFile,
-		})
-		require.NoError(t, err, method)
-		data := make([]byte, 4)
-		curFile, lineIdx, err := reader.Read(data)
-		require.NoError(t, err, method)
-		require.True(t, strings.HasPrefix(curFile, fileNamePrefix), method)
-		require.Equal(t, 1, lineIdx, method)
-		reader.Close()
 	}
 }

--- a/pkg/sqlreplay/store/line_test.go
+++ b/pkg/sqlreplay/store/line_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -230,13 +231,15 @@ func TestEncryptMethods(t *testing.T) {
 		EncryptPlain,
 		EncryptAes,
 	} {
-		writer, err := NewWriter(WriterCfg{
+		writer, err := NewWriter(zap.NewNop(), WriterCfg{
 			Dir:           dir,
 			EncryptMethod: method,
 			KeyFile:       keyFile,
 		})
 		require.NoError(t, err, method)
-		require.NoError(t, writer.Write([]byte("test")), method)
+		n, err := writer.Write([]byte("test"))
+		require.NoError(t, err, method)
+		require.Equal(t, 4, n, method)
 		require.NoError(t, writer.Close(), method)
 
 		reader, err := NewReader(zap.NewNop(), ReaderCfg{
@@ -248,7 +251,7 @@ func TestEncryptMethods(t *testing.T) {
 		data := make([]byte, 4)
 		curFile, lineIdx, err := reader.Read(data)
 		require.NoError(t, err, method)
-		require.Equal(t, fileName, curFile, method)
+		require.True(t, strings.HasPrefix(curFile, fileNamePrefix), method)
 		require.Equal(t, 1, lineIdx, method)
 		reader.Close()
 	}

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -4,34 +4,26 @@
 package store
 
 import (
-	"bufio"
-	"compress/gzip"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"go.uber.org/zap"
 )
 
-type Writer interface {
-	io.WriteCloser
-}
-
-var _ Writer = (*rotateWriter)(nil)
+var _ io.WriteCloser = (*rotateWriter)(nil)
 
 type rotateWriter struct {
-	cfg       WriterCfg
-	writer    io.WriteCloser
-	file      *os.File
-	lg        *zap.Logger
-	lastMilli int64
-	writeLen  int
+	cfg      WriterCfg
+	writer   io.WriteCloser
+	lg       *zap.Logger
+	fileIdx  int
+	writeLen int
 }
 
 func newRotateWriter(lg *zap.Logger, cfg WriterCfg) *rotateWriter {
@@ -62,50 +54,34 @@ func (w *rotateWriter) Write(data []byte) (n int, err error) {
 }
 
 func (w *rotateWriter) createFile() error {
-	// Get a different time if the current time is the same as the last time.
-	now := time.Now()
-	if millis := now.UnixMilli(); millis <= w.lastMilli {
-		w.lastMilli += 1
-		now = time.Unix(w.lastMilli/1e3, (w.lastMilli%1e3)*1e6)
-	} else {
-		w.lastMilli = millis
-	}
-	t := now.Format(fileTsLayout)
-
 	var ext string
 	if w.cfg.Compress {
 		ext = fileCompressFormat
 	}
-	fileName := fmt.Sprintf("%s-%s%s%s", fileNamePrefix, t, fileNameSuffix, ext)
+	w.fileIdx++
+	fileName := fmt.Sprintf("%s%d%s%s", fileNamePrefix, w.fileIdx, fileNameSuffix, ext)
 	path := filepath.Join(w.cfg.Dir, fileName)
+	// compressWriter -> encryptWriter -> file
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	w.file = file
+	if w.writer, err = newWriterWithEncryptOpts(file, w.cfg.EncryptMethod, w.cfg.KeyFile); err != nil {
+		return err
+	}
 	if w.cfg.Compress {
-		w.writer = gzip.NewWriter(file)
-	} else {
-		w.writer = file
+		w.writer = newCompressWriter(w.lg, w.writer)
 	}
 	return nil
 }
 
 func (w *rotateWriter) closeFile() error {
-	var err error
 	if w.writer != nil && !reflect.ValueOf(w.writer).IsNil() {
-		if err = w.writer.Close(); err != nil {
-			w.lg.Warn("failed to close writer", zap.Error(err))
-		}
+		err := w.writer.Close()
 		w.writer = nil
+		return err
 	}
-	if w.cfg.Compress && w.file != nil {
-		if err = w.file.Close(); err != nil {
-			w.lg.Warn("failed to close traffic file", zap.Error(err))
-		}
-	}
-	w.file = nil
-	return err
+	return nil
 }
 
 func (w *rotateWriter) Close() error {
@@ -120,24 +96,27 @@ type Reader interface {
 var _ Reader = (*rotateReader)(nil)
 
 type rotateReader struct {
-	dir string
-	// the time in the file name
+	cfg         ReaderCfg
 	curFileName string
-	curFileTs   int64
+	curFileIdx  int
 	curFile     *os.File
-	reader      *bufio.Reader
+	reader      io.Reader
 	lg          *zap.Logger
+	eof         bool
 }
 
-func newRotateReader(lg *zap.Logger, dir string) *rotateReader {
+func newRotateReader(lg *zap.Logger, cfg ReaderCfg) *rotateReader {
 	return &rotateReader{
-		dir: dir,
+		cfg: cfg,
 		lg:  lg,
 	}
 }
 
 func (r *rotateReader) Read(data []byte) (int, error) {
-	if r.reader == nil {
+	if r.eof {
+		return 0, io.EOF
+	}
+	if r.reader == nil || reflect.ValueOf(r.reader).IsNil() {
 		if err := r.nextReader(); err != nil {
 			return 0, err
 		}
@@ -151,7 +130,9 @@ func (r *rotateReader) Read(data []byte) (int, error) {
 		if err != io.EOF {
 			return m, errors.WithStack(err)
 		}
+		_ = r.Close()
 		if err := r.nextReader(); err != nil {
+			r.eof = true
 			return m, err
 		}
 		if m > 0 {
@@ -176,15 +157,11 @@ func (r *rotateReader) Close() error {
 }
 
 func (r *rotateReader) nextReader() error {
-	// has read the latest file
-	if r.curFileTs == math.MaxInt64 {
-		return io.EOF
-	}
-	files, err := os.ReadDir(r.dir)
+	files, err := os.ReadDir(r.cfg.Dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	var minFileTs int64
+	var minFileIdx int
 	var minFileName string
 	for _, file := range files {
 		if file.IsDir() {
@@ -194,80 +171,64 @@ func (r *rotateReader) nextReader() error {
 		if !strings.HasPrefix(name, fileNamePrefix) {
 			continue
 		}
-		// traffic.log (used for lumberjack before, not used anymore)
-		if name == fileName {
-			if minFileName == "" {
-				minFileTs = math.MaxInt64
-				minFileName = name
-			}
-			continue
-		}
-		// rotated traffic file
-		fileTs := parseFileTs(name)
-		if fileTs == 0 {
+		fileIdx := parseFileIdx(name)
+		if fileIdx == 0 {
 			r.lg.Warn("traffic file name is invalid", zap.String("filename", name))
 			continue
 		}
-		if fileTs <= r.curFileTs {
+		if fileIdx <= r.curFileIdx {
 			continue
 		}
-		if minFileName == "" || fileTs < minFileTs {
-			minFileTs = fileTs
+		if minFileName == "" || fileIdx < minFileIdx {
+			minFileIdx = fileIdx
 			minFileName = name
 		}
 	}
 	if minFileName == "" {
 		return io.EOF
 	}
-	fileReader, err := os.Open(filepath.Join(r.dir, minFileName))
+	fileReader, err := os.Open(filepath.Join(r.cfg.Dir, minFileName))
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if r.curFile != nil {
-		if err := r.curFile.Close(); err != nil {
-			r.lg.Warn("failed to close file", zap.String("filename", r.curFile.Name()), zap.Error(err))
-		}
-	}
 	r.curFile = fileReader
-	r.curFileTs = minFileTs
+	r.curFileIdx = minFileIdx
 	r.curFileName = minFileName
+	// compressReader -> encryptReader -> file
+	r.reader, err = newReaderWithEncryptOpts(fileReader, r.cfg.EncryptMethod, r.cfg.KeyFile)
+	if err != nil {
+		return err
+	}
 	if strings.HasSuffix(minFileName, fileCompressFormat) {
-		gr, err := gzip.NewReader(fileReader)
-		if err != nil {
-			return errors.WithStack(err)
+		if r.reader, err = newCompressReader(r.reader); err != nil {
+			return err
 		}
-		r.reader = bufio.NewReader(gr)
-	} else {
-		r.reader = bufio.NewReader(fileReader)
 	}
 	r.lg.Info("reading next file", zap.String("file", minFileName))
 	return nil
 }
 
-// Parse the file name to get the file time.
-// filename pattern: traffic-2024-08-29T17-37-12.477.log.gz
-// Ordering by string should also work.
-func parseFileTs(name string) int64 {
+// Parse the file name to get the file index.
+// filename pattern: traffic-1.log.gz
+func parseFileIdx(name string) int {
+	if !strings.HasPrefix(name, fileNamePrefix) {
+		return 0
+	}
 	startIdx := len(fileNamePrefix)
-	if len(name) <= startIdx {
+	if len(name) <= startIdx+len(fileNameSuffix) {
 		return 0
 	}
-	if name[startIdx] != '-' {
-		return 0
-	}
-	startIdx++
 	endIdx := len(name)
 	if strings.HasSuffix(name, fileCompressFormat) {
-		endIdx -= 3
+		endIdx -= len(fileCompressFormat)
 	}
 	if !strings.HasSuffix(name[:endIdx], fileNameSuffix) {
 		return 0
 	}
 	endIdx -= len(fileNameSuffix)
-	timeStr := name[startIdx:endIdx]
-	t, err := time.Parse(fileTsLayout, timeStr)
+	fileIdx, err := strconv.Atoi(name[startIdx:endIdx])
 	if err != nil {
 		return 0
 	}
-	return t.UnixMilli()
+	return fileIdx
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #726 

Problem Summary:
- `lumberjack` is used to write traffic commands, but it requires that each write should be less than the file size (300MB)
- `lumberjack` writes, rotates, and compresses internally, so it's hard to use S3

What is changed and how it works:
- Replace `lumberjack` with customized writers.
- Change the call chain from `encryptWriter -> rotateWriter` to `rotateWriter -> compressWriter -> encryptWriter`.
- Change the file name from pattern `traffic-{time}.log` to `traffic-{idx}.log`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
