### PR TITLE
balance: fix connection is repeatedly migrated by CPU and location

### DIFF
--- a/pkg/balance/factor/factor.go
+++ b/pkg/balance/factor/factor.go
@@ -8,6 +8,17 @@ import (
 	"go.uber.org/zap"
 )
 
+type BalanceAdvice int
+
+const (
+	// AdviceNeutral indicates skipping this factor and continue to the next factor.
+	AdviceNeutral BalanceAdvice = iota
+	// AdviceNegtive indicates don't balance these 2 backends, even for the rest factors.
+	AdviceNegtive
+	// AdvicePositive indicates balancing these 2 backends now.
+	AdvicePositive
+)
+
 type Factor interface {
 	// Name returns the name of the factor.
 	Name() string
@@ -17,7 +28,7 @@ type Factor interface {
 	ScoreBitNum() int
 	// BalanceCount returns the count of connections to balance per second.
 	// 0 indicates the factor is already balanced.
-	BalanceCount(from, to scoredBackend) (float64, []zap.Field)
+	BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field)
 	SetConfig(cfg *config.Config)
 	// CanBeRouted returns whether a connection can be routed or migrated to the backend with the score.
 	CanBeRouted(score uint64) bool

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -213,7 +213,9 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 			score2 := scoredBackends[0].scoreBits << (maxBitNum - leftBitNum) >> (maxBitNum - bitNum)
 			if score1 > score2 {
 				var balanceFields []zap.Field
-				if balanceCount, balanceFields = factor.BalanceCount(scoredBackends[i], scoredBackends[0]); balanceCount > 0.0001 {
+				var advice BalanceAdvice
+				advice, balanceCount, balanceFields = factor.BalanceCount(scoredBackends[i], scoredBackends[0])
+				if advice == AdvicePositive && balanceCount > 0.0001 {
 					// This backend is too busy. If it's routed, migration may happen.
 					fields = append(fields, zap.String(scoredBackends[i].Addr(), factor.Name()))
 					fields = append(fields, balanceFields...)
@@ -274,20 +276,28 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			score1 := scoredBackends[i].scoreBits << (maxBitNum - leftBitNum) >> (maxBitNum - bitNum)
 			score2 := scoredBackends[0].scoreBits << (maxBitNum - leftBitNum) >> (maxBitNum - bitNum)
 			if score1 > score2 {
-				// The previous factors are ordered, so this factor won't violate them.
-				// E.g. the factor scores of 2 backends are [1, 1], [0, 0]
-				// Balancing the second factor won't make the first factor unbalanced.
+				// The factors with higher priorities are ordered, so this factor shouldn't violate them.
+				// E.g. if the CPU usage of A is higher than B, don't migrate from B to A even if A is preferred in location.
 				var fields []zap.Field
-				if balanceCount, fields = factor.BalanceCount(scoredBackends[i], scoredBackends[0]); balanceCount > 0.0001 {
-					from, to = scoredBackends[i].BackendCtx, scoredBackends[0].BackendCtx
-					reason = factor.Name()
-					logFields = append(fields, zap.String("factor", reason),
-						zap.String("from_total_score", strconv.FormatUint(scoredBackends[i].scoreBits, 16)),
-						zap.String("to_total_score", strconv.FormatUint(scoredBackends[0].scoreBits, 16)),
-						zap.Uint64("from_factor_score", score1),
-						zap.Uint64("to_factor_score", score2),
-						zap.Float64("balance_count", balanceCount))
-					return
+				var advice BalanceAdvice
+				advice, balanceCount, fields = factor.BalanceCount(scoredBackends[i], scoredBackends[0])
+				if advice == AdviceNegtive {
+					// If the factor will be unbalanced after migration, skip the rest factors.
+					// E.g. if the CPU usage of A will be much higher than B after migration,
+					// don't migrate from B to A even if A is preferred in location.
+					break
+				} else if advice == AdvicePositive {
+					if balanceCount > 0.0001 {
+						from, to = scoredBackends[i].BackendCtx, scoredBackends[0].BackendCtx
+						reason = factor.Name()
+						logFields = append(fields, zap.String("factor", reason),
+							zap.String("from_total_score", strconv.FormatUint(scoredBackends[i].scoreBits, 16)),
+							zap.String("to_total_score", strconv.FormatUint(scoredBackends[0].scoreBits, 16)),
+							zap.Uint64("from_factor_score", score1),
+							zap.Uint64("to_factor_score", score2),
+							zap.Float64("balance_count", balanceCount))
+						return
+					}
 				}
 			} else if score1 < score2 {
 				// Stop it once a factor is in the opposite order, otherwise a subsequent factor may violate this one.

--- a/pkg/balance/factor/factor_conn.go
+++ b/pkg/balance/factor/factor_conn.go
@@ -54,16 +54,16 @@ func (fcc *FactorConnCount) ScoreBitNum() int {
 	return fcc.bitNum
 }
 
-func (fcc *FactorConnCount) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
+func (fcc *FactorConnCount) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	if float64(from.ConnScore()) <= float64(to.ConnScore()+1)*connBalancedRatio {
-		return 0, nil
+		return AdviceNeutral, 0, nil
 	}
 	targetTo := float64(from.ConnScore()+to.ConnScore()+1) / (1 + connBalancedRatio)
 	count := (targetTo - float64(to.ConnScore()+1)) / balanceSeconds4Conn
 	if count < 0 {
 		count = 0
 	}
-	return count, nil
+	return AdvicePositive, count, nil
 }
 
 func (fcc *FactorConnCount) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_conn_test.go
+++ b/pkg/balance/factor/factor_conn_test.go
@@ -73,8 +73,8 @@ func TestFactorConnSpeed(t *testing.T) {
 		lastRedirectTime := 0
 		// Simulate rebalance for 5 minutes.
 		for j := 0; j < 30000; j++ {
-			balanceCount, _ := factor.BalanceCount(scoredBackend1, scoredBackend2)
-			if balanceCount < 0.0001 {
+			advice, balanceCount, _ := factor.BalanceCount(scoredBackend1, scoredBackend2)
+			if advice != AdvicePositive || balanceCount < 0.0001 {
 				break
 			}
 			migrationInterval := 100 / balanceCount

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -349,18 +349,18 @@ func (fh *FactorHealth) ScoreBitNum() int {
 	return fh.bitNum
 }
 
-func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
+func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	// Only migrate connections when one is valueRangeNormal and the other is valueRangeAbnormal.
 	fromScore := fh.caclErrScore(from.Addr())
 	toScore := fh.caclErrScore(to.Addr())
 	if fromScore-toScore <= 1 {
-		return 0, nil
+		return AdviceNeutral, 0, nil
 	}
 	snapshot := fh.snapshot[from.Addr()]
 	fields := []zap.Field{
 		zap.String("indicator", snapshot.indicator),
 		zap.Int("value", snapshot.value)}
-	return snapshot.balanceCount, fields
+	return AdvicePositive, snapshot.balanceCount, fields
 }
 
 func (fh *FactorHealth) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -163,7 +163,8 @@ func TestHealthBalance(t *testing.T) {
 			return backends[i].score() < backends[j].score()
 		})
 		from, to := backends[len(backends)-1], backends[0]
-		balanceCount, _ := fh.BalanceCount(from, to)
+		advice, balanceCount, _ := fh.BalanceCount(from, to)
+		require.Equal(t, test.balanced, advice == AdviceNeutral, "test index %d", i)
 		require.Equal(t, test.balanced, balanceCount < 0.0001, "test index %d", i)
 	}
 }
@@ -286,7 +287,8 @@ func TestHealthBalanceCount(t *testing.T) {
 		if test.count == 0 {
 			continue
 		}
-		count, _ := fh.BalanceCount(backends[0], backends[1])
+		advice, count, _ := fh.BalanceCount(backends[0], backends[1])
+		require.Equal(t, AdvicePositive, advice)
 		require.Equal(t, test.count, count, "test idx: %d", i)
 	}
 }
@@ -373,7 +375,8 @@ func TestMissBackendInHealth(t *testing.T) {
 		Value:      model.Vector(values),
 	}
 	fh.UpdateScore(backends)
-	count, _ := fh.BalanceCount(backends[0], backends[1])
+	advice, count, _ := fh.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4Health, count)
 
 	// Miss the first backend but the snapshot should be preserved.
@@ -381,6 +384,7 @@ func TestMissBackendInHealth(t *testing.T) {
 	unhealthyBackend := backends[0].BackendCtx.(*mockBackend)
 	unhealthyBackend.connScore = 50
 	fh.UpdateScore(backends)
-	count, _ = fh.BalanceCount(backends[0], backends[1])
+	advice, count, _ = fh.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4Health, count)
 }

--- a/pkg/balance/factor/factor_label.go
+++ b/pkg/balance/factor/factor_label.go
@@ -53,13 +53,13 @@ func (fl *FactorLabel) ScoreBitNum() int {
 	return fl.bitNum
 }
 
-func (fl *FactorLabel) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
+func (fl *FactorLabel) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	fields := []zap.Field{
 		zap.String("label_key", fl.labelName),
 		zap.Any("from_labels", from.GetBackendInfo().Labels),
 		zap.String("self_label_value", fl.selfLabelVal),
 	}
-	return balanceCount4Label, fields
+	return AdvicePositive, balanceCount4Label, fields
 }
 
 func (fl *FactorLabel) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_location.go
+++ b/pkg/balance/factor/factor_location.go
@@ -13,7 +13,7 @@ const (
 	balanceCount4Location = 1
 )
 
-var _ Factor = (*FactorLabel)(nil)
+var _ Factor = (*FactorLocation)(nil)
 
 type FactorLocation struct {
 	bitNum int
@@ -46,8 +46,8 @@ func (fl *FactorLocation) ScoreBitNum() int {
 	return fl.bitNum
 }
 
-func (fl *FactorLocation) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
-	return balanceCount4Location, nil
+func (fl *FactorLocation) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
+	return AdvicePositive, balanceCount4Location, nil
 }
 
 func (fl *FactorLocation) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -26,7 +26,7 @@ const (
 	balanceSeconds4OOMRisk = 10.0
 )
 
-var _ Factor = (*FactorCPU)(nil)
+var _ Factor = (*FactorMemory)(nil)
 
 var (
 	memQueryExpr = metricsreader.QueryExpr{
@@ -268,21 +268,21 @@ func (fm *FactorMemory) ScoreBitNum() int {
 	return fm.bitNum
 }
 
-func (fm *FactorMemory) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
+func (fm *FactorMemory) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	// The risk level may change frequently, e.g. last time timeToOOM was 30s and connections were migrated away,
 	// then this time it becomes 60s and the connections are migrated back.
 	// So we only rebalance when the difference of risk levels of 2 backends is big enough.
 	fromSnapshot := fm.snapshot[from.Addr()]
 	toSnapshot := fm.snapshot[to.Addr()]
 	if fromSnapshot.riskLevel-toSnapshot.riskLevel <= 1 {
-		return 0, nil
+		return AdviceNeutral, 0, nil
 	}
 	fields := []zap.Field{
 		zap.Duration("from_time_to_oom", fromSnapshot.timeToOOM),
 		zap.Float64("from_mem_usage", fromSnapshot.memUsage),
 		zap.Duration("to_time_to_oom", toSnapshot.timeToOOM),
 		zap.Float64("to_mem_usage", toSnapshot.memUsage)}
-	return fromSnapshot.balanceCount, fields
+	return AdvicePositive, fromSnapshot.balanceCount, fields
 }
 
 func (fm *FactorMemory) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -225,7 +225,8 @@ func TestMemoryBalance(t *testing.T) {
 			return backends[i].score() < backends[j].score()
 		})
 		from, to := backends[len(backends)-1], backends[0]
-		balanceCount, _ := fm.BalanceCount(from, to)
+		advice, balanceCount, _ := fm.BalanceCount(from, to)
+		require.Equal(t, test.balanced, advice == AdviceNeutral)
 		require.EqualValues(t, test.balanced, balanceCount < 0.0001, "test index %d", i)
 	}
 }
@@ -344,7 +345,8 @@ func TestMemoryBalanceCount(t *testing.T) {
 		if test.riskLevel == 0 {
 			continue
 		}
-		count, _ := fs.BalanceCount(backends[0], backends[1])
+		advice, count, _ := fs.BalanceCount(backends[0], backends[1])
+		require.Equal(t, AdvicePositive, advice)
 		require.Equal(t, test.count, count, "test idx: %d", i)
 	}
 }
@@ -401,7 +403,8 @@ func TestMissBackendInMemory(t *testing.T) {
 		Value:      model.Matrix(values),
 	}
 	fm.UpdateScore(backends)
-	count, _ := fm.BalanceCount(backends[0], backends[1])
+	advice, count, _ := fm.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4HighMemory, count)
 
 	// Miss the first backend but the snapshot should be preserved.
@@ -409,6 +412,7 @@ func TestMissBackendInMemory(t *testing.T) {
 	unhealthyBackend := backends[0].BackendCtx.(*mockBackend)
 	unhealthyBackend.connScore = 50
 	fm.UpdateScore(backends)
-	count, _ = fm.BalanceCount(backends[0], backends[1])
+	advice, count, _ = fm.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4HighMemory, count)
 }

--- a/pkg/balance/factor/factor_status.go
+++ b/pkg/balance/factor/factor_status.go
@@ -100,8 +100,8 @@ func (fs *FactorStatus) ScoreBitNum() int {
 	return fs.bitNum
 }
 
-func (fs *FactorStatus) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
-	return fs.snapshot[from.Addr()].balanceCount, nil
+func (fs *FactorStatus) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
+	return AdvicePositive, fs.snapshot[from.Addr()].balanceCount, nil
 }
 
 func (fs *FactorStatus) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_status_test.go
+++ b/pkg/balance/factor/factor_status_test.go
@@ -81,7 +81,8 @@ func TestStatusBalanceCount(t *testing.T) {
 		if test.count == 0 {
 			continue
 		}
-		count, _ := fs.BalanceCount(backends[0], backends[1])
+		advice, count, _ := fs.BalanceCount(backends[0], backends[1])
+		require.Equal(t, AdvicePositive, advice, "test idx: %d", i)
 		require.Equal(t, test.count, count, "test idx: %d", i)
 	}
 }
@@ -94,13 +95,15 @@ func TestMissBackendInStatus(t *testing.T) {
 
 	fs := NewFactorStatus(zap.NewNop())
 	fs.UpdateScore(backends)
-	count, _ := fs.BalanceCount(backends[0], backends[1])
+	advice, count, _ := fs.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4Status, count)
 
 	// Miss the first backend but the snapshot should be preserved.
 	fs.UpdateScore(backends[1:])
 	unhealthyBackend.connScore = 50
 	fs.UpdateScore(backends)
-	count, _ = fs.BalanceCount(backends[0], backends[1])
+	advice, count, _ = fs.BalanceCount(backends[0], backends[1])
+	require.Equal(t, AdvicePositive, advice)
 	require.Equal(t, 100/balanceSeconds4Status, count)
 }

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -69,6 +69,7 @@ type mockFactor struct {
 	balanceCount float64
 	updateScore  func(backends []scoredBackend)
 	cfg          *config.Config
+	advice       BalanceAdvice
 	canBeRouted  bool
 }
 
@@ -90,12 +91,15 @@ func (mf *mockFactor) ScoreBitNum() int {
 	return mf.bitNum
 }
 
-func (mf *mockFactor) BalanceCount(from, to scoredBackend) (float64, []zap.Field) {
+func (mf *mockFactor) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	fromScore, toScore := mf.scores[from.Addr()], mf.scores[to.Addr()]
-	if fromScore-toScore > mf.threshold {
-		return mf.balanceCount, nil
+	if mf.advice == AdviceNegtive {
+		return AdviceNegtive, 0, nil
 	}
-	return 0, nil
+	if fromScore-toScore > mf.threshold {
+		return AdvicePositive, mf.balanceCount, nil
+	}
+	return AdviceNeutral, 0, nil
 }
 
 func (mf *mockFactor) SetConfig(cfg *config.Config) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #822

Problem Summary:
When there are few connections but CPU usage is high, one connection may be migrated by CPU and then migrated by location back.

What is changed and how it works:
If the CPU will be unbalanced after migration, do not migrate by location.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix connection is repeatedly migrated by CPU and location
```
