### PR TITLE
sqlreplay: support reading audit log files in order

### DIFF
--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -203,6 +203,7 @@ func (r *replay) readCommands(ctx context.Context) {
 	if reader == nil {
 		var err error
 		reader, err = store.NewReader(r.lg.Named("loader"), r.storage, store.ReaderCfg{
+			Format:           r.cfg.Format,
 			Dir:              r.cfg.Input,
 			EncryptionKey:    r.cfg.encryptionKey,
 			EncryptionMethod: r.meta.EncryptMethod,

--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -6,10 +6,12 @@ package store
 import "time"
 
 const (
-	fileNamePrefix     = "traffic-"
-	fileNameSuffix     = ".log"
-	fileCompressFormat = ".gz"
-	fileSize           = 300 << 20
-	bufferSize         = 1 << 20
-	opTimeout          = 10 * time.Second
+	fileNamePrefix      = "traffic-"
+	auditFileNamePrefix = "tidb-audit-"
+	fileNameSuffix      = ".log"
+	logTimeLayout       = "2006-01-02T15-04-05.999"
+	fileCompressFormat  = ".gz"
+	fileSize            = 300 << 20
+	bufferSize          = 1 << 20
+	opTimeout           = 10 * time.Second
 )

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -29,6 +29,7 @@ func NewWriter(lg *zap.Logger, externalStorage storage.ExternalStorage, cfg Writ
 
 type ReaderCfg struct {
 	Dir              string
+	Format           string
 	EncryptionMethod string
 	EncryptionKey    []byte
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #864 

Problem Summary:
Support reading audit log files in order.

What is changed and how it works:
Parse the time in the filename and order it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
