### PR TITLE
sqlreplay, api: add privilege argument to the cancel traffic api

### DIFF
--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/manager"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
 	"go.uber.org/zap"
 )
@@ -115,7 +116,17 @@ func (h *Server) TrafficCancel(c *gin.Context) {
 		return
 	}
 
-	result := h.mgr.ReplayJobMgr.Stop()
+	cfg := manager.CancelConfig{}
+	cfg.Type = manager.Capture | manager.Replay
+	if tp := c.PostForm("type"); tp != "" {
+		switch strings.ToLower(tp) {
+		case "capture":
+			cfg.Type = manager.Capture
+		case "replay":
+			cfg.Type = manager.Replay
+		}
+	}
+	result := h.mgr.ReplayJobMgr.Stop(cfg)
 	c.String(http.StatusOK, result)
 }
 

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -201,7 +201,7 @@ func (m *mockReplayJobManager) StartReplay(replayCfg replay.ReplayConfig) error 
 	return nil
 }
 
-func (m *mockReplayJobManager) Stop() string {
+func (m *mockReplayJobManager) Stop(manager.CancelConfig) string {
 	m.curJob = ""
 	return "stopped"
 }

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -13,15 +13,15 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
-type jobType int
+type JobType int
 
 const (
-	Capture jobType = iota
+	Capture JobType = 1 << iota
 	Replay
 )
 
 type Job interface {
-	Type() jobType
+	Type() JobType
 	String() string
 	MarshalJSON() ([]byte, error)
 	SetProgress(progress float64, endTime time.Time, done bool, err error)
@@ -89,7 +89,7 @@ type captureJob struct {
 	cfg capture.CaptureConfig
 }
 
-func (job *captureJob) Type() jobType {
+func (job *captureJob) Type() JobType {
 	return Capture
 }
 
@@ -116,7 +116,7 @@ type replayJob struct {
 	cfg replay.ReplayConfig
 }
 
-func (job *replayJob) Type() jobType {
+func (job *replayJob) Type() JobType {
 	return Replay
 }
 

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -16,7 +16,7 @@ import (
 func TestIsRunning(t *testing.T) {
 	tests := []struct {
 		job     Job
-		tp      jobType
+		tp      JobType
 		running bool
 	}{
 		{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #740 

Problem Summary:
https://github.com/pingcap/tidb/pull/59054 adds the privilege check to traffic replay statements, and it passes the `type` argument to the `cancel` api.

What is changed and how it works:
- Parse the `type` argument in the cancel API. The default is capture + replay.
- Check the type when canceling the job.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
