### PR TITLE
observer: fix supportRedirection keeps false after updating the signing certs

### DIFF
--- a/pkg/balance/observer/health_check.go
+++ b/pkg/balance/observer/health_check.go
@@ -178,7 +178,5 @@ func (dhc *DefaultHealthCheck) queryConfig(ctx context.Context, info *BackendInf
 		dhc.logger.Error("unmarshal body in healthy check failed", zap.String("addr", addr), zap.String("resp body", string(resp)), zap.Error(err))
 		return
 	}
-	if len(respBody.Security.SessionTokenSigningCert) == 0 {
-		bh.SupportRedirection = false
-	}
+	bh.SupportRedirection = len(respBody.Security.SessionTokenSigningCert) > 0
 }

--- a/pkg/balance/observer/mock_test.go
+++ b/pkg/balance/observer/mock_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
 
@@ -130,7 +131,8 @@ func (handler *mockHttpHandler) setHasSigningCert(hasSigningCert bool) {
 	if hasSigningCert {
 		resp.Security.SessionTokenSigningCert = "/tmp"
 	}
-	b, _ := json.Marshal(resp)
+	b, err := json.Marshal(resp)
+	require.NoError(handler.t, err)
 	handler.config.Store(string(b))
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #769

Problem Summary:
The previous PR #770 fixes supportRedirection changes to false when it's down, but it introduces another problem: supportRedirection won't be updated to true when it's false initially.

What is changed and how it works:
Always explicitly set supportRedirection in the health check.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
