### PR TITLE
balance: never route to backends with a different label

### DIFF
--- a/pkg/balance/factor/factor.go
+++ b/pkg/balance/factor/factor.go
@@ -19,5 +19,7 @@ type Factor interface {
 	// 0 indicates the factor is already balanced.
 	BalanceCount(from, to scoredBackend) (float64, []zap.Field)
 	SetConfig(cfg *config.Config)
+	// CanBeRouted returns whether a connection can be routed or migrated to the backend with the score.
+	CanBeRouted(score uint64) bool
 	Close()
 }

--- a/pkg/balance/factor/factor_conn.go
+++ b/pkg/balance/factor/factor_conn.go
@@ -69,5 +69,9 @@ func (fcc *FactorConnCount) BalanceCount(from, to scoredBackend) (float64, []zap
 func (fcc *FactorConnCount) SetConfig(cfg *config.Config) {
 }
 
+func (fcc *FactorConnCount) CanBeRouted(_ uint64) bool {
+	return true
+}
+
 func (fcc *FactorConnCount) Close() {
 }

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -272,6 +272,10 @@ func (fc *FactorCPU) BalanceCount(from, to scoredBackend) (float64, []zap.Field)
 func (fc *FactorCPU) SetConfig(cfg *config.Config) {
 }
 
+func (fc *FactorCPU) CanBeRouted(_ uint64) bool {
+	return true
+}
+
 func (fc *FactorCPU) Close() {
 	fc.mr.RemoveQueryExpr(fc.Name())
 }

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -366,6 +366,10 @@ func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (float64, []zap.Fie
 func (fh *FactorHealth) SetConfig(cfg *config.Config) {
 }
 
+func (fh *FactorHealth) CanBeRouted(_ uint64) bool {
+	return true
+}
+
 func (fh *FactorHealth) Close() {
 	for _, indicator := range fh.indicators {
 		fh.mr.RemoveQueryExpr(indicator.key)

--- a/pkg/balance/factor/factor_label.go
+++ b/pkg/balance/factor/factor_label.go
@@ -63,5 +63,10 @@ func (fl *FactorLabel) SetConfig(cfg *config.Config) {
 	}
 }
 
+func (fl *FactorLabel) CanBeRouted(score uint64) bool {
+	// Label is used to isolate business resources. Never route to the backends of another business.
+	return score == 0
+}
+
 func (fl *FactorLabel) Close() {
 }

--- a/pkg/balance/factor/factor_location.go
+++ b/pkg/balance/factor/factor_location.go
@@ -53,5 +53,9 @@ func (fl *FactorLocation) BalanceCount(from, to scoredBackend) (float64, []zap.F
 func (fl *FactorLocation) SetConfig(cfg *config.Config) {
 }
 
+func (fl *FactorLocation) CanBeRouted(_ uint64) bool {
+	return true
+}
+
 func (fl *FactorLocation) Close() {
 }

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -288,6 +288,10 @@ func (fm *FactorMemory) BalanceCount(from, to scoredBackend) (float64, []zap.Fie
 func (fm *FactorMemory) SetConfig(cfg *config.Config) {
 }
 
+func (fm *FactorMemory) CanBeRouted(_ uint64) bool {
+	return true
+}
+
 func (fm *FactorMemory) Close() {
 	fm.mr.RemoveQueryExpr(fm.Name())
 }

--- a/pkg/balance/factor/factor_status.go
+++ b/pkg/balance/factor/factor_status.go
@@ -107,5 +107,9 @@ func (fs *FactorStatus) BalanceCount(from, to scoredBackend) (float64, []zap.Fie
 func (fs *FactorStatus) SetConfig(cfg *config.Config) {
 }
 
+func (fl *FactorStatus) CanBeRouted(score uint64) bool {
+	return score == 0
+}
+
 func (fs *FactorStatus) Close() {
 }

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -69,6 +69,7 @@ type mockFactor struct {
 	balanceCount float64
 	updateScore  func(backends []scoredBackend)
 	cfg          *config.Config
+	canBeRouted  bool
 }
 
 func (mf *mockFactor) Name() string {
@@ -99,6 +100,13 @@ func (mf *mockFactor) BalanceCount(from, to scoredBackend) (float64, []zap.Field
 
 func (mf *mockFactor) SetConfig(cfg *config.Config) {
 	mf.cfg = cfg
+}
+
+func (mf *mockFactor) CanBeRouted(score uint64) bool {
+	if mf.canBeRouted {
+		return true
+	}
+	return score == 0
 }
 
 func (mf *mockFactor) Close() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #804

Problem Summary:
Currently, status is at the highest priority, which means if all the TiDB instances of one business fail, the traffic will be routed to the TiDB of another business.
However, more surveys reveal that label is typically used for a hard limit. That is, the traffic of one business should NEVER affect another business.

What is changed and how it works:
- Place label in a higher priority than status
- If the idlest backend has a different label, do not route or rebalance

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [x] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Never route to backends with a different label
```
