### PR TITLE
balance: fix TiDB regionMiss backoff causes TiProxy to incorrectly migrate connections

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -101,7 +101,7 @@ graceful-close-conn-timeout = 15
 	# server object
 	[security.server-tls]
 	# proxy SQL port will use this
-	# auto-certs = true
+	auto-certs = true
 
 	# server object
 	[security.server-http-tls]

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -101,7 +101,7 @@ graceful-close-conn-timeout = 15
 	# server object
 	[security.server-tls]
 	# proxy SQL port will use this
-	auto-certs = true
+	# auto-certs = true
 
 	# server object
 	[security.server-http-tls]

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -265,6 +265,13 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 	// Even if the busiest backend can not migrate to the idlest one, the second busiest one may migrate.
 	// E.g. the factor scores of 3 backends are [1, 0], [0, 100], [0, 0].
 	// The first one is the busiest but not busy enough to migrate to the third one, but the second one is.
+	var logFactor string
+	var logAdvice int
+	defer func() {
+		if balanceCount > 0 && (from == nil || to == nil) {
+			fbb.lg.Debug("wrong count", zap.String("factor", logFactor), zap.Int("advice", logAdvice), zap.Float64("balance_count", balanceCount))
+		}
+	}()
 	for i := len(scoredBackends) - 1; i > 0; i-- {
 		// Skip the backends without connections.
 		if scoredBackends[i].ConnCount() <= 0 || scoredBackends[i].ConnScore() <= 0 {
@@ -279,10 +286,11 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			if score1 >= score2 {
 				// The factors with higher priorities are ordered, so this factor shouldn't violate them.
 				// E.g. if the CPU usage of A is higher than B, don't migrate from B to A even if A is preferred in location.
-				advice, count, fields := factor.BalanceCount(scoredBackends[i], scoredBackends[0])
-				if count > 0 && !(score1 > score2 && advice == AdvicePositive) {
-					fbb.lg.Debug("maybe error", zap.String("factor", factor.Name()), zap.Int("advice", int(advice)), zap.Float64("count", count))
-				}
+				var advice BalanceAdvice
+				var fields []zap.Field
+				advice, balanceCount, fields = factor.BalanceCount(scoredBackends[i], scoredBackends[0])
+				logFactor = factor.Name()
+				logAdvice = int(advice)
 				if advice == AdviceNegtive {
 					// If the factor will be unbalanced after migration, skip the rest factors.
 					// E.g. if the CPU usage of A will be much higher than B after migration,
@@ -290,9 +298,8 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 					break
 				}
 				logFields = append(logFields, fields...)
-				if score1 > score2 && advice == AdvicePositive && count > 0.0001 {
+				if score1 > score2 && advice == AdvicePositive && balanceCount > 0.0001 {
 					from, to = scoredBackends[i].BackendCtx, scoredBackends[0].BackendCtx
-					balanceCount = count
 					reason = factor.Name()
 					logFields = append(logFields, zap.String("factor", reason),
 						zap.String("from_total_score", strconv.FormatUint(scoredBackends[i].scoreBits, 16)),

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -279,9 +279,10 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 			if score1 >= score2 {
 				// The factors with higher priorities are ordered, so this factor shouldn't violate them.
 				// E.g. if the CPU usage of A is higher than B, don't migrate from B to A even if A is preferred in location.
-				var advice BalanceAdvice
-				var fields []zap.Field
-				advice, balanceCount, fields = factor.BalanceCount(scoredBackends[i], scoredBackends[0])
+				advice, count, fields := factor.BalanceCount(scoredBackends[i], scoredBackends[0])
+				if count > 0 && !(score1 > score2 && advice == AdvicePositive) {
+					fbb.lg.Debug("maybe error", zap.String("factor", factor.Name()), zap.Int("advice", int(advice)), zap.Float64("count", count))
+				}
 				if advice == AdviceNegtive {
 					// If the factor will be unbalanced after migration, skip the rest factors.
 					// E.g. if the CPU usage of A will be much higher than B after migration,
@@ -289,8 +290,9 @@ func (fbb *FactorBasedBalance) BackendsToBalance(backends []policy.BackendCtx) (
 					break
 				}
 				logFields = append(logFields, fields...)
-				if score1 > score2 && advice == AdvicePositive && balanceCount > 0.0001 {
+				if score1 > score2 && advice == AdvicePositive && count > 0.0001 {
 					from, to = scoredBackends[i].BackendCtx, scoredBackends[0].BackendCtx
+					balanceCount = count
 					reason = factor.Name()
 					logFields = append(logFields, zap.String("factor", reason),
 						zap.String("from_total_score", strconv.FormatUint(scoredBackends[i].scoreBits, 16)),

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -41,6 +41,12 @@ var (
 		Names:     []string{"process_cpu_seconds_total", "tidb_server_maxprocs"},
 		Retention: 1 * time.Minute,
 		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			if mfs["process_cpu_seconds_total"] == nil || len(mfs["process_cpu_seconds_total"].Metric) == 0 {
+				return model.SampleValue(math.NaN())
+			}
+			if mfs["tidb_server_maxprocs"] == nil || len(mfs["tidb_server_maxprocs"].Metric) == 0 {
+				return model.SampleValue(math.NaN())
+			}
 			cpuTotal := mfs["process_cpu_seconds_total"].Metric[0].Untyped
 			maxProcs := mfs["tidb_server_maxprocs"].Metric[0].Untyped
 			if cpuTotal == nil || maxProcs == nil {

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -70,7 +70,7 @@ var (
 			failureKey:       "failure_pd",
 			totalKey:         "total_pd",
 			failThreshold:    0.3,
-			recoverThreshold: 0.05,
+			recoverThreshold: 0.1,
 			failurePromQL:    `sum(increase(tidb_tikvclient_backoff_seconds_count{type="pdRPC"}[2m])) by (instance)`,
 			queryFailureRule: metricsreader.QueryRule{
 				Names:     []string{"tidb_tikvclient_backoff_seconds_count"},
@@ -97,7 +97,7 @@ var (
 			failureKey:       "failure_tikv",
 			totalKey:         "total_tikv",
 			failThreshold:    0.3,
-			recoverThreshold: 0.05,
+			recoverThreshold: 0.1,
 			failurePromQL:    `sum(increase(tidb_tikvclient_backoff_seconds_count{type="tikvRPC"}[2m])) by (instance)`,
 			queryFailureRule: metricsreader.QueryRule{
 				Names:     []string{"tidb_tikvclient_backoff_seconds_count"},

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -35,11 +35,14 @@ const (
 )
 
 type errDefinition struct {
-	queryRule        metricsreader.QueryRule
-	promQL           string
-	key              string
-	failThreshold    int
-	recoverThreshold int
+	queryFailureRule metricsreader.QueryRule
+	queryTotalRule   metricsreader.QueryRule
+	failurePromQL    string
+	totalPromQL      string
+	failureKey       string
+	totalKey         string
+	failThreshold    float64
+	recoverThreshold float64
 }
 
 var (
@@ -64,89 +67,88 @@ var (
 	errDefinitions = []errDefinition{
 		{
 			// may be caused by disconnection to PD
-			// test with no connection in no network: around 80/m
-			// test with 100 connections in unstable network: [50, 135]/2m
-			// test with 50 TPS in unstable network: around 500/2m, the higher the TPS, the higher the metric value
-			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type="pdRPC"}[2m])) by (instance)`,
-			failThreshold:    500,
-			recoverThreshold: 50,
-			key:              "health_pd",
-			queryRule: metricsreader.QueryRule{
+			failureKey:       "failure_pd",
+			totalKey:         "total_pd",
+			failThreshold:    0.3,
+			recoverThreshold: 0.05,
+			failurePromQL:    `sum(increase(tidb_tikvclient_backoff_seconds_count{type="pdRPC"}[2m])) by (instance)`,
+			queryFailureRule: metricsreader.QueryRule{
 				Names:     []string{"tidb_tikvclient_backoff_seconds_count"},
 				Retention: 2 * time.Minute,
 				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
-					mt := mfs["tidb_tikvclient_backoff_seconds_count"].Metric
-					total := 0
-					for _, m := range mt {
-						for _, label := range m.Label {
-							if *label.Name == "type" {
-								if *label.Value == "pdRPC" && m.Untyped != nil {
-									total += int(*m.Untyped.Value)
-								}
-								break
-							}
-						}
-					}
-					return model.SampleValue(total)
+					return generalMetric2Value(mfs, "tidb_tikvclient_backoff_seconds_count", "pdRPC")
 				},
-				Range2Value: func(pairs []model.SamplePair) model.SampleValue {
-					if len(pairs) < 2 {
-						return model.SampleValue(math.NaN())
-					}
-					diff := pairs[len(pairs)-1].Value - pairs[0].Value
-					// Maybe the backend just rebooted.
-					if diff < 0 {
-						return model.SampleValue(math.NaN())
-					}
-					return diff
+				Range2Value: generalRange2Value,
+				ResultType:  model.ValVector,
+			},
+			totalPromQL: `sum(increase(pd_client_request_handle_requests_duration_seconds_count[2m])) by (instance)`,
+			queryTotalRule: metricsreader.QueryRule{
+				Names:     []string{"pd_client_request_handle_requests_duration_seconds_count"},
+				Retention: 2 * time.Minute,
+				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+					return generalMetric2Value(mfs, "pd_client_request_handle_requests_duration_seconds_count", "")
 				},
-				ResultType: model.ValVector,
+				Range2Value: generalRange2Value,
+				ResultType:  model.ValVector,
 			},
 		},
 		{
 			// may be caused by disconnection to TiKV
-			// test with no connection in no network: regionMiss is around 1300/m, tikvRPC is around 40/m
-			// test with 100 idle connections in unstable network: [1000, 3300]/2m
-			// test with 100 QPS in unstable network: around 1000/2m
-			// test with 50 TPS in unstable network: around 5000/2m, the higher the TPS, the higher the metric value
-			promQL:           `sum(increase(tidb_tikvclient_backoff_seconds_count{type=~"regionMiss|tikvRPC"}[2m])) by (instance)`,
-			failThreshold:    5000,
-			recoverThreshold: 500,
-			key:              "health_tikv",
-			queryRule: metricsreader.QueryRule{
+			failureKey:       "failure_tikv",
+			totalKey:         "total_tikv",
+			failThreshold:    0.3,
+			recoverThreshold: 0.05,
+			failurePromQL:    `sum(increase(tidb_tikvclient_backoff_seconds_count{type="tikvRPC"}[2m])) by (instance)`,
+			queryFailureRule: metricsreader.QueryRule{
 				Names:     []string{"tidb_tikvclient_backoff_seconds_count"},
 				Retention: 2 * time.Minute,
 				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
-					mt := mfs["tidb_tikvclient_backoff_seconds_count"].Metric
-					total := 0
-					for _, m := range mt {
-						for _, label := range m.Label {
-							if *label.Name == "type" {
-								if (*label.Value == "regionMiss" || *label.Value == "tikvRPC") && m.Untyped != nil {
-									total += int(*m.Untyped.Value)
-								}
-								break
-							}
-						}
-					}
-					return model.SampleValue(total)
+					return generalMetric2Value(mfs, "tidb_tikvclient_backoff_seconds_count", "tikvRPC")
 				},
-				Range2Value: func(pairs []model.SamplePair) model.SampleValue {
-					if len(pairs) < 2 {
-						return model.SampleValue(math.NaN())
-					}
-					diff := pairs[len(pairs)-1].Value - pairs[0].Value
-					// Maybe the backend just rebooted.
-					if diff < 0 {
-						return model.SampleValue(math.NaN())
-					}
-					return diff
+				Range2Value: generalRange2Value,
+				ResultType:  model.ValVector,
+			},
+			totalPromQL: `sum(increase(tidb_tikvclient_request_seconds_count[2m])) by (instance)`,
+			queryTotalRule: metricsreader.QueryRule{
+				Names:     []string{"tidb_tikvclient_request_seconds_count"},
+				Retention: 2 * time.Minute,
+				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+					return generalMetric2Value(mfs, "tidb_tikvclient_request_seconds_count", "")
 				},
-				ResultType: model.ValVector,
+				Range2Value: generalRange2Value,
+				ResultType:  model.ValVector,
 			},
 		},
 	}
 )
+
+func generalMetric2Value(mfs map[string]*dto.MetricFamily, metricName string, typeValue string) model.SampleValue {
+	mt := mfs[metricName].Metric
+	total := 0
+	for _, m := range mt {
+		for _, label := range m.Label {
+			if *label.Name == "type" {
+				if (typeValue == "" || *label.Value == typeValue) && m.Untyped != nil {
+					total += int(*m.Untyped.Value)
+				}
+				break
+			}
+		}
+	}
+	return model.SampleValue(total)
+}
+
+func generalRange2Value(pairs []model.SamplePair) model.SampleValue {
+	if len(pairs) < 2 {
+		return model.SampleValue(math.NaN())
+	}
+	diff := pairs[len(pairs)-1].Value - pairs[0].Value
+	// Maybe the backend just rebooted.
+	if diff < 0 {
+		return model.SampleValue(math.NaN())
+	}
+	return diff
+}
 
 var _ Factor = (*FactorHealth)(nil)
 
@@ -154,19 +156,25 @@ var _ Factor = (*FactorHealth)(nil)
 type healthBackendSnapshot struct {
 	updatedTime time.Time
 	valueRange  valueRange
-	indicator   string
-	value       int
+	// indicator, failureValue, and totalValue are the info of the failed indicator.
+	indicator    string
+	failureValue int
+	totalValue   int
 	// Record the balance count when the backend becomes unhealthy so that it won't be smaller in the next rounds.
 	balanceCount float64
 }
 
 type errIndicator struct {
-	queryExpr        metricsreader.QueryExpr
-	queryRule        metricsreader.QueryRule
-	queryResult      metricsreader.QueryResult
-	key              string
-	failThreshold    int
-	recoverThreshold int
+	queryFailureRule   metricsreader.QueryRule
+	queryTotalRule     metricsreader.QueryRule
+	queryFailureExpr   metricsreader.QueryExpr
+	queryTotalExpr     metricsreader.QueryExpr
+	queryFailureResult metricsreader.QueryResult
+	queryTotalResult   metricsreader.QueryResult
+	failureKey         string
+	totalKey           string
+	failThreshold      float64
+	recoverThreshold   float64
 }
 
 type FactorHealth struct {
@@ -191,15 +199,21 @@ func initErrIndicator(mr metricsreader.MetricsReader) []errIndicator {
 	indicators := make([]errIndicator, 0, len(errDefinitions))
 	for _, def := range errDefinitions {
 		indicator := errIndicator{
-			queryExpr: metricsreader.QueryExpr{
-				PromQL: def.promQL,
+			queryFailureExpr: metricsreader.QueryExpr{
+				PromQL: def.failurePromQL,
 			},
-			queryRule:        def.queryRule,
-			key:              def.key,
+			queryTotalExpr: metricsreader.QueryExpr{
+				PromQL: def.totalPromQL,
+			},
+			queryFailureRule: def.queryFailureRule,
+			queryTotalRule:   def.queryTotalRule,
+			failureKey:       def.failureKey,
+			totalKey:         def.totalKey,
 			failThreshold:    def.failThreshold,
 			recoverThreshold: def.recoverThreshold,
 		}
-		mr.AddQueryExpr(indicator.key, indicator.queryExpr, indicator.queryRule)
+		mr.AddQueryExpr(indicator.failureKey, indicator.queryFailureExpr, indicator.queryFailureRule)
+		mr.AddQueryExpr(indicator.totalKey, indicator.queryTotalExpr, indicator.queryTotalRule)
 		indicators = append(indicators, indicator)
 	}
 	return indicators
@@ -215,16 +229,27 @@ func (fh *FactorHealth) UpdateScore(backends []scoredBackend) {
 	}
 	needUpdateSnapshot, latestTime := false, time.Time{}
 	for i := 0; i < len(fh.indicators); i++ {
-		qr := fh.mr.GetQueryResult(fh.indicators[i].key)
-		if qr.Empty() {
+		failureQR := fh.mr.GetQueryResult(fh.indicators[i].failureKey)
+		if failureQR.Empty() {
 			continue
 		}
-		if fh.indicators[i].queryResult.UpdateTime != qr.UpdateTime {
-			fh.indicators[i].queryResult = qr
+		totalQR := fh.mr.GetQueryResult(fh.indicators[i].totalKey)
+		if totalQR.Empty() {
+			continue
+		}
+		if fh.indicators[i].queryFailureResult.UpdateTime != failureQR.UpdateTime {
+			fh.indicators[i].queryFailureResult = failureQR
 			needUpdateSnapshot = true
 		}
-		if qr.UpdateTime.After(latestTime) {
-			latestTime = qr.UpdateTime
+		if failureQR.UpdateTime.After(latestTime) {
+			latestTime = failureQR.UpdateTime
+		}
+		if fh.indicators[i].queryTotalResult.UpdateTime != totalQR.UpdateTime {
+			fh.indicators[i].queryTotalResult = totalQR
+			needUpdateSnapshot = true
+		}
+		if totalQR.UpdateTime.After(latestTime) {
+			latestTime = totalQR.UpdateTime
 		}
 	}
 	if time.Since(latestTime) > errMetricExpDuration {
@@ -249,9 +274,12 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 	for _, backend := range backends {
 		addr := backend.Addr()
 		// Get the current value range.
-		updatedTime, valueRange, indicator, value := time.Time{}, valueRangeNormal, "", 0
-		for i := 0; i < len(fh.indicators); i++ {
-			ts := fh.indicators[i].queryResult.UpdateTime
+		updatedTime, valueRange, indicator, failureValue, totalValue := time.Time{}, valueRangeNormal, "", 0, 0
+		for _, ind := range fh.indicators {
+			ts := ind.queryFailureResult.UpdateTime
+			if ind.queryTotalResult.UpdateTime.After(ts) {
+				ts = ind.queryTotalResult.UpdateTime
+			}
 			if ts.Add(errMetricExpDuration).Before(now) {
 				// The metrics have not been updated for a long time (maybe Prometheus is unavailable).
 				continue
@@ -259,16 +287,18 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 			if ts.After(updatedTime) {
 				updatedTime = ts
 			}
-			sample := fh.indicators[i].queryResult.GetSample4Backend(backend)
-			if sample == nil {
+			failureSample, totalSample := ind.queryFailureResult.GetSample4Backend(backend), ind.queryTotalResult.GetSample4Backend(backend)
+			if failureSample == nil || totalSample == nil {
 				continue
 			}
-			indicator = fh.indicators[i].key
-			metrics.BackendMetricGauge.WithLabelValues(addr, indicator).Set(float64(sample.Value))
-			vr := calcValueRange(sample, fh.indicators[i])
+			metrics.BackendMetricGauge.WithLabelValues(addr, ind.failureKey).Set(float64(failureSample.Value))
+			metrics.BackendMetricGauge.WithLabelValues(addr, ind.totalKey).Set(float64(totalSample.Value))
+			vr := calcValueRange(failureSample, totalSample, ind)
 			if vr > valueRange {
 				valueRange = vr
-				value = int(sample.Value)
+				failureValue = int(failureSample.Value)
+				totalValue = int(totalSample.Value)
+				indicator = ind.failureKey
 			}
 		}
 		// If the metric is unavailable, try to reuse the latest one.
@@ -291,7 +321,8 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 				zap.String("addr", addr),
 				zap.Int("risk", int(valueRange)),
 				zap.String("indicator", indicator),
-				zap.Int("value", value),
+				zap.Int("failure_value", failureValue),
+				zap.Int("total_value", totalValue),
 				zap.Int("last_risk", int(snapshot.valueRange)),
 				zap.Float64("balance_count", balanceCount),
 				zap.Int("conn_score", backend.ConnScore()))
@@ -300,7 +331,8 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 			updatedTime:  updatedTime,
 			valueRange:   valueRange,
 			indicator:    indicator,
-			value:        value,
+			failureValue: failureValue,
+			totalValue:   totalValue,
 			balanceCount: balanceCount,
 		}
 	}
@@ -313,15 +345,18 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 	}
 }
 
-func calcValueRange(sample *model.Sample, indicator errIndicator) valueRange {
+func calcValueRange(failureSample, totalSample *model.Sample, indicator errIndicator) valueRange {
 	// A backend is typically normal, so if its metric misses, take it as normal.
-	if sample == nil {
+	if failureSample == nil || totalSample == nil {
 		return valueRangeNormal
 	}
-	if math.IsNaN(float64(sample.Value)) {
+	if math.IsNaN(float64(failureSample.Value)) || math.IsNaN(float64(totalSample.Value)) {
 		return valueRangeNormal
 	}
-	value := int(sample.Value)
+	if failureSample.Value == 0 || totalSample.Value == 0 {
+		return valueRangeNormal
+	}
+	value := float64(failureSample.Value) / float64(totalSample.Value)
 	if indicator.failThreshold > indicator.recoverThreshold {
 		switch {
 		case value <= indicator.recoverThreshold:
@@ -356,7 +391,9 @@ func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (BalanceAdvice, flo
 	snapshot := fh.snapshot[from.Addr()]
 	fields := []zap.Field{
 		zap.String("indicator", snapshot.indicator),
-		zap.Int("value", snapshot.value)}
+		zap.Int("failure_value", snapshot.failureValue),
+		zap.Int("total_value", snapshot.totalValue),
+	}
 	if fromScore-toScore <= 1 {
 		return AdviceNeutral, 0, fields
 	}
@@ -372,6 +409,7 @@ func (fh *FactorHealth) CanBeRouted(_ uint64) bool {
 
 func (fh *FactorHealth) Close() {
 	for _, indicator := range fh.indicators {
-		fh.mr.RemoveQueryExpr(indicator.key)
+		fh.mr.RemoveQueryExpr(indicator.failureKey)
+		fh.mr.RemoveQueryExpr(indicator.totalKey)
 	}
 }

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -389,10 +389,13 @@ func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (BalanceAdvice, flo
 	fromScore := fh.caclErrScore(from.Addr())
 	toScore := fh.caclErrScore(to.Addr())
 	snapshot := fh.snapshot[from.Addr()]
-	fields := []zap.Field{
-		zap.String("indicator", snapshot.indicator),
-		zap.Int("failure_value", snapshot.failureValue),
-		zap.Int("total_value", snapshot.totalValue),
+	var fields []zap.Field
+	if snapshot.indicator != "" {
+		fields = append(fields,
+			zap.String("indicator", snapshot.indicator),
+			zap.Int("failure_value", snapshot.failureValue),
+			zap.Int("total_value", snapshot.totalValue),
+		)
 	}
 	if fromScore-toScore <= 1 {
 		return AdviceNeutral, 0, fields

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -89,6 +89,21 @@ func TestHealthBalance(t *testing.T) {
 			balanced:  true,
 		},
 		{
+			errCounts: [][]float64{{math.NaN(), 0}, {0, math.NaN()}},
+			scores:    []uint64{0, 0},
+			balanced:  true,
+		},
+		{
+			errCounts: [][]float64{{0, 0}, {0, 0}},
+			scores:    []uint64{0, 0},
+			balanced:  true,
+		},
+		{
+			errCounts: [][]float64{{10, 0}, {0, 0}},
+			scores:    []uint64{2, 0},
+			balanced:  false,
+		},
+		{
 			errCounts: [][]float64{
 				{float64(errDefinitions[0].recoverThreshold*100 + 1), 100},
 				{math.NaN(), math.NaN()}},
@@ -303,12 +318,12 @@ func TestHealthQueryRule(t *testing.T) {
 		{
 			text: `tidb_tikvclient_backoff_seconds_count{type=""} 0
 tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 10
-tidb_tikvclient_backoff_seconds_count{type="regionMiss"} 10
-pd_client_request_handle_requests_duration_seconds_count{type="tso"} 100
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 20
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 30
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 20
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 30
+pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 10
+pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 100
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 20
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 30
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 20
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 30
 `,
 			curValue:   []model.SampleValue{10, 100, 0, 100},
 			finalValue: []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN())},
@@ -316,13 +331,13 @@ tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2"
 		{
 			text: `tidb_tikvclient_backoff_seconds_count{type=""} 10
 tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 20
-tidb_tikvclient_backoff_seconds_count{type="regionMiss"} 30
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 100
-pd_client_request_handle_requests_duration_seconds_count{type="tso"} 200
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 50
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 50
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 50
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 50
+pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 20
+pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 200
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 50
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 50
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 50
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 50
 `,
 			curValue:   []model.SampleValue{20, 200, 100, 200},
 			finalValue: []model.SampleValue{10, 100, 100, 100},
@@ -330,26 +345,31 @@ tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2"
 		{
 			text: `tidb_tikvclient_backoff_seconds_count{type=""} 10
 tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 20
-tidb_tikvclient_backoff_seconds_count{type="regionMiss"} 50
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 150
-pd_client_request_handle_requests_duration_seconds_count{type="tso"} 300
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 100
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 100
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 100
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 100
+pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 20
+pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 300
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 100
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 100
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 100
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 100
 `,
 			curValue:   []model.SampleValue{20, 300, 150, 400},
 			finalValue: []model.SampleValue{10, 200, 150, 300},
 		},
 		{
 			text: `tidb_tikvclient_backoff_seconds_count{type=""} 0
-tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 5
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 10
-pd_client_request_handle_requests_duration_seconds_count{type="tso"} 50
-tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 50
+pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 5
+pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 50
+tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 50
 `,
 			curValue:   []model.SampleValue{5, 50, 10, 50},
 			finalValue: []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), 10, model.SampleValue(math.NaN())},
+		},
+		{
+			text:       ``,
+			curValue:   []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN())},
+			finalValue: []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN())},
 		},
 	}
 
@@ -366,7 +386,11 @@ tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1"
 		require.NoError(t, err, "case %d", i)
 		for j, rule := range rules {
 			value := rule.Metric2Value(mfs)
-			require.Equal(t, test.curValue[j], value, "case %d %d", i, j)
+			if math.IsNaN(float64(test.curValue[j])) {
+				require.True(t, math.IsNaN(float64(value)), "case %d %d", i, j)
+			} else {
+				require.Equal(t, test.curValue[j], value, "case %d %d", i, j)
+			}
 			historyPair[j] = append(historyPair[j], model.SamplePair{Value: value})
 			value = rule.Range2Value(historyPair[j])
 			if math.IsNaN(float64(test.finalValue[j])) {

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -38,6 +38,12 @@ var (
 		Names:     []string{"process_resident_memory_bytes", "tidb_server_memory_quota_bytes"},
 		Retention: 1 * time.Minute,
 		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			if mfs["process_resident_memory_bytes"] == nil || len(mfs["process_resident_memory_bytes"].Metric) == 0 {
+				return model.SampleValue(math.NaN())
+			}
+			if mfs["tidb_server_memory_quota_bytes"] == nil || len(mfs["tidb_server_memory_quota_bytes"].Metric) == 0 {
+				return model.SampleValue(math.NaN())
+			}
 			memoryUsage := mfs["process_resident_memory_bytes"].Metric[0].Untyped
 			memoryQuota := mfs["tidb_server_memory_quota_bytes"].Metric[0].Untyped
 			if memoryUsage == nil || memoryQuota == nil {

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -87,14 +87,14 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) error {
 
 // readMetrics reads from Prometheus first. If it fails, fall back to read backends.
 func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
-	// if ctx.Err() != nil {
-	// 	return
-	// }
-	// promErr := dmr.promReader.ReadMetrics(ctx)
-	// if promErr == nil {
-	// 	dmr.setSource(sourceProm, nil)
-	// 	return
-	// }
+	if ctx.Err() != nil {
+		return
+	}
+	promErr := dmr.promReader.ReadMetrics(ctx)
+	if promErr == nil {
+		dmr.setSource(sourceProm, nil)
+		return
+	}
 
 	if ctx.Err() != nil {
 		return
@@ -104,7 +104,7 @@ func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
 		dmr.setSource(sourceBackend, nil)
 		return
 	}
-	// dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
+	dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
 }
 
 func (dmr *DefaultMetricsReader) setSource(source int32, err error) {

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -87,24 +87,24 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) error {
 
 // readMetrics reads from Prometheus first. If it fails, fall back to read backends.
 func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
-	if ctx.Err() != nil {
-		return
-	}
-	promErr := dmr.promReader.ReadMetrics(ctx)
-	if promErr == nil {
-		dmr.setSource(sourceProm, nil)
-		return
-	}
+	// if ctx.Err() != nil {
+	// 	return
+	// }
+	// promErr := dmr.promReader.ReadMetrics(ctx)
+	// if promErr == nil {
+	// 	dmr.setSource(sourceProm, nil)
+	// 	return
+	// }
 
 	if ctx.Err() != nil {
 		return
 	}
 	backendErr := dmr.backendReader.ReadMetrics(ctx)
 	if backendErr == nil {
-		dmr.setSource(sourceBackend, promErr)
+		dmr.setSource(sourceBackend, nil)
 		return
 	}
-	dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
+	// dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
 }
 
 func (dmr *DefaultMetricsReader) setSource(source int32, err error) {

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -65,9 +65,9 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 	r.cancelFunc = cancelFunc
 	r.cfgCh = cfgCh
 	// Failing to rebalance backends may cause even more serious problems than TiProxy reboot, so we don't recover panics.
-	r.wg.Run(func() {
+	r.wg.RunWithRecover(func() {
 		r.rebalanceLoop(childCtx)
-	})
+	}, nil, r.logger)
 }
 
 // GetBackendSelector implements Router.GetBackendSelector interface.

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -64,7 +64,7 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 	childCtx, cancelFunc := context.WithCancel(ctx)
 	r.cancelFunc = cancelFunc
 	r.cfgCh = cfgCh
-	// Failing to rebalance backends may cause even more serious problems than TiProxy reboot, so we don't recover panics.
+	// Log the panic.
 	r.wg.RunWithRecover(func() {
 		r.rebalanceLoop(childCtx)
 	}, nil, r.logger)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #828

Problem Summary:
- When TiDB executes heavy DML, there may be many regionMiss, which causes TiProxy to incorrectly take TiDB as unhealthy.
- When connections are migrated to one TiDB, the QPS is higher and has more backoff. Judging by the backoff number is unfair.
- There may be panic when TiDB locations are the same.
- If the router panics, the panic reason is not logged.

What is changed and how it works:
- Remove regionMiss backoffs in the health judgment
- Change backoff number to backoff rate in the health judgment
- Fix possible panic
- Recover router panic and log the panic stack

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Fix TiDB regionMiss backoff causes TiProxy to incorrectly migrate connections
```
