### PR TITLE
balance: fix the cpu factor may produce a negative score

### DIFF
--- a/pkg/balance/factor/backend.go
+++ b/pkg/balance/factor/backend.go
@@ -3,18 +3,23 @@
 
 package factor
 
-import "github.com/pingcap/tiproxy/pkg/balance/policy"
+import (
+	"github.com/pingcap/tiproxy/pkg/balance/policy"
+	"go.uber.org/zap"
+)
 
 type scoredBackend struct {
 	policy.BackendCtx
 	// The score composed by all factors. Each factor sets some bits of the score.
 	// The higher the score is, the more unhealthy / busy the backend is.
 	scoreBits uint64
+	lg        *zap.Logger
 }
 
-func newScoredBackend(backend policy.BackendCtx) scoredBackend {
+func newScoredBackend(backend policy.BackendCtx, lg *zap.Logger) scoredBackend {
 	return scoredBackend{
 		BackendCtx: backend,
+		lg:         lg,
 	}
 }
 
@@ -26,8 +31,10 @@ func (b *scoredBackend) prepareScore(bitNum int) {
 // addScore must be called after prepareScore.
 func (b *scoredBackend) addScore(score int, bitNum int) {
 	if score >= 1<<bitNum {
+		b.lg.Error("factor score overflows", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Int("bit_num", bitNum), zap.Stack("stack"))
 		score = 1<<bitNum - 1
 	} else if score < 0 {
+		b.lg.Error("factor score is negtive", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Stack("stack"))
 		score = 0
 	}
 	b.scoreBits += uint64(score)

--- a/pkg/balance/factor/backend.go
+++ b/pkg/balance/factor/backend.go
@@ -31,10 +31,10 @@ func (b *scoredBackend) prepareScore(bitNum int) {
 // addScore must be called after prepareScore.
 func (b *scoredBackend) addScore(score int, bitNum int) {
 	if score >= 1<<bitNum {
-		b.lg.Error("factor score overflows", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Int("bit_num", bitNum), zap.Stack("stack"))
+		b.lg.Warn("factor score overflows", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Int("bit_num", bitNum), zap.Stack("stack"))
 		score = 1<<bitNum - 1
 	} else if score < 0 {
-		b.lg.Error("factor score is negtive", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Stack("stack"))
+		b.lg.Warn("factor score is negtive", zap.String("backend", b.Addr()), zap.Int("score", score), zap.Stack("stack"))
 		score = 0
 	}
 	b.scoreBits += uint64(score)

--- a/pkg/balance/factor/backend.go
+++ b/pkg/balance/factor/backend.go
@@ -27,6 +27,8 @@ func (b *scoredBackend) prepareScore(bitNum int) {
 func (b *scoredBackend) addScore(score int, bitNum int) {
 	if score >= 1<<bitNum {
 		score = 1<<bitNum - 1
+	} else if score < 0 {
+		score = 0
 	}
 	b.scoreBits += uint64(score)
 }

--- a/pkg/balance/factor/backend_test.go
+++ b/pkg/balance/factor/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestAddScore(t *testing.T) {
@@ -34,9 +35,15 @@ func TestAddScore(t *testing.T) {
 			factorScores:  []int{1<<3 - 1, 1<<5 - 1},
 			expectedScore: (1<<3-1)<<5 + 1<<5 - 1,
 		},
+		{
+			scores:        []int{-1, -10},
+			bitNums:       []int{3, 5},
+			factorScores:  []int{0, 0},
+			expectedScore: 0,
+		},
 	}
 	for idx, test := range tests {
-		backend := newScoredBackend(nil)
+		backend := newScoredBackend(newMockBackend(true, 0), zap.NewNop())
 		for i := 0; i < len(test.scores); i++ {
 			backend.prepareScore(test.bitNums[i])
 			backend.addScore(test.scores[i], test.bitNums[i])

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -144,7 +144,7 @@ func (fbb *FactorBasedBalance) updateBitNum() error {
 func (fbb *FactorBasedBalance) updateScore(backends []policy.BackendCtx) []scoredBackend {
 	scoredBackends := fbb.cachedList[:0]
 	for _, backend := range backends {
-		scoredBackends = append(scoredBackends, newScoredBackend(backend))
+		scoredBackends = append(scoredBackends, newScoredBackend(backend, fbb.lg))
 	}
 	needUpdateMetric := false
 	now := time.Now()

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -211,7 +211,7 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			idlestBackend = backend
 		}
 		// Skip the backends without connections.
-		if score > maxScore && backend.ConnScore() > 0 {
+		if score > maxScore && backend.ConnScore() > 0 && backend.ConnCount() > 0 {
 			maxScore = score
 			busiestBackend = backend
 		}

--- a/pkg/balance/factor/factor_conn_test.go
+++ b/pkg/balance/factor/factor_conn_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestFactorConnCount(t *testing.T) {
@@ -30,11 +31,7 @@ func TestFactorConnCount(t *testing.T) {
 	}
 	backends := make([]scoredBackend, 0, len(tests))
 	for _, test := range tests {
-		backends = append(backends, scoredBackend{
-			BackendCtx: &mockBackend{
-				connScore: test.connScore,
-			},
-		})
+		backends = append(backends, newScoredBackend(newMockBackend(true, test.connScore), zap.NewNop()))
 	}
 	factor.UpdateScore(backends)
 	for i, test := range tests {

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -237,6 +237,8 @@ func (fc *FactorCPU) getUsage(backend scoredBackend) (avgUsage, latestUsage floa
 	latestUsage = snapshot.latestUsage + float64(backend.ConnScore()-snapshot.connCount)*fc.usagePerConn
 	if latestUsage > 1 {
 		latestUsage = 1
+	} else if latestUsage < 0 {
+		latestUsage = 0
 	}
 	return
 }

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -235,11 +235,7 @@ func (fc *FactorCPU) getUsage(backend scoredBackend) (avgUsage, latestUsage floa
 	}
 	avgUsage = snapshot.avgUsage
 	latestUsage = snapshot.latestUsage + float64(backend.ConnScore()-snapshot.connCount)*fc.usagePerConn
-	if latestUsage > 1 {
-		latestUsage = 1
-	} else if latestUsage < 0 {
-		latestUsage = 0
-	}
+	latestUsage = math.Max(math.Min(latestUsage, 1), 0)
 	return
 }
 

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -31,6 +31,7 @@ func newMockBackend(healthy bool, connScore int) *mockBackend {
 	return &mockBackend{
 		healthy:   healthy,
 		connScore: connScore,
+		connCount: connScore,
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #773

Problem Summary:
The CPU factor may produce a negative score, and `uint64(score)` overflows. The final score is wrong and the connections may fail to migrate.

What is changed and how it works:
- Check the score in the CPU factor
- Check the score in the scoredBackend

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix that TiProxy may be too slow to migrate connections when TiDB scales in 
```
