### PR TITLE
config, api: add a config to turn off traffic replay on TiDB Cloud

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -22,15 +22,16 @@ var (
 )
 
 type Config struct {
-	Proxy    ProxyServer       `yaml:"proxy,omitempty" toml:"proxy,omitempty" json:"proxy,omitempty"`
-	API      API               `yaml:"api,omitempty" toml:"api,omitempty" json:"api,omitempty"`
-	Advance  Advance           `yaml:"advance,omitempty" toml:"advance,omitempty" json:"advance,omitempty"`
-	Workdir  string            `yaml:"workdir,omitempty" toml:"workdir,omitempty" json:"workdir,omitempty"`
-	Security Security          `yaml:"security,omitempty" toml:"security,omitempty" json:"security,omitempty"`
-	Log      Log               `yaml:"log,omitempty" toml:"log,omitempty" json:"log,omitempty"`
-	Balance  Balance           `yaml:"balance,omitempty" toml:"balance,omitempty" json:"balance,omitempty"`
-	Labels   map[string]string `yaml:"labels,omitempty" toml:"labels,omitempty" json:"labels,omitempty"`
-	HA       HA                `yaml:"ha,omitempty" toml:"ha,omitempty" json:"ha,omitempty"`
+	Proxy               ProxyServer       `yaml:"proxy,omitempty" toml:"proxy,omitempty" json:"proxy,omitempty"`
+	API                 API               `yaml:"api,omitempty" toml:"api,omitempty" json:"api,omitempty"`
+	Advance             Advance           `yaml:"advance,omitempty" toml:"advance,omitempty" json:"advance,omitempty"`
+	Workdir             string            `yaml:"workdir,omitempty" toml:"workdir,omitempty" json:"workdir,omitempty"`
+	Security            Security          `yaml:"security,omitempty" toml:"security,omitempty" json:"security,omitempty"`
+	Log                 Log               `yaml:"log,omitempty" toml:"log,omitempty" json:"log,omitempty"`
+	Balance             Balance           `yaml:"balance,omitempty" toml:"balance,omitempty" json:"balance,omitempty"`
+	Labels              map[string]string `yaml:"labels,omitempty" toml:"labels,omitempty" json:"labels,omitempty"`
+	HA                  HA                `yaml:"ha,omitempty" toml:"ha,omitempty" json:"ha,omitempty"`
+	EnableTrafficReplay bool              `yaml:"enable-traffic-replay,omitempty" toml:"enable-traffic-replay,omitempty" json:"enable-traffic-replay,omitempty"`
 }
 
 type KeepAlive struct {
@@ -136,6 +137,8 @@ func NewConfig() *Config {
 	cfg.Security.ClusterTLS.MinTLSVersion = "1.2"
 
 	cfg.Balance = DefaultBalance()
+
+	cfg.EnableTrafficReplay = true
 
 	return &cfg
 }

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -128,6 +128,42 @@ func cancelJob(t *testing.T, doHTTP doHTTPFunc) {
 	})
 }
 
+func TestDisableTrafficReplay(t *testing.T) {
+	server, doHTTP := createServer(t)
+	server.mgr.CfgMgr.GetConfig().EnableTrafficReplay = false
+
+	doHTTP(t, http.MethodPost, "/api/traffic/capture", httpOpts{
+		reader: cli.GetFormReader(map[string]string{"output": "/tmp", "duration": "1h"}),
+		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+	}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadRequest, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "traffic capture is disabled", string(all))
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
+		reader: cli.GetFormReader(map[string]string{"input": "/tmp"}),
+		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+	}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadRequest, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "traffic replay is disabled", string(all))
+	})
+	doHTTP(t, http.MethodPost, "/api/traffic/cancel", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadRequest, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "traffic cancel is disabled", string(all))
+	})
+	doHTTP(t, http.MethodGet, "/api/traffic/show", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadRequest, r.StatusCode)
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, "traffic show is disabled", string(all))
+	})
+}
+
 var _ manager.JobManager = (*mockReplayJobManager)(nil)
 
 type mockReplayJobManager struct {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #737

Problem Summary:
We don't need to support traffic replay on TiDB Cloud because users should not be aware of TiDB versions. However, it involves more security problems so we need to disable it on the cloud.

What is changed and how it works:
- Add a config `enable-traffic-replay` in the top level
- Report an error in the HTTP API if it's disabled

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [x] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
