### PR TITLE
router: avoid deadlock in rebalance

### DIFF
--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -404,7 +404,6 @@ func (router *ScoreBasedRouter) redirectConn(conn *connWrapper, fromBackend *bac
 		zap.String("to", toBackend.addr),
 	}
 	fields = append(fields, logFields...)
-	fields = append(fields, conn.ConnInfo()...)
 	succeed := conn.Redirect(toBackend)
 	if succeed {
 		router.logger.Debug("begin redirect connection", fields...)

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -844,6 +844,7 @@ func (mgr *BackendConnManager) UpdateLogger(fields ...zap.Field) {
 }
 
 // ConnInfo returns detailed info of the connection, which should not be logged too many times.
+// Be careful about deadlocks.
 func (mgr *BackendConnManager) ConnInfo() []zap.Field {
 	mgr.processLock.Lock()
 	var fields []zap.Field


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #816

Problem Summary:
`BackendConnMgr.ConnInfo()` holds a lock, and the caller `ScoreBasedRouter.redirectConn()` holds another lock. This could lead to deadlocks.

What is changed and how it works:
Do not call `BackendConnMgr.ConnInfo()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Create a workload and check the rebalance.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
