### PR TITLE
sqlreplay: redact the S3 secrets

### DIFF
--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/capture"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
 	"github.com/siddontang/go/hack"
@@ -96,7 +97,7 @@ func (job *captureJob) Type() JobType {
 func (job *captureJob) MarshalJSON() ([]byte, error) {
 	job4Marshal := job.getJob4Marshal()
 	job4Marshal.Type = "capture"
-	job4Marshal.Output = job.cfg.Output
+	job4Marshal.Output = ast.RedactURL(job.cfg.Output)
 	job4Marshal.Duration = job.cfg.Duration.String()
 	return json.Marshal(job4Marshal)
 }
@@ -123,7 +124,7 @@ func (job *replayJob) Type() JobType {
 func (job *replayJob) MarshalJSON() ([]byte, error) {
 	job4Marshal := job.getJob4Marshal()
 	job4Marshal.Type = "replay"
-	job4Marshal.Input = job.cfg.Input
+	job4Marshal.Input = ast.RedactURL(job.cfg.Input)
 	job4Marshal.Username = job.cfg.Username
 	job4Marshal.Speed = job.cfg.Speed
 	if job4Marshal.Speed == 0 {

--- a/pkg/sqlreplay/manager/job_test.go
+++ b/pkg/sqlreplay/manager/job_test.go
@@ -130,6 +130,21 @@ func TestMarshalJob(t *testing.T) {
 			marshal: `{"type":"capture","status":"canceled","start_time":"2020-01-01T00:00:00Z","end_time":"2020-01-01T02:01:01Z","duration":"2h0m0s","output":"/tmp/traffic","progress":"50%","error":"mock error"}`,
 		},
 		{
+			job: &captureJob{
+				job: job{
+					startTime: startTime,
+					endTime:   endTime,
+					progress:  0.5,
+					done:      true,
+				},
+				cfg: capture.CaptureConfig{
+					Output:   "s3://bucket/prefix?access-key=abcdefghi&secret-access-key=123&force-path-style=true",
+					Duration: 2 * time.Hour,
+				},
+			},
+			marshal: `{"type":"capture","status":"done","start_time":"2020-01-01T00:00:00Z","end_time":"2020-01-01T02:01:01Z","duration":"2h0m0s","output":"s3://bucket/prefix?access-key=xxxxxx\u0026force-path-style=true\u0026secret-access-key=xxxxxx","progress":"50%"}`,
+		},
+		{
 			job: &replayJob{
 				job: job{
 					startTime: startTime,
@@ -157,6 +172,19 @@ func TestMarshalJob(t *testing.T) {
 				},
 			},
 			marshal: `{"type":"replay","status":"done","start_time":"2020-01-01T00:00:00Z","end_time":"2020-01-01T02:01:01Z","input":"/tmp/traffic","username":"root","speed":0.5,"progress":"100%"}`,
+		},
+		{
+			job: &replayJob{
+				job: job{
+					startTime: startTime,
+					progress:  0,
+				},
+				cfg: replay.ReplayConfig{
+					Input:    "s3://bucket/prefix?access-key=abcdefghi&secret-access-key=123&force-path-style=true",
+					Username: "root",
+				},
+			},
+			marshal: `{"type":"replay","status":"running","start_time":"2020-01-01T00:00:00Z","input":"s3://bucket/prefix?access-key=xxxxxx\u0026force-path-style=true\u0026secret-access-key=xxxxxx","username":"root","speed":1,"progress":"0%"}`,
 		},
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #742

Problem Summary:
S3 secrets should be redacted for log and API output.

What is changed and how it works:
Redact the URL when marshaling the job.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
