### PR TITLE
sqlreplay: fix decoding the SQL_TEXT in audit logs

### DIFF
--- a/pkg/sqlreplay/cmd/audit_log_plugin.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin.go
@@ -215,6 +215,16 @@ func parseStartTs(kvs map[string]string) (time.Time, error) {
 	return endTs.Add(-time.Duration(millis * 1000)), nil
 }
 
+func parseSQL(value string) (string, error) {
+	if len(value) == 0 {
+		return "", errors.New("empty sql")
+	}
+	if value[0] == '"' {
+		return strconv.Unquote(value)
+	}
+	return value, nil
+}
+
 // "[\"KindInt64 1\",\"KindInt64 1\"]"
 func parseExecuteParams(value string) ([]any, error) {
 	v, err := strconv.Unquote(value)
@@ -304,7 +314,7 @@ func (decoder *AuditLogPluginDecoder) parseGeneralEvent(kvs map[string]string, c
 
 	switch cmdStr {
 	case "Query", "Init DB":
-		sql, err := strconv.Unquote(kvs[auditPluginKeySQL])
+		sql, err := parseSQL(kvs[auditPluginKeySQL])
 		if err != nil {
 			return nil, errors.Wrapf(err, "unquote sql failed: %s", kvs[auditPluginKeySQL])
 		}
@@ -319,7 +329,7 @@ func (decoder *AuditLogPluginDecoder) parseGeneralEvent(kvs map[string]string, c
 			// the old format doesn't output params
 			break
 		}
-		sql, err := strconv.Unquote(kvs[auditPluginKeySQL])
+		sql, err := parseSQL(kvs[auditPluginKeySQL])
 		if err != nil {
 			return nil, errors.Wrapf(err, "unquote sql failed: %s", kvs[auditPluginKeySQL])
 		}

--- a/pkg/sqlreplay/cmd/audit_log_plugin_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin_test.go
@@ -366,6 +366,39 @@ func TestParseStartTs(t *testing.T) {
 	}
 }
 
+func TestParseSQL(t *testing.T) {
+	tests := []struct {
+		value  string
+		sql    string
+		errMsg string
+	}{
+		{
+			value: `COMMIT`,
+			sql:   `COMMIT`,
+		},
+		{
+			value: `"SELECT 1"`,
+			sql:   `SELECT 1`,
+		},
+		{
+			value:  ``,
+			errMsg: "empty",
+		},
+	}
+
+	for i, test := range tests {
+		sql, err := parseSQL(test.value)
+		if test.errMsg != "" {
+			require.Error(t, err, "case %d", i)
+			require.Contains(t, err.Error(), test.errMsg, "case %d", i)
+			continue
+		} else {
+			require.NoError(t, err, "case %d", i)
+		}
+		require.EqualValues(t, test.sql, sql, "case %d", i)
+	}
+}
+
 func TestParseParams(t *testing.T) {
 	tests := []struct {
 		s      string


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #859

Problem Summary:
The `SQL_TEXT` sometimes contains quotes but sometimes doesn't.

What is changed and how it works:
Unquote it only when it doesn't start with quotes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
