### PR TITLE
balance: fix connection migration may stop when one TiDB is unhealthy

### DIFF
--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -191,6 +191,7 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 	// Always choosing the idlest one works badly for short connections because even a little jitter may cause all the connections
 	// in the next second route to the same backend.
 	idxes := make([]int, 0, len(scoredBackends))
+	idxes = append(idxes, 0)
 	for i := len(scoredBackends) - 1; i > 0; i-- {
 		leftBitNum := fbb.totalBitNum
 		var balanceCount float64

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -264,8 +264,8 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 					from, to = scoredBackends[i].BackendCtx, scoredBackends[0].BackendCtx
 					reason = factor.Name()
 					logFields = append(fields, zap.String("factor", reason),
-						zap.String("from_total_score", strconv.FormatUint(score1, 16)),
-						zap.String("to_total_score", strconv.FormatUint(score2, 16)),
+						zap.String("from_total_score", strconv.FormatUint(scoredBackends[i].scoreBits, 16)),
+						zap.String("to_total_score", strconv.FormatUint(scoredBackends[0].scoreBits, 16)),
 						zap.Uint64("from_factor_score", score1),
 						zap.Uint64("to_factor_score", score2),
 						zap.Float64("balance_count", balanceCount))

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -193,7 +193,8 @@ func TestBalanceWithOneFactor(t *testing.T) {
 func TestBalanceWith2Factors(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
-	factor1, factor2 := &mockFactor{bitNum: 1, balanceCount: 2}, &mockFactor{bitNum: 12, balanceCount: 1}
+	factor1 := &mockFactor{bitNum: 2, balanceCount: 2, threshold: 1}
+	factor2 := &mockFactor{bitNum: 12, balanceCount: 1}
 	fm.factors = []Factor{factor1, factor2}
 	require.NoError(t, fm.updateBitNum())
 
@@ -205,14 +206,14 @@ func TestBalanceWith2Factors(t *testing.T) {
 		count   int
 	}{
 		{
-			scores1: []int{1, 0, 0},
+			scores1: []int{2, 0, 0},
 			scores2: []int{0, 100, 200},
 			fromIdx: 0,
 			toIdx:   1,
 			count:   2,
 		},
 		{
-			scores1: []int{1, 1, 0},
+			scores1: []int{2, 2, 0},
 			scores2: []int{0, 100, 200},
 			fromIdx: 1,
 			toIdx:   2,
@@ -233,7 +234,7 @@ func TestBalanceWith2Factors(t *testing.T) {
 			count:   1,
 		},
 		{
-			scores1: []int{0, 1, 0},
+			scores1: []int{0, 2, 0},
 			scores2: []int{100, 0, 0},
 			fromIdx: 1,
 			toIdx:   2,
@@ -243,6 +244,13 @@ func TestBalanceWith2Factors(t *testing.T) {
 			scores1: []int{0, 0, 0},
 			scores2: []int{100, 100, 100},
 			count:   0,
+		},
+		{
+			scores1: []int{1, 0, 0},
+			scores2: []int{0, 100, 0},
+			fromIdx: 1,
+			toIdx:   2,
+			count:   1,
 		},
 	}
 	for tIdx, test := range tests {

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -238,7 +238,7 @@ func calcMemUsage(usageHistory []model.SamplePair) (latestUsage float64, timeToO
 			}
 			usageDiff := latestUsage - value
 			if usageDiff > 1e-4 {
-				timeToOOM = timeDiff * time.Duration((oomMemoryUsage-latestUsage)/usageDiff)
+				timeToOOM = time.Duration(float64(timeDiff) * (oomMemoryUsage - latestUsage) / usageDiff)
 			}
 			break
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #794

Problem Summary:
The rebalance algorithm only compares the busiest and idlest backends, but does not compare other backends. When one TiDB is unhealthy and is thought to be busiest, the second busiest will never be considered.

What is changed and how it works:
Sort the backends and iterate over all the backends until an unbalance is found.
Note that the routing algorithm still has a problem. It compares other backends with only the idlest one but ignores the unbalance among the busiest and the second idlest backend. For example, all the backends may be routed to, while the third one is better not.
1. CPU=0, location=1
2. CPU=1, location=0
3. CPU=1, location=1

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix the load balance may not work when one TiDB is unhealthy
```
