### PR TITLE
backend, lex: use a simpler lexer to parse begin statements

### DIFF
--- a/pkg/proxy/backend/cmd_processor_exec.go
+++ b/pkg/proxy/backend/cmd_processor_exec.go
@@ -5,12 +5,11 @@ package backend
 
 import (
 	"encoding/binary"
-	"strings"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
-	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	"github.com/pingcap/tiproxy/pkg/util/lex"
 	"github.com/siddontang/go/hack"
 	"go.uber.org/zap"
 )
@@ -361,10 +360,5 @@ func (cp *CmdProcessor) needHoldRequest(request []byte) bool {
 		data = data[:len(data)-1]
 	}
 	query := hack.String(data)
-	return isBeginStmt(query)
-}
-
-func isBeginStmt(query string) bool {
-	normalized := parser.Normalize(query, "ON")
-	return strings.HasPrefix(normalized, "begin") || strings.HasPrefix(normalized, "start transaction")
+	return lex.IsStartTxn(query)
 }

--- a/pkg/proxy/backend/cmd_processor_test.go
+++ b/pkg/proxy/backend/cmd_processor_test.go
@@ -918,61 +918,6 @@ func TestHoldRequest(t *testing.T) {
 	}
 }
 
-func TestBeginStmt(t *testing.T) {
-	tests := []struct {
-		stmt    string
-		isBegin bool
-	}{
-		{
-			stmt:    "begin",
-			isBegin: true,
-		},
-		{
-			stmt:    "BEGIN",
-			isBegin: true,
-		},
-		{
-			stmt:    "begin optimistic as of timestamp now()",
-			isBegin: true,
-		},
-		{
-			stmt:    "    begin",
-			isBegin: true,
-		},
-		{
-			stmt:    "start transaction",
-			isBegin: true,
-		},
-		{
-			stmt:    "START transaction",
-			isBegin: true,
-		},
-		{
-			stmt:    "start transaction with consistent snapshot",
-			isBegin: true,
-		},
-		{
-			stmt:    "begin; select 1",
-			isBegin: true,
-		},
-		{
-			stmt:    "/*+ some_hint */begin",
-			isBegin: true,
-		},
-		{
-			stmt:    "commit",
-			isBegin: false,
-		},
-		{
-			stmt:    "select 1; begin",
-			isBegin: false,
-		},
-	}
-	for _, test := range tests {
-		require.Equal(t, test.isBegin, isBeginStmt(test.stmt), test.stmt)
-	}
-}
-
 // Test forwarding multi-statements works well.
 func TestMultiStmt(t *testing.T) {
 	tc := newTCPConnSuite(t)

--- a/pkg/util/lex/filter.go
+++ b/pkg/util/lex/filter.go
@@ -66,3 +66,12 @@ var readOnlyKeywords = [][]string{
 func IsReadOnly(sql string) bool {
 	return startsWithKeyword(sql, readOnlyKeywords)
 }
+
+var startTxnKeywords = [][]string{
+	{"START", "TRANSACTION"},
+	{"BEGIN"},
+}
+
+func IsStartTxn(sql string) bool {
+	return startsWithKeyword(sql, startTxnKeywords)
+}

--- a/pkg/util/lex/filter_test.go
+++ b/pkg/util/lex/filter_test.go
@@ -60,3 +60,58 @@ func TestReadOnlySQL(t *testing.T) {
 		require.Equal(t, test.readOnly, IsReadOnly(test.sql), test.sql)
 	}
 }
+
+func TestStartTxn(t *testing.T) {
+	tests := []struct {
+		stmt    string
+		isBegin bool
+	}{
+		{
+			stmt:    "begin",
+			isBegin: true,
+		},
+		{
+			stmt:    "BEGIN",
+			isBegin: true,
+		},
+		{
+			stmt:    "begin optimistic as of timestamp now()",
+			isBegin: true,
+		},
+		{
+			stmt:    "    begin",
+			isBegin: true,
+		},
+		{
+			stmt:    "start transaction",
+			isBegin: true,
+		},
+		{
+			stmt:    "START transaction",
+			isBegin: true,
+		},
+		{
+			stmt:    "start transaction with consistent snapshot",
+			isBegin: true,
+		},
+		{
+			stmt:    "begin; select 1",
+			isBegin: true,
+		},
+		{
+			stmt:    "/*+ some_hint */begin",
+			isBegin: true,
+		},
+		{
+			stmt:    "commit",
+			isBegin: false,
+		},
+		{
+			stmt:    "select 1; begin",
+			isBegin: false,
+		},
+	}
+	for _, test := range tests {
+		require.Equal(t, test.isBegin, IsStartTxn(test.stmt), test.stmt)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #732 

Problem Summary:
During session migration, TiProxy may need to parse a statement to see if it's a BEGIN statement. It's too heavy to use the TiDB parser because it parses the whole statement. We can just parse the first 2 tokens to see if it's BEGIN.

What is changed and how it works:
- Use `lex.IsStartTxn` to check if it's a start transaction statement

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
