### PR TITLE
router: pass the client IP to the router to route based on CIDR

### DIFF
--- a/lib/config/balance.go
+++ b/lib/config/balance.go
@@ -13,7 +13,7 @@ const (
 
 type Balance struct {
 	LabelName   string `yaml:"label-name,omitempty" toml:"label-name,omitempty" json:"label-name,omitempty" reloadable:"true"`
-	RoutingRule string `yaml:"routing-rule,omitempty" toml:"routing-rule,omitempty" json:"routing-rule,omitempty" reloadable:"true"`
+	RoutingRule string `yaml:"routing-rule,omitempty" toml:"routing-rule,omitempty" json:"routing-rule,omitempty" reloadable:"false"`
 	Policy      string `yaml:"policy,omitempty" toml:"policy,omitempty" json:"policy,omitempty" reloadable:"true"`
 }
 

--- a/pkg/balance/router/backend_selector.go
+++ b/pkg/balance/router/backend_selector.go
@@ -3,6 +3,14 @@
 
 package router
 
+import "net"
+
+type ClientInfo struct {
+	ClientAddr net.Addr
+	ProxyAddr  net.Addr
+	// TODO: username, database, etc.
+}
+
 type BackendSelector struct {
 	excluded  []BackendInst
 	cur       BackendInst

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -25,8 +25,17 @@ type MatchType int
 const (
 	// Match all connections, used when there is only one backend group.
 	MatchAll MatchType = iota
-	// Match connections based on CIDR.
-	MatchCIDR
+	// Match connections based on the client CIDR.
+	MatchClientCIDR
+	// Match connections based on proxy CIDR. If proxy-protocol is disabled, route by the client CIDR.
+	MatchProxyCIDR
+)
+
+const (
+	// MatchClientCIDRStr is used for MatchClientCIDR.
+	MatchClientCIDRStr = "client_cidr"
+	// MatchProxyCIDRStr is used for MatchProxyCIDR.
+	MatchProxyCIDRStr = "proxy_cidr"
 )
 
 var _ ConnEventReceiver = (*Group)(nil)
@@ -69,7 +78,7 @@ func NewGroup(values []string, bpCreator func(lg *zap.Logger) policy.BalancePoli
 func (g *Group) parseValues() error {
 	var parseErr error
 	switch g.matchType {
-	case MatchCIDR:
+	case MatchClientCIDR, MatchProxyCIDR:
 		cidrList := make([]*net.IPNet, 0, len(g.values))
 		for _, v := range g.values {
 			_, cidr, err := net.ParseCIDR(v)
@@ -84,9 +93,17 @@ func (g *Group) parseValues() error {
 	return parseErr
 }
 
-func (g *Group) Match(value string) bool {
+func (g *Group) Match(clientInfo ClientInfo) bool {
 	switch g.matchType {
-	case MatchCIDR:
+	case MatchClientCIDR, MatchProxyCIDR:
+		addr := clientInfo.ProxyAddr
+		if g.matchType == MatchClientCIDR {
+			addr = clientInfo.ClientAddr
+		}
+		if addr == nil || reflect.ValueOf(addr).IsNil() {
+			return false
+		}
+		value := addr.String()
 		ip := net.ParseIP(value)
 		if ip == nil {
 			g.lg.Error("parsing IP failed", zap.String("ip", value))
@@ -104,7 +121,7 @@ func (g *Group) Match(value string) bool {
 
 func (g *Group) EqualValues(values []string) bool {
 	switch g.matchType {
-	case MatchCIDR:
+	case MatchClientCIDR, MatchProxyCIDR:
 		if len(g.values) != len(values) {
 			return false
 		}

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -104,7 +104,11 @@ func (g *Group) Match(clientInfo ClientInfo) bool {
 			return false
 		}
 		value := addr.String()
-		ip := net.ParseIP(value)
+		ipStr, _, err := net.SplitHostPort(value)
+		if err == nil {
+			g.lg.Error("parsing address failed", zap.String("addr", value), zap.Error(err))
+		}
+		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			g.lg.Error("parsing IP failed", zap.String("ip", value))
 			return false

--- a/pkg/balance/router/group_test.go
+++ b/pkg/balance/router/group_test.go
@@ -96,7 +96,7 @@ func TestMatchIP(t *testing.T) {
 			}, matchType, lg)
 			require.NoError(t, err)
 			ci := ClientInfo{}
-			addr := &net.IPAddr{IP: net.ParseIP(test.ip)}
+			addr := &net.TCPAddr{IP: net.ParseIP(test.ip), Port: 10000}
 			if matchType == MatchProxyCIDR {
 				ci.ProxyAddr = addr
 			} else {

--- a/pkg/balance/router/group_test.go
+++ b/pkg/balance/router/group_test.go
@@ -4,6 +4,7 @@
 package router
 
 import (
+	"net"
 	"testing"
 
 	"github.com/pingcap/tiproxy/lib/util/logger"
@@ -43,7 +44,7 @@ func TestParseCIDR(t *testing.T) {
 	for _, test := range tests {
 		g, err := NewGroup(test.cidrs, func(lg *zap.Logger) policy.BalancePolicy {
 			return nil
-		}, MatchCIDR, lg)
+		}, MatchClientCIDR, lg)
 		if test.success {
 			require.NoError(t, err)
 			require.Equal(t, len(test.cidrs), len(g.cidrList))
@@ -88,11 +89,63 @@ func TestMatchIP(t *testing.T) {
 	}
 
 	lg, _ := logger.CreateLoggerForTest(t)
+	for _, matchType := range []MatchType{MatchClientCIDR, MatchProxyCIDR} {
+		for _, test := range tests {
+			g, err := NewGroup(test.cidrs, func(lg *zap.Logger) policy.BalancePolicy {
+				return nil
+			}, matchType, lg)
+			require.NoError(t, err)
+			ci := ClientInfo{}
+			addr := &net.IPAddr{IP: net.ParseIP(test.ip)}
+			if matchType == MatchProxyCIDR {
+				ci.ProxyAddr = addr
+			} else {
+				ci.ClientAddr = addr
+			}
+			require.Equal(t, test.success, g.Match(ci))
+		}
+	}
+}
+
+func TestEqualCIDR(t *testing.T) {
+	tests := []struct {
+		cidrs1 []string
+		cidrs2 []string
+		equal  bool
+	}{
+		{
+			cidrs1: []string{"1.1.1.1/32"},
+			cidrs2: []string{"1.1.1.1/32"},
+			equal:  true,
+		},
+		{
+			cidrs1: []string{"1.1.1.1/32"},
+			cidrs2: []string{"1.1.1.2/32"},
+			equal:  false,
+		},
+		{
+			cidrs1: []string{"1.1.1.1/24", "1.1.2.1/24"},
+			cidrs2: []string{"1.1.1.1/24", "1.1.2.1/24"},
+			equal:  true,
+		},
+		{
+			cidrs1: []string{"1.1.1.1/24", "1.1.2.1/24"},
+			cidrs2: []string{"1.1.1.1/24"},
+			equal:  false,
+		},
+		{
+			cidrs1: []string{"1.1.1.1/24", "1.1.2.1/24"},
+			cidrs2: []string{"1.1.1.1/24", "1.1.3.1/24"},
+			equal:  false,
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
 	for _, test := range tests {
-		g, err := NewGroup(test.cidrs, func(lg *zap.Logger) policy.BalancePolicy {
+		g1, err := NewGroup(test.cidrs1, func(lg *zap.Logger) policy.BalancePolicy {
 			return nil
-		}, MatchCIDR, lg)
+		}, MatchClientCIDR, lg)
 		require.NoError(t, err)
-		require.Equal(t, test.success, g.Match(test.ip))
+		require.Equal(t, test.equal, g1.EqualValues(test.cidrs2))
 	}
 }

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -26,7 +26,7 @@ type ConnEventReceiver interface {
 
 // Router routes client connections to backends.
 type Router interface {
-	GetBackendSelector() BackendSelector
+	GetBackendSelector(clientInfo ClientInfo) BackendSelector
 	HealthyBackendCount() int
 	RefreshBackend()
 	RedirectConnections() error

--- a/pkg/balance/router/router_static.go
+++ b/pkg/balance/router/router_static.go
@@ -20,7 +20,7 @@ func NewStaticRouter(addrs []string) *StaticRouter {
 	return &StaticRouter{backends: backends}
 }
 
-func (r *StaticRouter) GetBackendSelector() BackendSelector {
+func (r *StaticRouter) GetBackendSelector(_ ClientInfo) BackendSelector {
 	return BackendSelector{
 		routeOnce: func(excluded []BackendInst) (BackendInst, error) {
 			for _, backend := range r.backends {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -265,7 +265,12 @@ func (mgr *BackendConnManager) getBackendIO(ctx context.Context, cctx ConnContex
 	// - The TiDB instances may not be initialized yet
 	// - One TiDB may be just shut down and another is just started but not ready yet
 	bctx, cancel := context.WithTimeout(ctx, mgr.config.ConnectTimeout)
-	selector := r.GetBackendSelector()
+	ci := router.ClientInfo{}
+	if mgr.clientIO != nil {
+		ci.ClientAddr = mgr.clientIO.RemoteAddr()
+		ci.ProxyAddr = mgr.clientIO.ProxyAddr()
+	}
+	selector := r.GetBackendSelector(ci)
 	startTime := time.Now()
 	var addr string
 	var backend router.BackendInst

--- a/pkg/proxy/net/packetio.go
+++ b/pkg/proxy/net/packetio.go
@@ -64,6 +64,7 @@ type packetReadWriter interface {
 	DirectWrite(p []byte) (int, error)
 	ReadFrom(r io.Reader) (int64, error)
 	Proxy() *proxyprotocol.Proxy
+	ProxyAddr() net.Addr
 	TLSConnectionState() tls.ConnectionState
 	InBytes() uint64
 	OutBytes() uint64
@@ -131,6 +132,10 @@ func (brw *basicReadWriter) Sequence() uint8 {
 
 func (brw *basicReadWriter) Proxy() *proxyprotocol.Proxy {
 	return nil
+}
+
+func (brw *basicReadWriter) ProxyAddr() net.Addr {
+	return brw.RemoteAddr()
 }
 
 func (brw *basicReadWriter) InBytes() uint64 {
@@ -212,6 +217,7 @@ type PacketIO interface {
 	EnableProxyClient(proxy *proxyprotocol.Proxy)
 	EnableProxyServer()
 	Proxy() *proxyprotocol.Proxy
+	ProxyAddr() net.Addr
 
 	// tls
 	ServerTLSHandshake(tlsConfig *tls.Config) (tls.ConnectionState, error)
@@ -265,6 +271,10 @@ func (p *packetIO) RemoteAddr() net.Addr {
 		return p.remoteAddr
 	}
 	return p.readWriter.RemoteAddr()
+}
+
+func (p *packetIO) ProxyAddr() net.Addr {
+	return p.readWriter.ProxyAddr()
 }
 
 func (p *packetIO) ResetSequence() {

--- a/pkg/proxy/net/proxy.go
+++ b/pkg/proxy/net/proxy.go
@@ -156,3 +156,7 @@ func (prw *proxyReadWriter) RemoteAddr() net.Addr {
 func (prw *proxyReadWriter) Proxy() *proxyprotocol.Proxy {
 	return prw.proxy
 }
+
+func (prw *proxyReadWriter) ProxyAddr() net.Addr {
+	return prw.packetReadWriter.RemoteAddr()
+}

--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -49,6 +49,7 @@ func TestProxyReadWrite(t *testing.T) {
 		},
 		func(t *testing.T, c net.Conn) {
 			prw := newProxyServer(newBasicReadWriter(c, DefaultConnBufferSize))
+			require.Equal(t, c.RemoteAddr().String(), prw.RemoteAddr().String())
 			data := make([]byte, len(message))
 			n, err := prw.Read(data)
 			require.NoError(t, err)

--- a/pkg/sqlreplay/conn/packetio.go
+++ b/pkg/sqlreplay/conn/packetio.go
@@ -125,6 +125,11 @@ func (p *packetIO) Proxy() *proxyprotocol.Proxy {
 	return nil
 }
 
+// ProxyAddr implements net.PacketIO.
+func (p *packetIO) ProxyAddr() net.Addr {
+	return &net.TCPAddr{}
+}
+
 // RemoteAddr implements net.PacketIO.
 func (p *packetIO) RemoteAddr() net.Addr {
 	return &net.TCPAddr{}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #849 

Problem Summary:
The previous PR supports CIDR but doesn't pass the client IP in.

What is changed and how it works:
- Pass the client IP and proxy IP into the router
- The routing-rule is changed to `client_cidr` and `proxy_cidr`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

E2E tests are added to endless.

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
