### PR TITLE
cmd, replay: filter out the commands before command start time

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -40,16 +40,18 @@ func main() {
 	readonly := rootCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
 	format := rootCmd.PersistentFlags().String("format", "", "the format of traffic files")
 	logFile := rootCmd.PersistentFlags().String("log-file", "", "the output log file")
+	cmdStartTime := rootCmd.PersistentFlags().Time("command-start-time", time.Now(), []string{time.RFC3339, time.RFC3339Nano}, "the start time to replay the traffic, format is RFC3339. The command before this start time will be ignored.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		replayCfg := replay.ReplayConfig{
-			Input:     *input,
-			Speed:     *speed,
-			Username:  *username,
-			Password:  *password,
-			Format:    *format,
-			ReadOnly:  *readonly,
-			StartTime: time.Now(),
+			Input:            *input,
+			Speed:            *speed,
+			Username:         *username,
+			Password:         *password,
+			Format:           *format,
+			ReadOnly:         *readonly,
+			StartTime:        time.Now(),
+			CommandStartTime: *cmdStartTime,
 		}
 
 		r := &replayer{}

--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -64,6 +64,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 	password := replayCmd.PersistentFlags().String("password", "", "the password to connect to TiDB for replay")
 	readonly := replayCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
 	format := replayCmd.PersistentFlags().String("format", "", "the format of traffic files")
+	cmdStartTime := replayCmd.PersistentFlags().String("command-start-time", "", "the start time to replay the traffic, format is RFC3339 or RFC3339Nano. The command before this start time will be ignored.")
 	replayCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		username := *username
 		if len(username) == 0 {
@@ -79,12 +80,13 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 			password = string(bytePassword)
 		}
 		reader := GetFormReader(map[string]string{
-			"input":    *input,
-			"speed":    strconv.FormatFloat(*speed, 'f', -1, 64),
-			"username": username,
-			"password": password,
-			"readonly": strconv.FormatBool(*readonly),
-			"format":   *format,
+			"input":        *input,
+			"speed":        strconv.FormatFloat(*speed, 'f', -1, 64),
+			"username":     username,
+			"password":     password,
+			"readonly":     strconv.FormatBool(*readonly),
+			"format":       *format,
+			"cmdstarttime": *cmdStartTime,
 		})
 		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/replay", reader)
 		if err != nil {

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -102,6 +102,18 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 	cfg.Format = c.PostForm("format")
 	cfg.ReadOnly = strings.EqualFold(c.PostForm("readonly"), "true")
 	cfg.KeyFile = globalCfg.Security.EncryptionKeyPath
+	// By default, if `cmdstarttime` is not specified, use zero time
+	if cmdStartTimeStr := c.PostForm("cmdstarttime"); cmdStartTimeStr != "" {
+		cmdStartTime, err := time.Parse(time.RFC3339, cmdStartTimeStr)
+		if err != nil {
+			cmdStartTime, err = time.Parse(time.RFC3339Nano, cmdStartTimeStr)
+			if err != nil {
+				c.String(http.StatusBadRequest, err.Error())
+				return
+			}
+		}
+		cfg.CommandStartTime = cmdStartTime
+	}
 
 	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -46,6 +46,8 @@ func NewCmdDecoder(format string) CmdDecoder {
 
 type CmdDecoder interface {
 	Decode(reader LineReader) (c *Command, err error)
+
+	SetCommandStartTime(t time.Time)
 }
 
 type Command struct {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #874

Problem Summary:

What is changed and how it works:

1. Add a new field `cmdstarttime` in HTTP API.
2. Add a new flag `command-start-time` in replayer and tiproxyctl cli.
3. Modify the decoder to support filter out commands according to the config.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [x] Has HTTP API interfaces change
- [x] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
