### PR TITLE
balance: fix connection migration may be slower and slower when TiDB shuts down

### DIFF
--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -240,9 +240,8 @@ func (fh *FactorHealth) UpdateScore(backends []scoredBackend) {
 	}
 }
 
-// - Not exist in the backends for a long time: delete it
-// - Metric is missing for a long time: delete it
-// - Metric is missing temporarily or missing in the backends temporarily: preserve the snapshot
+// - Not exist in the backends or metric is missing for a long time: delete it
+// - Metric is missing temporarily or not exist in the backends temporarily: preserve the snapshot
 // - Exist in the backends but the metric is not updated: perserve the snapshot
 // - Exist in the backends and metric is updated: update the snapshot
 func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -242,7 +242,7 @@ func (fh *FactorHealth) UpdateScore(backends []scoredBackend) {
 
 // - Not exist in the backends or metric is missing for a long time: delete it
 // - Metric is missing temporarily or not exist in the backends temporarily: preserve the snapshot
-// - Exist in the backends but the metric is not updated: perserve the snapshot
+// - Exist in the backends but the metric is not updated: preserve the snapshot
 // - Exist in the backends and metric is updated: update the snapshot
 func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 	now := time.Now()

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -155,9 +155,8 @@ func (fm *FactorMemory) UpdateScore(backends []scoredBackend) {
 	}
 }
 
-// - Not exist in the backends for a long time: delete it
-// - Metric is missing for a long time: delete it
-// - Metric is missing temporarily or missing in the backends temporarily: preserve the snapshot
+// - Not exist in the backends or metric is missing for a long time: delete it
+// - Metric is missing temporarily or not exist in the backends temporarily: preserve the snapshot
 // - Exist in the backends but the metric is not updated: perserve the snapshot
 // - Exist in the backends and metric is updated: update the snapshot
 func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []scoredBackend) {

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -157,7 +157,7 @@ func (fm *FactorMemory) UpdateScore(backends []scoredBackend) {
 
 // - Not exist in the backends or metric is missing for a long time: delete it
 // - Metric is missing temporarily or not exist in the backends temporarily: preserve the snapshot
-// - Exist in the backends but the metric is not updated: perserve the snapshot
+// - Exist in the backends but the metric is not updated: preserve the snapshot
 // - Exist in the backends and metric is updated: update the snapshot
 func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []scoredBackend) {
 	now := time.Now()

--- a/pkg/balance/factor/factor_status_test.go
+++ b/pkg/balance/factor/factor_status_test.go
@@ -85,3 +85,22 @@ func TestStatusBalanceCount(t *testing.T) {
 		require.Equal(t, test.count, count, "test idx: %d", i)
 	}
 }
+
+func TestMissBackendInStatus(t *testing.T) {
+	backends := []scoredBackend{createBackend(0, 0, 0), createBackend(1, 0, 0)}
+	unhealthyBackend := backends[0].BackendCtx.(*mockBackend)
+	unhealthyBackend.connScore = 100
+	unhealthyBackend.healthy = false
+
+	fs := NewFactorStatus(zap.NewNop())
+	fs.UpdateScore(backends)
+	count, _ := fs.BalanceCount(backends[0], backends[1])
+	require.Equal(t, 100/balanceSeconds4Status, count)
+
+	// Miss the first backend but the snapshot should be preserved.
+	fs.UpdateScore(backends[1:])
+	unhealthyBackend.connScore = 50
+	fs.UpdateScore(backends)
+	count, _ = fs.BalanceCount(backends[0], backends[1])
+	require.Equal(t, 100/balanceSeconds4Status, count)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #792 

Problem Summary:
When TiDB shuts down and new connections come in, the balance speed will be calculated each time because the balance speed is not preserved when the backend is missing.

What is changed and how it works:
For status, health, memory, and CPU factors, preserve the backend snapshot even when the backend is missing in updating scores.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. Create a workload to create both long and short connections
2. Scale in TiDB
3. The connections should be reserved and only one `update status risk` is printed

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
