### PR TITLE
meter: fix meter data may contain empty data

### DIFF
--- a/pkg/manager/meter/meter.go
+++ b/pkg/manager/meter/meter.go
@@ -118,7 +118,7 @@ func (m *Meter) flush(ts int64, timeout time.Duration) {
 	if len(data) == 0 {
 		return
 	}
-	array := make([]map[string]any, len(data))
+	array := make([]map[string]any, 0, len(data))
 	for clusterID, d := range data {
 		array = append(array, map[string]any{
 			"version":         "1",

--- a/pkg/manager/meter/meter_test.go
+++ b/pkg/manager/meter/meter_test.go
@@ -60,7 +60,7 @@ func TestWrite(t *testing.T) {
 	m.flush(ts, time.Second)
 
 	data := readMeteringData(t, reader, ts)
-	require.True(t, len(data) > 0)
+	require.Len(t, data, 2)
 	resp, crossAZ := getValuesFromData(t, data, "cluster-1")
 	require.Equal(t, int64(100), resp)
 	require.Equal(t, int64(200), crossAZ)
@@ -95,6 +95,7 @@ func TestLoop(t *testing.T) {
 		if len(data) == 0 {
 			continue
 		}
+		require.Len(t, data, 2)
 		resp, crossAZ := getValuesFromData(t, data, "cluster-1")
 		totalResp["cluster-1"] += resp
 		totalCrossAZ["cluster-1"] += crossAZ


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #857

Problem Summary:
The written metering data may contain empty clusters.

What is changed and how it works:
Fix wrong array initialization.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
