### PR TITLE
router, backend: fix some migrations are skipped when some connections are closing

### DIFF
--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -78,6 +79,10 @@ func (conn *mockRedirectableConn) GetRedirectingAddr() string {
 
 func (conn *mockRedirectableConn) ConnectionID() uint64 {
 	return conn.connID
+}
+
+func (conn *mockRedirectableConn) ConnInfo() []zap.Field {
+	return nil
 }
 
 func (conn *mockRedirectableConn) getAddr() (string, string) {

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -10,6 +10,7 @@ import (
 	glist "github.com/bahlo/generic-list-go"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	"go.uber.org/zap"
 )
 
 var (
@@ -69,6 +70,7 @@ type RedirectableConn interface {
 	// Redirect returns false if the current conn is not redirectable.
 	Redirect(backend BackendInst) bool
 	ConnectionID() uint64
+	ConnInfo() []zap.Field
 }
 
 // BackendInst defines a backend that a connection is redirecting to.

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -375,41 +375,38 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 		}
 	}
 	// Migrate balanceCount connections.
-	for i := 0; i < count && ctx.Err() == nil; i++ {
-		var ce *glist.Element[*connWrapper]
-		for ele := fromBackend.connList.Front(); ele != nil; ele = ele.Next() {
-			conn := ele.Value
-			switch conn.phase {
-			case phaseRedirectNotify:
-				// A connection cannot be redirected again when it has not finished redirecting.
+	i := 0
+	for ele := fromBackend.connList.Front(); ele != nil && ctx.Err() == nil && i < count; ele = ele.Next() {
+		conn := ele.Value
+		switch conn.phase {
+		case phaseRedirectNotify:
+			// A connection cannot be redirected again when it has not finished redirecting.
+			continue
+		case phaseRedirectFail:
+			// If it failed recently, it will probably fail this time.
+			if conn.lastRedirect.Add(redirectFailMinInterval).After(curTime) {
 				continue
-			case phaseRedirectFail:
-				// If it failed recently, it will probably fail this time.
-				if conn.lastRedirect.Add(redirectFailMinInterval).After(curTime) {
-					continue
-				}
 			}
-			ce = ele
-			break
 		}
-		if ce == nil {
-			break
+		if router.redirectConn(conn, fromBackend, toBackend, reason, logFields, curTime) {
+			router.lastRedirectTime = curTime
+			i++
 		}
-		router.redirectConn(ce.Value, fromBackend, toBackend, reason, logFields, curTime)
-		router.lastRedirectTime = curTime
 	}
 }
 
 func (router *ScoreBasedRouter) redirectConn(conn *connWrapper, fromBackend *backendWrapper, toBackend *backendWrapper,
-	reason string, logFields []zap.Field, curTime time.Time) {
+	reason string, logFields []zap.Field, curTime time.Time) bool {
 	// Skip the connection if it's closing.
-	if conn.Redirect(toBackend) {
-		fields := []zap.Field{
-			zap.Uint64("connID", conn.ConnectionID()),
-			zap.String("from", fromBackend.addr),
-			zap.String("to", toBackend.addr),
-		}
-		fields = append(fields, logFields...)
+	fields := []zap.Field{
+		zap.Uint64("connID", conn.ConnectionID()),
+		zap.String("from", fromBackend.addr),
+		zap.String("to", toBackend.addr),
+	}
+	fields = append(fields, logFields...)
+	fields = append(fields, conn.ConnInfo()...)
+	succeed := conn.Redirect(toBackend)
+	if succeed {
 		router.logger.Debug("begin redirect connection", fields...)
 		fromBackend.connScore--
 		router.removeBackendIfEmpty(fromBackend)
@@ -420,8 +417,10 @@ func (router *ScoreBasedRouter) redirectConn(conn *connWrapper, fromBackend *bac
 	} else {
 		// Avoid it to be redirected again immediately.
 		conn.phase = phaseRedirectFail
+		router.logger.Debug("skip redirecting because it's closing", fields...)
 	}
 	conn.lastRedirect = curTime
+	return succeed
 }
 
 func (router *ScoreBasedRouter) removeBackendIfEmpty(backend *backendWrapper) bool {

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -936,6 +936,17 @@ func TestRedirectFail(t *testing.T) {
 	// If the connection refuses to redirect, the connScore should not change.
 	require.Equal(t, 1, tester.getBackendByIndex(0).connScore)
 	require.Equal(t, 0, tester.getBackendByIndex(1).connScore)
+
+	tester = newRouterTester(t, nil)
+	tester.addBackends(1)
+	tester.addConnections(2)
+	tester.conns[1].closing = true
+	tester.killBackends(1)
+	tester.addBackends(1)
+	tester.rebalance(1)
+	// Even if the first connection refuses to redirect, the second one should be redirected.
+	require.Equal(t, 1, tester.getBackendByIndex(0).connScore)
+	require.Equal(t, 1, tester.getBackendByIndex(1).connScore)
 }
 
 func TestSkipRedirection(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #812

Problem Summary:
When some connections are closing and refuse to migrate, the rebalance may skip this round. The final result is, the migration may be slower than expected.

What is changed and how it works:
- If a connection refuses to migrate, continue to the next one
- Add some debug logs for migration

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix connection migrations may be slower than expected
```
