### PR TITLE
Reduce useless migrations based on connection count in short connection workload

### DIFF
--- a/pkg/balance/factor/factor_conn_test.go
+++ b/pkg/balance/factor/factor_conn_test.go
@@ -38,3 +38,59 @@ func TestFactorConnCount(t *testing.T) {
 		require.Equal(t, test.expectedScore, backends[i].score(), "test idx: %d", i)
 	}
 }
+
+func TestFactorConnSpeed(t *testing.T) {
+	tests := []struct {
+		score1      int
+		score2      int
+		targetRange [2]int
+	}{
+		{
+			score1:      120,
+			score2:      100,
+			targetRange: [2]int{100, 100},
+		},
+		{
+			score1:      150,
+			score2:      100,
+			targetRange: [2]int{110, 114},
+		},
+		{
+			score1:      10000,
+			score2:      0,
+			targetRange: [2]int{3500, 4550},
+		},
+	}
+
+	factor := NewFactorConnCount()
+	backend1 := newMockBackend(true, 0)
+	backend2 := newMockBackend(true, 0)
+	scoredBackend1 := newScoredBackend(backend1, zap.NewNop())
+	scoredBackend2 := newScoredBackend(backend2, zap.NewNop())
+	for i, test := range tests {
+		backend1.connScore = test.score1
+		backend2.connScore = test.score2
+		lastRedirectTime := 0
+		// Simulate rebalance for 5 minutes.
+		for j := 0; j < 30000; j++ {
+			balanceCount, _ := factor.BalanceCount(scoredBackend1, scoredBackend2)
+			if balanceCount < 0.0001 {
+				break
+			}
+			migrationInterval := 100 / balanceCount
+			count := 0
+			if migrationInterval < 2 {
+				count = int(1 / migrationInterval)
+			} else if float64(j-lastRedirectTime) >= migrationInterval {
+				count = 1
+			}
+			if count > 0 {
+				lastRedirectTime = j
+				backend1.connScore -= count
+				backend2.connScore += count
+			}
+		}
+		require.GreaterOrEqual(t, backend2.connScore, test.targetRange[0], "case id: %d", i)
+		require.LessOrEqual(t, backend2.connScore, test.targetRange[1], "case id: %d", i)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #801

Problem Summary:
When I start a workload with 1000 short connections per second on a 2 TiProxy + 3 TiDB cluster, the migrations are about 120 per minute, which is the upper limit of the speed, considering that the speed is limited to 1 per second on each TiProxy.
Actually, it's useless because the CPU-based factor can do the rebalance. Connection-count-based factor should be used only when CPU usage doesn't work.

What is changed and how it works:
The speed of connection-count-based migration should be based on the current connection count difference, not a constant.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Start the workload above, and the migration OPM is reduced to 8.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Reduce useless migrations based on connection count in short connection workload
```
