### PR TITLE
balance: use more conservative thresholds for health and memory factors

### DIFF
--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -79,11 +79,11 @@ func TestMemoryScore(t *testing.T) {
 			score:  2,
 		},
 		{
-			memory: []float64{0.55, math.NaN(), math.NaN(), 0.6},
+			memory: []float64{0.45, math.NaN(), math.NaN(), 0.6},
 			score:  1,
 		},
 		{
-			memory: []float64{0.55, 0.6, 0.55, 0.6},
+			memory: []float64{0.5, 0.6, 0.5, 0.6},
 			score:  1,
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #777

Problem Summary:
Currently, the thresholds for health and memory factors are tested under an empty workload, but this may introduce unnecessary connection jitters. In a typical workload, the PD health indicator may be up to 10000+, and the TiKV health indicator may be up to 5000+, which are far larger than the thresholds.

What is changed and how it works:
- Increase the indicator threshold for PD and TiKV
- Increase the balance time for health
- Decrease the threshold for time to OOM
- Increase the balance time for memory
- Remove duplicated memory risk level calculation

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test (endless)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Use more conservative thresholds for health and memory factors
```
