### PR TITLE
balance: route to a random backend when they have close scores

### DIFF
--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -194,7 +194,7 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 
 	leftBitNum := fbb.totalBitNum
 	// For each factor, if a backend is so busy that it should migrate connections to another, evict this backend.
-	// Always choosing the idlest one works bad for short connections because even a little jitter may cause all the connections
+	// Always choosing the idlest one works badly for short connections because even a little jitter may cause all the connections
 	// in the next second route to the same backend.
 	for _, factor := range fbb.factors {
 		bitNum := factor.ScoreBitNum()

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -109,7 +109,7 @@ func TestRouteWith2Factors(t *testing.T) {
 		{
 			scores1:  []int{10, 11, 11},
 			scores2:  []int{110, 101, 100},
-			idxRange: []int{1, 2},
+			idxRange: []int{0, 1, 2},
 		},
 		{
 			scores1:  []int{10, 20, 11},

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -114,7 +114,7 @@ func TestRouteWith2Factors(t *testing.T) {
 		{
 			scores1:  []int{10, 20, 11},
 			scores2:  []int{110, 0, 100},
-			idxRange: []int{2},
+			idxRange: []int{0, 2},
 		},
 	}
 	for tIdx, test := range tests {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #766

Problem Summary:
The current routing policy always chooses the backend with the lowest score, and it works well for long-lived connections. However, for short-lived connections (typically living for less than 1 second), it works badly.
For example, when a backend has little memory jitter (memory score = 1), all the connections in the next second won't be routed to this backend, which is too aggressive. In my testing, I also found that the CPU usage keeps jittering.

What is changed and how it works:
Use a conservative algorithm: do not route to the backend when it will migrate connections away. For example, if a backend's CPU usage is higher than 30% than another, do not route to it.
And for the rest of the backends, choose a random one.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

I've tested short connections, and it works much better.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix the bug that the CPU usage jitters too much in the short-lived connection workload.
```
