### PR TITLE
security, config: add a config `cert-allowed-cn` to the HTTP API

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -107,6 +107,7 @@ graceful-close-conn-timeout = 15
 	[security.server-http-tls]
 	# proxy HTTP port will use this
 	# auto-certs = true
+	# cert-allowed-cn = ["tiproxy", "tidb", "test-client", "prometheus"]
 
 # require-backend-tls = false
 

--- a/lib/config/security.go
+++ b/lib/config/security.go
@@ -4,14 +4,15 @@
 package config
 
 type TLSConfig struct {
-	Cert               string `yaml:"cert,omitempty" toml:"cert,omitempty" json:"cert,omitempty"`
-	Key                string `yaml:"key,omitempty" toml:"key,omitempty" json:"key,omitempty"`
-	CA                 string `yaml:"ca,omitempty" toml:"ca,omitempty" json:"ca,omitempty"`
-	MinTLSVersion      string `yaml:"min-tls-version,omitempty" toml:"min-tls-version,omitempty" json:"min-tls-version,omitempty"`
-	AutoCerts          bool   `yaml:"auto-certs,omitempty" toml:"auto-certs,omitempty" json:"auto-certs,omitempty"`
-	RSAKeySize         int    `yaml:"rsa-key-size,omitempty" toml:"rsa-key-size,omitempty" json:"rsa-key-size,omitempty"`
-	AutoExpireDuration string `yaml:"autocert-expire-duration,omitempty" toml:"autocert-expire-duration,omitempty" json:"autocert-expire-duration,omitempty"`
-	SkipCA             bool   `yaml:"skip-ca,omitempty" toml:"skip-ca,omitempty" json:"skip-ca,omitempty"`
+	Cert               string   `yaml:"cert,omitempty" toml:"cert,omitempty" json:"cert,omitempty"`
+	Key                string   `yaml:"key,omitempty" toml:"key,omitempty" json:"key,omitempty"`
+	CA                 string   `yaml:"ca,omitempty" toml:"ca,omitempty" json:"ca,omitempty"`
+	MinTLSVersion      string   `yaml:"min-tls-version,omitempty" toml:"min-tls-version,omitempty" json:"min-tls-version,omitempty"`
+	CertAllowedCN      []string `yaml:"cert-allowed-cn,omitempty" toml:"cert-allowed-cn,omitempty" json:"cert-allowed-cn,omitempty"`
+	AutoCerts          bool     `yaml:"auto-certs,omitempty" toml:"auto-certs,omitempty" json:"auto-certs,omitempty"`
+	RSAKeySize         int      `yaml:"rsa-key-size,omitempty" toml:"rsa-key-size,omitempty" json:"rsa-key-size,omitempty"`
+	AutoExpireDuration string   `yaml:"autocert-expire-duration,omitempty" toml:"autocert-expire-duration,omitempty" json:"autocert-expire-duration,omitempty"`
+	SkipCA             bool     `yaml:"skip-ca,omitempty" toml:"skip-ca,omitempty" json:"skip-ca,omitempty"`
 }
 
 func (c TLSConfig) HasCert() bool {

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -25,7 +25,7 @@ import (
 
 const DefaultCertExpiration = 24 * 90 * time.Hour
 
-func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration) error {
+func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string, rsaKeySize int, expiration time.Duration, commonName string) error {
 	logger = logger.With(zap.String("cert", certpath), zap.String("key", keypath), zap.String("ca", capath), zap.Int("rsaKeySize", rsaKeySize))
 
 	_, e1 := os.Stat(certpath)
@@ -55,7 +55,7 @@ func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string,
 		}
 	}
 
-	certPEM, keyPEM, caPEM, err := createTempTLS(rsaKeySize, expiration)
+	certPEM, keyPEM, caPEM, err := createTempTLS(rsaKeySize, expiration, commonName)
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func CreateTLSCertificates(logger *zap.Logger, certpath, keypath, capath string,
 	return nil
 }
 
-func createTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []byte, error) {
+func createTempTLS(rsaKeySize int, expiration time.Duration, commonName string) ([]byte, []byte, []byte, error) {
 	if rsaKeySize <= 0 {
 		rsaKeySize = 4096
 	} else if rsaKeySize < 1024 {
@@ -133,6 +133,7 @@ func createTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []
 			Locality:      []string{"San Francisco"},
 			StreetAddress: []string{"Golden Gate Bridge"},
 			PostalCode:    []string{"94016"},
+			CommonName:    commonName,
 		},
 		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 		NotBefore:    time.Now(),
@@ -173,7 +174,7 @@ func createTempTLS(rsaKeySize int, expiration time.Duration) ([]byte, []byte, []
 
 // CreateTLSConfigForTest is from https://gist.github.com/shaneutt/5e1995295cff6721c89a71d13a71c251.
 func CreateTLSConfigForTest() (serverTLSConf *tls.Config, clientTLSConf *tls.Config, err error) {
-	certPEM, keyPEM, caPEM, uerr := createTempTLS(1024, DefaultCertExpiration)
+	certPEM, keyPEM, caPEM, uerr := createTempTLS(1024, DefaultCertExpiration, "")
 	if uerr != nil {
 		err = uerr
 		return

--- a/lib/util/security/tls_test.go
+++ b/lib/util/security/tls_test.go
@@ -13,7 +13,7 @@ import (
 
 func BenchmarkCreateTLS(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := createTempTLS(0, DefaultCertExpiration)
+		_, _, _, err := createTempTLS(0, DefaultCertExpiration, "")
 		require.Nil(b, err)
 	}
 }
@@ -67,7 +67,7 @@ func TestGetMinTLSVer(t *testing.T) {
 func TestRsaSize(t *testing.T) {
 	sizes := []int{0, 512, 1024, 2048, 4096}
 	for _, size := range sizes {
-		_, _, _, err := createTempTLS(size, DefaultCertExpiration)
+		_, _, _, err := createTempTLS(size, DefaultCertExpiration, "")
 		require.Nil(t, err)
 	}
 }

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -159,8 +159,8 @@ func TestRotate(t *testing.T) {
 	createFile(t, caPath)
 	createFile(t, keyPath)
 	createFile(t, certPath)
-	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration))
-	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, ""))
 
 	cfg := &config.Config{
 		Workdir: tmpdir,
@@ -335,16 +335,17 @@ func TestBidirectional(t *testing.T) {
 	keyPath2 := filepath.Join(tmpdir, "c2", "key")
 	certPath2 := filepath.Join(tmpdir, "c2", "cert")
 
-	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration))
-	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, "server"))
 
 	cfg := &config.Config{
 		Workdir: tmpdir,
 		Security: config.Security{
 			ServerSQLTLS: config.TLSConfig{
-				Cert: certPath1,
-				Key:  keyPath1,
-				CA:   caPath2,
+				Cert:          certPath1,
+				Key:           keyPath1,
+				CA:            caPath2,
+				CertAllowedCN: []string{"server"},
 			},
 			SQLTLS: config.TLSConfig{
 				CA:   caPath1,
@@ -369,7 +370,7 @@ func TestWatchConfig(t *testing.T) {
 	caPath1 := filepath.Join(tmpdir, "c1", "ca")
 	keyPath1 := filepath.Join(tmpdir, "c1", "key")
 	certPath1 := filepath.Join(tmpdir, "c1", "cert")
-	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
 
 	tests := []struct {
 		cfg     config.TLSConfig


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #735

Problem Summary:
The traffic replay API is crucial, normal users shouldn't call it.

What is changed and how it works:
- Add a config `cert-allowed-cn` to `TLSConfig`
- If `cert-allowed-cn` is set, verify the CN and set `tcfg.ClientAuth = tls.RequireAndVerifyClientCert`
- Add the CA to `tcfg.ClientCAs`. But the problem is, the ClientCAs in the returned tls.Config can't be updated after reload, which results in connection failure after CA rotation and cert-allowed-cn is

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
