### PR TITLE
sqlreplay: fix replay traffic from S3 always reports request is canceled

### DIFF
--- a/pkg/sqlreplay/store/encrypt.go
+++ b/pkg/sqlreplay/store/encrypt.go
@@ -112,10 +112,10 @@ func (ctr *aesCTRReader) Read(data []byte) (int, error) {
 	if n > 0 {
 		ctr.stream.XORKeyStream(data[:n], data[:n])
 	}
-	if err != nil {
-		return n, errors.WithStack(err)
+	if errors.Is(err, io.EOF) {
+		return n, err
 	}
-	return n, nil
+	return n, errors.WithStack(err)
 }
 
 func readAesKey(filename string) ([]byte, error) {

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -192,9 +192,8 @@ func (r *rotateReader) nextReader() error {
 	if minFileName == "" {
 		return io.EOF
 	}
-	ctx, cancel = context.WithTimeout(context.Background(), opTimeout)
-	fileReader, err := r.storage.Open(ctx, minFileName, &storage.ReaderOption{})
-	cancel()
+	// storage.Open(ctx) stores the context internally for subsequent reads, so don't set a short timeout.
+	fileReader, err := r.storage.Open(context.Background(), minFileName, &storage.ReaderOption{})
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -133,7 +133,7 @@ func (r *rotateReader) Read(data []byte) (int, error) {
 		if err == nil {
 			return m, nil
 		}
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			return m, errors.WithStack(err)
 		}
 		_ = r.Close()


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #746

Problem Summary:
- Replay traffic from S3 always reports `request is canceled` because the context is passed from `storage.Open()` to `storage.Read()`
- Replay always reads only one file when the files are encrypted because `rotateReader` uses `err != io.EOF` while the `encryptReader` returns a wrapped `io.EOF`

What is changed and how it works:
- Do not pass a context with timeout into `storage.Open()`
- Replace `err != io.EOF` with `!errors.Is(err, io.EOF)`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manually test traffic replay from S3

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
