### PR TITLE
metricreader: fix judging k8s deployment by the address

### DIFF
--- a/pkg/balance/metricsreader/query_result.go
+++ b/pkg/balance/metricsreader/query_result.go
@@ -138,14 +138,12 @@ func getLabel4Addr(addr string) string {
 
 func isOperatorDeployed(addr string) bool {
 	// (.+-tidb-[0-9]+).*peer.*.svc.*")
-	idx := strings.Index(addr, "-tidb-")
-	if idx < 0 {
-		return false
+	for _, str := range []string{"-tidb-", ".", "peer", ".svc"} {
+		idx := strings.Index(addr, str)
+		if idx < 0 {
+			return false
+		}
+		addr = addr[idx+len(str):]
 	}
-	idx = strings.Index(addr[idx:], "peer")
-	if idx < 0 {
-		return false
-	}
-	idx = strings.Index(addr[idx:], ".svc")
-	return idx >= 0
+	return true
 }

--- a/pkg/balance/metricsreader/query_result_test.go
+++ b/pkg/balance/metricsreader/query_result_test.go
@@ -206,6 +206,14 @@ func TestAddrMatchLabel(t *testing.T) {
 			addr:  "tc-tidb-0.tc-tidb-peer.ns.svc.cluster.local:3080",
 			label: "tc-tidb-0",
 		},
+		{
+			addr:  "12345678-tidb-0.svc.peer:3080",
+			label: "12345678-tidb-0.svc.peer:3080",
+		},
+		{
+			addr:  "tc-tidb-0.peer:3080",
+			label: "tc-tidb-0.peer:3080",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #833

Problem Summary:
The PR #835 judges the k8s deployment by the address but it's a little wrong.

What is changed and how it works:
Fix the judgment

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
