### PR TITLE
balance: fix panic in updating metrics

### DIFF
--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -255,7 +255,11 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 				updatedTime = ts
 			}
 			sample := fh.indicators[i].queryResult.GetSample4Backend(backend)
-			metrics.BackendMetricGauge.WithLabelValues(backend.Addr(), fh.indicators[i].key).Set(float64(sample.Value))
+			var float float64
+			if sample != nil {
+				float = float64(sample.Value)
+			}
+			metrics.BackendMetricGauge.WithLabelValues(backend.Addr(), fh.indicators[i].key).Set(float)
 			vr := calcValueRange(sample, fh.indicators[i])
 			if vr > valueRange {
 				valueRange = vr

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -174,7 +174,12 @@ func TestNoHealthMetrics(t *testing.T) {
 		updateTime time.Time
 	}{
 		{
-			errCounts: [][]float64{nil, nil},
+			errCounts:  [][]float64{nil, nil},
+			updateTime: time.Now(),
+		},
+		{
+			errCounts:  [][]float64{nil, {1, 1}},
+			updateTime: time.Now(),
 		},
 		{
 			errCounts:  [][]float64{{1, 1}, {0, 0}},

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/pingcap/tiproxy/pkg/metrics"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/model"
 	"go.uber.org/zap"
@@ -168,6 +169,7 @@ func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []
 			// If this backend is not updated, ignore it.
 			if !existsSnapshot || snapshot.updatedTime.Before(updateTime) {
 				latestUsage, timeToOOM := calcMemUsage(pairs)
+				metrics.BackendMetricGauge.WithLabelValues(addr, "memory").Set(latestUsage)
 				if latestUsage >= 0 {
 					riskLevel := getRiskLevel(latestUsage, timeToOOM)
 					balanceCount := fm.calcBalanceCount(backend, riskLevel, timeToOOM)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #789

Problem Summary:
- When updating BackendMetricGauge, the sample is nil and TiProxy panics
- BackendMetricGauge misses memory metric

What is changed and how it works:
- Check sample before updating the metric
- Add memory usage to BackendMetricGauge

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![image](https://github.com/user-attachments/assets/67e12934-0127-4ead-91e1-9ba25f599a8c)

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```