### PR TITLE
factor, router: routing fails when there's only one backend with a different label

### DIFF
--- a/pkg/balance/factor/factor_label.go
+++ b/pkg/balance/factor/factor_label.go
@@ -35,7 +35,8 @@ func (fl *FactorLabel) Name() string {
 }
 
 func (fl *FactorLabel) UpdateScore(backends []scoredBackend) {
-	if len(fl.labelName) == 0 || len(fl.selfLabelVal) == 0 || len(backends) <= 1 {
+	// The score will be used for CanBeRouted so don't skip updating even when only one backend.
+	if len(fl.labelName) == 0 || len(fl.selfLabelVal) == 0 {
 		return
 	}
 	for i := 0; i < len(backends); i++ {
@@ -53,7 +54,12 @@ func (fl *FactorLabel) ScoreBitNum() int {
 }
 
 func (fl *FactorLabel) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
-	return balanceCount4Label, nil
+	fields := []zap.Field{
+		zap.String("label_key", fl.labelName),
+		zap.Any("from_labels", from.GetBackendInfo().Labels),
+		zap.String("self_label_value", fl.selfLabelVal),
+	}
+	return balanceCount4Label, fields
 }
 
 func (fl *FactorLabel) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_label_test.go
+++ b/pkg/balance/factor/factor_label_test.go
@@ -53,11 +53,7 @@ func TestFactorLabelOneBackend(t *testing.T) {
 		backendCtx := &mockBackend{
 			BackendInfo: observer.BackendInfo{Labels: backendLabels},
 		}
-		// Create 2 backends so that UpdateScore won't skip calculating scores.
 		backends := []scoredBackend{
-			{
-				BackendCtx: backendCtx,
-			},
 			{
 				BackendCtx: backendCtx,
 			},
@@ -75,6 +71,7 @@ func TestFactorLabelOneBackend(t *testing.T) {
 		factor.UpdateScore(backends)
 		for _, backend := range backends {
 			require.Equal(t, test.expectedScore, backend.score(), "test idx: %d", i)
+			require.Equal(t, test.expectedScore == 0, factor.CanBeRouted(backend.score()), "test idx: %d", i)
 		}
 	}
 }
@@ -133,5 +130,6 @@ func TestFactorLabelMultiBackends(t *testing.T) {
 	factor.UpdateScore(backends)
 	for i, test := range tests {
 		require.Equal(t, test.expectedScore, backends[i].score(), "test idx: %d", i)
+		require.Equal(t, test.expectedScore == 0, factor.CanBeRouted(backends[i].score()), "test idx: %d", i)
 	}
 }

--- a/pkg/balance/observer/backend_health_test.go
+++ b/pkg/balance/observer/backend_health_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package observer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendHealthToString(t *testing.T) {
+	tests := []BackendHealth{
+		{},
+		{
+			BackendInfo: BackendInfo{
+				IP:         "127.0.0.1",
+				StatusPort: 1,
+				Labels:     map[string]string{"k1": "v1", "k2": "v2"},
+			},
+			Healthy:            true,
+			PingErr:            errors.New("mock error"),
+			ServerVersion:      "v1.0.0",
+			SupportRedirection: true,
+			Local:              true,
+		},
+	}
+	// Just test no error happens
+	for _, test := range tests {
+		_ = test.String()
+	}
+}
+
+func TestBackendHealthEquals(t *testing.T) {
+	tests := []struct {
+		a, b  BackendHealth
+		equal bool
+	}{
+		{
+			a:     BackendHealth{},
+			b:     BackendHealth{},
+			equal: true,
+		},
+		{
+			a: BackendHealth{
+				BackendInfo: BackendInfo{
+					IP:         "127.0.0.1",
+					StatusPort: 1,
+					Labels:     map[string]string{"k1": "v1", "k2": "v2"},
+				},
+			},
+			b: BackendHealth{
+				BackendInfo: BackendInfo{
+					IP:         "127.0.0.1",
+					StatusPort: 1,
+				},
+			},
+			equal: false,
+		},
+		{
+			a: BackendHealth{
+				BackendInfo: BackendInfo{
+					IP:         "127.0.0.1",
+					StatusPort: 1,
+					Labels:     map[string]string{"k1": "v1", "k2": "v2"},
+				},
+			},
+			b: BackendHealth{
+				BackendInfo: BackendInfo{
+					IP:         "127.0.0.1",
+					StatusPort: 1,
+					Labels:     map[string]string{"k1": "v1", "k2": "v2"},
+				},
+			},
+			equal: true,
+		},
+		{
+			a: BackendHealth{
+				BackendInfo: BackendInfo{
+					IP:         "127.0.0.1",
+					StatusPort: 1,
+					Labels:     map[string]string{"k1": "v1", "k2": "v2"},
+				},
+				Healthy:            true,
+				PingErr:            errors.New("mock error"),
+				ServerVersion:      "v1.0.0",
+				SupportRedirection: true,
+				Local:              true,
+			},
+			b:     BackendHealth{},
+			equal: false,
+		},
+		{
+			a: BackendHealth{
+				ServerVersion: "v1.0.0",
+			},
+			b: BackendHealth{
+				ServerVersion: "v1.1.0",
+			},
+			equal: false,
+		},
+		{
+			a: BackendHealth{
+				SupportRedirection: true,
+			},
+			b: BackendHealth{
+				SupportRedirection: false,
+			},
+			equal: false,
+		},
+	}
+	// Just test no error happens
+	for i, test := range tests {
+		require.True(t, test.a.Equals(test.a), "test %d", i)
+		require.True(t, test.b.Equals(test.b), "test %d", i)
+		require.Equal(t, test.equal, test.a.Equals(test.b), "test %d", i)
+		require.Equal(t, test.equal, test.b.Equals(test.a), "test %d", i)
+	}
+}

--- a/pkg/balance/observer/backend_observer.go
+++ b/pkg/balance/observer/backend_observer.go
@@ -5,6 +5,7 @@ package observer
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -195,14 +196,13 @@ func (bo *DefaultBackendObserver) updateHealthResult(result HealthResult) {
 			continue
 		}
 		if oldHealth, ok := bo.curBackends[addr]; !ok || !oldHealth.Healthy {
-			prev := "none"
-			if oldHealth != nil {
-				prev = oldHealth.String()
-			}
-			bo.logger.Info("update backend", zap.String("backend_addr", addr),
-				zap.String("prev", prev), zap.String("cur", newHealth.String()))
+			bo.logger.Info("update backend", zap.String("addr", addr), zap.Stringer("prev", oldHealth), zap.Stringer("cur", newHealth),
+				zap.Int("total", len(bo.curBackends)))
 			updateBackendStatusMetrics(addr, true)
 			delete(bo.downBackends, addr)
+		} else if ok && !maps.Equal(oldHealth.Labels, newHealth.Labels) {
+			bo.logger.Info("update backend labels", zap.String("addr", addr),
+				zap.Any("prev", oldHealth.Labels), zap.Any("cur", newHealth.Labels))
 		}
 	}
 	for addr, oldHealth := range bo.curBackends {
@@ -210,12 +210,8 @@ func (bo *DefaultBackendObserver) updateHealthResult(result HealthResult) {
 			continue
 		}
 		if newHealth, ok := result.backends[addr]; !ok || !newHealth.Healthy {
-			cur := "not in list"
-			if newHealth != nil {
-				cur = newHealth.String()
-			}
-			bo.logger.Info("update backend", zap.String("backend_addr", addr),
-				zap.String("prev", oldHealth.String()), zap.String("cur", cur))
+			bo.logger.Info("update backend", zap.String("addr", addr), zap.Stringer("prev", oldHealth), zap.Stringer("cur", newHealth),
+				zap.Int("total", len(bo.curBackends)))
 			updateBackendStatusMetrics(addr, false)
 			bo.downBackends[addr] = time.Now()
 		}

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -110,6 +110,13 @@ func (b *backendWrapper) setHealth(health observer.BackendHealth) {
 	b.mu.Unlock()
 }
 
+func (b *backendWrapper) getHealth() observer.BackendHealth {
+	b.mu.RLock()
+	health := b.mu.BackendHealth
+	b.mu.RUnlock()
+	return health
+}
+
 func (b *backendWrapper) ConnScore() int {
 	return b.connScore
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #819

Problem Summary:
When there's only one backend and it has a different label with TiProxy, the backend should not be routed to.

What is changed and how it works:
- Don't skip setting the label score when there's only one backend
- Add debug logs about labels

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Steps to test debug logs:
1. Start a cluster.
2. Set labels to TiProxy and TiDB.
3. Check the debug logs.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
