### PR TITLE
replay: fix report may not be written before close

### DIFF
--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -261,7 +261,7 @@ func (r *replay) readCommands(ctx context.Context) {
 				break
 			}
 
-			// Do not use calculate the wait time by the duration since last command because the go scheduler
+			// Do not calculate the wait time by the duration since last command because the go scheduler
 			// may wait a little bit longer than expected, and then the difference becomes larger and larger.
 			expectedInterval := command.StartTs.Sub(captureStartTs)
 			if r.cfg.Speed != 1 {
@@ -420,4 +420,7 @@ func (r *replay) Stop(err error) {
 
 func (r *replay) Close() {
 	r.Stop(errors.New("shutting down"))
+	if r.report != nil {
+		r.report.Close()
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #880

Problem Summary:
The replay failure may not be written to the table `fail`.

What is changed and how it works:
Close `report` before closing `replay`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Replay and check the `tiproxy_traffic_replay.fail`.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
