### PR TITLE
sqlreplay: fix replay reports invalid encryption key length

### DIFF
--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -159,7 +159,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	if err != nil {
 		return errors.Wrapf(err, "failed to load encryption key")
 	}
-	cfg.encryptionKey = key
+	r.cfg.encryptionKey = key
 
 	hsHandler = NewHandshakeHandler(hsHandler)
 	r.connCreator = cfg.connCreator

--- a/pkg/sqlreplay/store/encrypt.go
+++ b/pkg/sqlreplay/store/encrypt.go
@@ -121,7 +121,7 @@ func LoadEncryptionKey(encryptionMethod, keyFile string) ([]byte, error) {
 
 func readAesKey(filename string) ([]byte, error) {
 	if len(filename) == 0 {
-		return nil, errors.New("security.encryption-key-file is not set")
+		return nil, errors.New("security.encryption-key-path is not set")
 	}
 	key, err := os.ReadFile(filename)
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #754 

Problem Summary:
The replayer doesn't correctly set the encryption key

What is changed and how it works:
Set `replay.cfg.encryptionKey` instead of `cfg.encryptionKey`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Repeat the issue steps and replay succeeds

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
