### PR TITLE
cmd, sqlreplay: support client mode to replay audit logs

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -59,6 +59,7 @@ func main() {
 		if err := r.start(replayCfg); err != nil {
 			return err
 		}
+		r.close()
 		return nil
 	}
 
@@ -68,7 +69,6 @@ func main() {
 type replayer struct {
 	lgMgr  *logger.LoggerManager
 	replay mgrrp.JobManager
-	idMgr  *id.IDManager
 }
 
 func (r *replayer) initComponents(addr, logFile string) error {
@@ -95,6 +95,11 @@ func (r *replayer) start(replayCfg replay.ReplayConfig) error {
 	}
 	r.replay.Wait()
 	return nil
+}
+
+func (r *replayer) close() {
+	r.replay.Close()
+	_ = r.lgMgr.Close()
 }
 
 var _ mgrrp.CertManager = &nopCertManager{}

--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -1,0 +1,146 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/lib/util/cmd"
+	"github.com/pingcap/tiproxy/pkg/balance/router"
+	"github.com/pingcap/tiproxy/pkg/manager/id"
+	"github.com/pingcap/tiproxy/pkg/manager/logger"
+	"github.com/pingcap/tiproxy/pkg/proxy/backend"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+	mgrrp "github.com/pingcap/tiproxy/pkg/sqlreplay/manager"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/replay"
+	"github.com/pingcap/tiproxy/pkg/util/versioninfo"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:     os.Args[0],
+		Short:   "start the replayer",
+		Version: fmt.Sprintf("%s, commit %s", versioninfo.TiProxyVersion, versioninfo.TiProxyGitHash),
+	}
+	rootCmd.SetOut(os.Stdout)
+	rootCmd.SetErr(os.Stderr)
+
+	addr := rootCmd.PersistentFlags().String("addr", "127.0.0.1:4000", "the downstream address to connect to")
+	input := rootCmd.PersistentFlags().String("input", "", "directory for traffic files")
+	speed := rootCmd.PersistentFlags().Float64("speed", 1, "replay speed")
+	username := rootCmd.PersistentFlags().String("username", "root", "the username to connect to TiDB for replay")
+	password := rootCmd.PersistentFlags().String("password", "", "the password to connect to TiDB for replay")
+	readonly := rootCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
+	format := rootCmd.PersistentFlags().String("format", "", "the format of traffic files")
+	logFile := rootCmd.PersistentFlags().String("log-file", "", "the output log file")
+
+	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		replayCfg := replay.ReplayConfig{
+			Input:     *input,
+			Speed:     *speed,
+			Username:  *username,
+			Password:  *password,
+			Format:    *format,
+			ReadOnly:  *readonly,
+			StartTime: time.Now(),
+		}
+
+		r := &replayer{}
+		if err := r.initComponents(*addr, *logFile); err != nil {
+			return err
+		}
+		if err := r.start(replayCfg); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	cmd.RunRootCommand(rootCmd)
+}
+
+type replayer struct {
+	lgMgr  *logger.LoggerManager
+	replay mgrrp.JobManager
+	idMgr  *id.IDManager
+}
+
+func (r *replayer) initComponents(addr, logFile string) error {
+	lgMgr, lg, err := logger.NewLoggerManager(&config.Log{
+		LogOnline: config.LogOnline{
+			Level:   "info",
+			LogFile: config.LogFile{Filename: logFile},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	r.lgMgr = lgMgr
+	hsHandler := newStaticHandshakeHandler(addr)
+	idMgr := id.NewIDManager()
+	cfg := config.NewConfig()
+	r.replay = mgrrp.NewJobManager(lg.Named("replay"), cfg, &nopCertManager{}, idMgr, hsHandler)
+	return nil
+}
+
+func (r *replayer) start(replayCfg replay.ReplayConfig) error {
+	if err := r.replay.StartReplay(replayCfg); err != nil {
+		return err
+	}
+	r.replay.Wait()
+	return nil
+}
+
+var _ mgrrp.CertManager = &nopCertManager{}
+
+type nopCertManager struct{}
+
+func (c *nopCertManager) SQLTLS() *tls.Config {
+	return nil
+}
+
+type staticHandshakeHandler struct {
+	rt router.Router
+}
+
+func newStaticHandshakeHandler(addr string) *staticHandshakeHandler {
+	return &staticHandshakeHandler{
+		rt: router.NewStaticRouter([]string{addr}),
+	}
+}
+
+func (handler *staticHandshakeHandler) HandleHandshakeResp(backend.ConnContext, *pnet.HandshakeResp) error {
+	return nil
+}
+
+func (handler *staticHandshakeHandler) HandleHandshakeErr(backend.ConnContext, *mysql.MyError) bool {
+	return false
+}
+
+func (handler *staticHandshakeHandler) GetRouter(backend.ConnContext, *pnet.HandshakeResp) (router.Router, error) {
+	return handler.rt, nil
+}
+
+func (handler *staticHandshakeHandler) OnHandshake(backend.ConnContext, string, error, backend.ErrorSource) {
+}
+
+func (handler *staticHandshakeHandler) OnTraffic(backend.ConnContext) {
+}
+
+func (handler *staticHandshakeHandler) OnConnClose(backend.ConnContext, backend.ErrorSource) error {
+	return nil
+}
+
+func (handler *staticHandshakeHandler) GetCapability() pnet.Capability {
+	return backend.SupportedServerCapabilities
+}
+
+func (handler *staticHandshakeHandler) GetServerVersion() string {
+	return pnet.ServerVersion
+}

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -128,6 +128,9 @@ func (mc *mockCapture) Start(cfg capture.CaptureConfig) error {
 	return nil
 }
 
+func (mc *mockCapture) Wait() {
+}
+
 func (mc *mockCapture) Stop(err error) {
 }
 

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -201,6 +201,9 @@ func (m *mockReplayJobManager) StartReplay(replayCfg replay.ReplayConfig) error 
 	return nil
 }
 
+func (m *mockReplayJobManager) Wait() {
+}
+
 func (m *mockReplayJobManager) Stop(manager.CancelConfig) string {
 	m.curJob = ""
 	return "stopped"

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -39,6 +39,8 @@ const (
 type Capture interface {
 	// Start starts the capture
 	Start(cfg CaptureConfig) error
+	// Wait for the job done.
+	Wait()
 	// Stop stops the capture.
 	// err means the error that caused the capture to stop. nil means the capture stopped manually.
 	Stop(err error)
@@ -417,6 +419,10 @@ func (c *capture) stop(err error) {
 	c.Lock()
 	c.stopNoLock(err)
 	c.Unlock()
+}
+
+func (c *capture) Wait() {
+	c.wg.Wait()
 }
 
 func (c *capture) Stop(err error) {

--- a/pkg/sqlreplay/manager/manager.go
+++ b/pkg/sqlreplay/manager/manager.go
@@ -33,6 +33,7 @@ type JobManager interface {
 	StartCapture(capture.CaptureConfig) error
 	StartReplay(replay.ReplayConfig) error
 	GetCapture() capture.Capture
+	Wait()
 	Stop(CancelConfig) string
 	Jobs() string
 	Close()
@@ -160,6 +161,19 @@ func (jm *jobManager) Jobs() string {
 		return err.Error()
 	}
 	return hack.String(b)
+}
+
+func (jm *jobManager) Wait() {
+	job := jm.runningJob()
+	if job == nil {
+		return
+	}
+	switch job.Type() {
+	case Capture:
+		jm.capture.Wait()
+	case Replay:
+		jm.replay.Wait()
+	}
 }
 
 func (jm *jobManager) Stop(cfg CancelConfig) string {

--- a/pkg/sqlreplay/manager/mock_test.go
+++ b/pkg/sqlreplay/manager/mock_test.go
@@ -42,6 +42,9 @@ func (m *mockCapture) Progress() (float64, time.Time, bool, error) {
 	return m.progress, time.Time{}, m.done, m.err
 }
 
+func (m *mockCapture) Wait() {
+}
+
 func (m *mockCapture) Stop(err error) {
 	m.err = err
 }
@@ -66,6 +69,9 @@ func (m *mockReplay) Close() {
 
 func (m *mockReplay) Progress() (float64, time.Time, bool, error) {
 	return m.progress, time.Time{}, m.done, m.err
+}
+
+func (m *mockReplay) Wait() {
 }
 
 func (m *mockReplay) Start(cfg replay.ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -41,6 +41,8 @@ const (
 type Replay interface {
 	// Start starts the replay
 	Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error
+	// Wait for the job done.
+	Wait()
 	// Stop stops the replay
 	Stop(err error)
 	// Progress returns the progress of the replay job
@@ -144,7 +146,9 @@ func NewReplay(lg *zap.Logger, idMgr *id.IDManager) *replay {
 func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error {
 	storage, err := cfg.Validate()
 	if err != nil {
-		storage.Close()
+		if storage != nil {
+			storage.Close()
+		}
 		return err
 	}
 
@@ -392,6 +396,10 @@ func (r *replay) stop(err error) {
 		r.storage.Close()
 		r.storage = nil
 	}
+}
+
+func (r *replay) Wait() {
+	r.wg.Wait()
 }
 
 func (r *replay) Stop(err error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #876 

Problem Summary:
Support replay in the client mode.

What is changed and how it works:
- Add a binary `replayer`
- The replayer calls `ReplayJobManager` to replay and wait it done

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
make
bin/replayer --addr "127.1:4000" --username="root" --password="" --input="/Users/zhangming/.tiup/data/audit2/tidb-0" --format="audit_log_plugin" --log-file="./replay-log"
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
