### PR TITLE
config, api: rename configs and command arguments for traffic replay

### DIFF
--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -29,7 +29,7 @@ func GetTrafficCaptureCmd(ctx *Context) *cobra.Command {
 	}
 	output := captureCmd.PersistentFlags().String("output", "", "output directory for traffic files")
 	duration := captureCmd.PersistentFlags().String("duration", "", "the duration of traffic capture")
-	encrypt := captureCmd.PersistentFlags().String("encrypt-method", "", "the encryption method used for encrypting traffic files")
+	encrypt := captureCmd.PersistentFlags().String("encryption-method", "", "the encryption method used for encrypting traffic files")
 	compress := captureCmd.PersistentFlags().Bool("compress", true, "whether compress the traffic files")
 	captureCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		reader := GetFormReader(map[string]string{
@@ -58,7 +58,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 	speed := replayCmd.PersistentFlags().Float64("speed", 1, "replay speed")
 	username := replayCmd.PersistentFlags().String("username", "", "the username to connect to TiDB for replay")
 	password := replayCmd.PersistentFlags().String("password", "", "the password to connect to TiDB for replay")
-	readonly := replayCmd.PersistentFlags().Bool("readonly", false, "only replay read-only queries, default is false")
+	readonly := replayCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
 	replayCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		reader := GetFormReader(map[string]string{
 			"input":    *input,

--- a/lib/config/security.go
+++ b/lib/config/security.go
@@ -24,14 +24,10 @@ func (c TLSConfig) HasCA() bool {
 }
 
 type Security struct {
-	ServerSQLTLS      TLSConfig  `yaml:"server-tls,omitempty" toml:"server-tls,omitempty" json:"server-tls,omitempty"`
-	ServerHTTPTLS     TLSConfig  `yaml:"server-http-tls,omitempty" toml:"server-http-tls,omitempty" json:"server-http-tls,omitempty"`
-	ClusterTLS        TLSConfig  `yaml:"cluster-tls,omitempty" toml:"cluster-tls,omitempty" json:"cluster-tls,omitempty"`
-	SQLTLS            TLSConfig  `yaml:"sql-tls,omitempty" toml:"sql-tls,omitempty" json:"sql-tls,omitempty"`
-	Encryption        Encryption `yaml:"encryption,omitempty" toml:"encryption,omitempty" json:"encryption,omitempty"`
-	RequireBackendTLS bool       `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
-}
-
-type Encryption struct {
-	KeyPath string `yaml:"key-path,omitempty" toml:"key-path,omitempty" json:"key-path,omitempty"`
+	ServerSQLTLS      TLSConfig `yaml:"server-tls,omitempty" toml:"server-tls,omitempty" json:"server-tls,omitempty"`
+	ServerHTTPTLS     TLSConfig `yaml:"server-http-tls,omitempty" toml:"server-http-tls,omitempty" json:"server-http-tls,omitempty"`
+	ClusterTLS        TLSConfig `yaml:"cluster-tls,omitempty" toml:"cluster-tls,omitempty" json:"cluster-tls,omitempty"`
+	SQLTLS            TLSConfig `yaml:"sql-tls,omitempty" toml:"sql-tls,omitempty" json:"sql-tls,omitempty"`
+	EncryptionKeyPath string    `yaml:"encryption-key-path,omitempty" toml:"encryption-key-path,omitempty" json:"encryption-key-path,omitempty"`
+	RequireBackendTLS bool      `yaml:"require-backend-tls,omitempty" toml:"require-backend-tls,omitempty" json:"require-backend-tls,omitempty"`
 }

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -50,7 +50,7 @@ func (h *Server) TrafficCapture(c *gin.Context) {
 		}
 	}
 	cfg.Compress = compress
-	cfg.KeyFile = globalCfg.Security.Encryption.KeyPath
+	cfg.KeyFile = globalCfg.Security.EncryptionKeyPath
 	if startTimeStr := c.PostForm("start-time"); startTimeStr != "" {
 		startTime, err := time.Parse(time.RFC3339, startTimeStr)
 		if err != nil {
@@ -99,7 +99,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 	cfg.Username = c.PostForm("username")
 	cfg.Password = c.PostForm("password")
 	cfg.ReadOnly = strings.EqualFold(c.PostForm("readonly"), "true")
-	cfg.KeyFile = globalCfg.Security.Encryption.KeyPath
+	cfg.KeyFile = globalCfg.Security.EncryptionKeyPath
 
 	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #733 

Problem Summary:
- Command line arguments `encrypt-method` and `readonly` are inconsistent with SQL.
- Config `security.encryption.key-path` is too complicated.

What is changed and how it works:
- Rename `encrypt-method` to `encryption-method`
- Rename `readonly` to `read-only`
- Rename `security.encryption.key-path` to `security.encryption-key-path`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [x] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
