### PR TITLE
sqlreplay: deduplicate audit logs and ignore uninitialized statements

### DIFF
--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -36,10 +36,6 @@ func (c *mockConn) Run(ctx context.Context) {
 	c.closeCh <- c.connID
 }
 
-func (c *mockConn) LastCmd() *cmd.Command {
-	return nil
-}
-
 func (c *mockConn) Stop() {
 	c.closed <- struct{}{}
 }
@@ -61,10 +57,6 @@ func (c *mockPendingConn) Run(ctx context.Context) {
 	<-c.closed
 	c.stats.PendingCmds.Add(-c.pendingCmds)
 	c.closeCh <- c.connID
-}
-
-func (c *mockPendingConn) LastCmd() *cmd.Command {
-	return nil
 }
 
 func (c *mockPendingConn) Stop() {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -311,10 +311,7 @@ func (r *replay) executeCmd(ctx context.Context, command *cmd.Command, conns map
 		}, nil, r.lg)
 	}
 	if conn != nil && !reflect.ValueOf(conn).IsNil() {
-		// Deduplicate commands in audit logs.
-		if r.cfg.Format != cmd.FormatAuditLogPlugin || !command.Equal(conn.LastCmd()) {
-			conn.ExecuteCmd(command)
-		}
+		conn.ExecuteCmd(command)
 	}
 	r.decodedCmds.Add(1)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #862

Problem Summary:
- Audit logs record the beginning and end of each statement, but we only care about the beginning
- Audit logs may contain existing connections, wait until the current db is specified

What is changed and how it works:
- Move the deduplication from the replay process to the decode process to decouple logic
- If a connection is not started with a `Connected` event, ignore the table accesses until a `Use` statement shows

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
