### PR TITLE
replay: implement reading commands from multiple sources

### DIFF
--- a/pkg/sqlreplay/replay/merge_decoder.go
+++ b/pkg/sqlreplay/replay/merge_decoder.go
@@ -1,0 +1,91 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"io"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+)
+
+// decoder is used to decode commands from one or multiple readers.
+type decoder interface {
+	Decode() (*cmd.Command, error)
+}
+
+// mergeDecoder merges multiple decoders and merge sort them in `StartTS` order.
+// However, if the commands read from decoder are not sorted, the order is not
+// strictly guaranteed.
+type mergeDecoder struct {
+	decoders []decoder
+	buf      []*cmd.Command
+}
+
+func newMergeDecoder(decoders ...decoder) *mergeDecoder {
+	return &mergeDecoder{
+		decoders: decoders,
+	}
+}
+
+// Decode returns the command with the smallest StartTS from multiple decoders.
+func (d *mergeDecoder) Decode() (*cmd.Command, error) {
+	for i, decoder := range d.decoders {
+		if decoder == nil {
+			continue
+		}
+
+		if i >= len(d.buf) {
+			d.buf = append(d.buf, nil)
+		}
+
+		if d.buf[i] == nil {
+			cmd, err := decoder.Decode()
+			if err != nil {
+				if err == io.EOF {
+					// Mark decoder as exhausted
+					d.decoders[i] = nil
+					continue
+				}
+				return nil, err
+			}
+			d.buf[i] = cmd
+		}
+	}
+
+	var minIdx = -1
+	var minCmd *cmd.Command
+
+	for i, cmd := range d.buf {
+		if cmd != nil {
+			if minCmd == nil || cmd.StartTs.Before(minCmd.StartTs) {
+				minCmd = cmd
+				minIdx = i
+			}
+		}
+	}
+
+	if minCmd == nil {
+		return nil, io.EOF
+	}
+	d.buf[minIdx] = nil
+
+	return minCmd, nil
+}
+
+type singleDecoder struct {
+	decoder cmd.CmdDecoder
+	reader  cmd.LineReader
+}
+
+func newSingleDecoder(decoder cmd.CmdDecoder, reader cmd.LineReader) *singleDecoder {
+	return &singleDecoder{
+		decoder: decoder,
+		reader:  reader,
+	}
+}
+
+// Decode decodes a command from the single reader.
+func (d *singleDecoder) Decode() (*cmd.Command, error) {
+	return d.decoder.Decode(d.reader)
+}

--- a/pkg/sqlreplay/replay/merge_decoder_test.go
+++ b/pkg/sqlreplay/replay/merge_decoder_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"io"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDecoder struct {
+	commands []*cmd.Command
+	index    int
+}
+
+func newMockDecoder(commands []*cmd.Command) *mockDecoder {
+	return &mockDecoder{
+		commands: commands,
+		index:    0,
+	}
+}
+
+func (d *mockDecoder) Decode() (*cmd.Command, error) {
+	if d.index >= len(d.commands) {
+		return nil, io.EOF
+	}
+	cmd := d.commands[d.index]
+	d.index++
+	return cmd, nil
+}
+
+func TestMergeDecoderSingleDecoder(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(20 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(30 * time.Millisecond)},
+	}
+
+	decoder := newMockDecoder(commands)
+	merger := newMergeDecoder(decoder)
+
+	for i, expected := range commands {
+		cmd, err := merger.Decode()
+		require.NoError(t, err, "decode %d", i)
+		require.Equal(t, expected.ConnID, cmd.ConnID, "decode %d", i)
+		require.Equal(t, expected.StartTs, cmd.StartTs, "decode %d", i)
+	}
+
+	// Should return EOF when exhausted
+	_, err := merger.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestMergeDecoderMultipleDecoders(t *testing.T) {
+	now := time.Now()
+
+	commands1 := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(30 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(50 * time.Millisecond)},
+	}
+
+	commands2 := []*cmd.Command{
+		{ConnID: 2, StartTs: now.Add(20 * time.Millisecond)},
+		{ConnID: 2, StartTs: now.Add(40 * time.Millisecond)},
+		{ConnID: 2, StartTs: now.Add(60 * time.Millisecond)},
+	}
+
+	decoder1 := newMockDecoder(commands1)
+	decoder2 := newMockDecoder(commands2)
+	merger := newMergeDecoder(decoder1, decoder2)
+
+	expectedOrder := []uint64{1, 2, 1, 2, 1, 2}
+	expectedTimes := []time.Time{
+		now.Add(10 * time.Millisecond),
+		now.Add(20 * time.Millisecond),
+		now.Add(30 * time.Millisecond),
+		now.Add(40 * time.Millisecond),
+		now.Add(50 * time.Millisecond),
+		now.Add(60 * time.Millisecond),
+	}
+
+	for i, conn := range expectedOrder {
+		cmd, err := merger.Decode()
+		require.NoError(t, err, "decode %d", i)
+		require.Equal(t, conn, cmd.ConnID, "decode %d", i)
+		require.Equal(t, expectedTimes[i], cmd.StartTs, "decode %d", i)
+	}
+
+	// Should return EOF when all decoders are exhausted
+	_, err := merger.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestMergeDecoderRandomizedCommands(t *testing.T) {
+	now := time.Now()
+	rng := rand.New(rand.NewSource(42))
+
+	numDecoders := 5
+	commandsPerDecoder := 20
+
+	var allCommands []*cmd.Command
+	var decoders []decoder
+
+	for decoderID := 0; decoderID < numDecoders; decoderID++ {
+		var commands []*cmd.Command
+
+		for range commandsPerDecoder {
+			offset := time.Duration(rng.Intn(1000)) * time.Millisecond
+			command := &cmd.Command{
+				ConnID:  uint64(decoderID + 1),
+				StartTs: now.Add(offset),
+			}
+			commands = append(commands, command)
+			allCommands = append(allCommands, command)
+		}
+
+		sort.Slice(commands, func(i, j int) bool {
+			return commands[i].StartTs.Before(commands[j].StartTs)
+		})
+
+		decoders = append(decoders, newMockDecoder(commands))
+	}
+
+	sort.Slice(allCommands, func(i, j int) bool {
+		if allCommands[i].StartTs.Equal(allCommands[j].StartTs) {
+			// For equal timestamps, maintain stable sort by ConnID
+			return allCommands[i].ConnID < allCommands[j].ConnID
+		}
+		return allCommands[i].StartTs.Before(allCommands[j].StartTs)
+	})
+
+	merger := newMergeDecoder(decoders...)
+
+	for i, expected := range allCommands {
+		cmd, err := merger.Decode()
+		require.NoError(t, err, "decode %d", i)
+		require.Equal(t, expected.ConnID, cmd.ConnID, "decode %d", i)
+		require.Equal(t, expected.StartTs, cmd.StartTs, "decode %d", i)
+	}
+
+	_, err := merger.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestMergeDecoderEmptyDecoders(t *testing.T) {
+	decoder1 := newMockDecoder([]*cmd.Command{})
+	decoder2 := newMockDecoder([]*cmd.Command{})
+	merger := newMergeDecoder(decoder1, decoder2)
+
+	// Should return EOF immediately
+	_, err := merger.Decode()
+	require.Equal(t, io.EOF, err)
+}

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -30,7 +30,7 @@ func TestManageConns(t *testing.T) {
 		Input:     t.TempDir(),
 		Username:  "u1",
 		StartTime: time.Now(),
-		reader:    loader,
+		readers:   []cmd.LineReader{loader},
 		connCreator: func(connID uint64) conn.Conn {
 			connCount++
 			return &mockConn{
@@ -109,7 +109,9 @@ func TestValidateCfg(t *testing.T) {
 		storage, err := cfg.Validate()
 		require.Error(t, err, "case %d", i)
 		if storage != nil && !reflect.ValueOf(storage).IsNil() {
-			storage.Close()
+			for _, s := range storage {
+				s.Close()
+			}
 		}
 	}
 }
@@ -127,7 +129,7 @@ func TestReplaySpeed(t *testing.T) {
 			Username:  "u1",
 			Speed:     speed,
 			StartTime: time.Now(),
-			reader:    loader,
+			readers:   []cmd.LineReader{loader},
 			report:    newMockReport(replay.exceptionCh),
 			connCreator: func(connID uint64) conn.Conn {
 				return &mockConn{
@@ -191,7 +193,7 @@ func TestProgress(t *testing.T) {
 		Input:     dir,
 		Username:  "u1",
 		StartTime: time.Now(),
-		reader:    loader,
+		readers:   []cmd.LineReader{loader},
 		report:    newMockReport(replay.exceptionCh),
 		connCreator: func(connID uint64) conn.Conn {
 			return &mockConn{
@@ -240,7 +242,7 @@ func TestPendingCmds(t *testing.T) {
 		Input:     dir,
 		Username:  "u1",
 		StartTime: time.Now(),
-		reader:    loader,
+		readers:   []cmd.LineReader{loader},
 		report:    newMockReport(replay.exceptionCh),
 		connCreator: func(connID uint64) conn.Conn {
 			return &mockPendingConn{
@@ -310,7 +312,7 @@ func TestLoadEncryptionKey(t *testing.T) {
 		Input:     dir,
 		Username:  "u1",
 		StartTime: now,
-		reader:    loader,
+		readers:   []cmd.LineReader{loader},
 	}
 	for i, test := range tests {
 		cfg.KeyFile = test.keyFile


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #875 

Problem Summary:

What is changed and how it works:

1. Add a `mergeDecoder` struct to merge sort the result of decoders. However, in the current implementation, the commands returned by each internal decoder are not sorted by the `StartTs`, so the order of `mergeDecoder` is also not strictly guaranteed.
2. Support to add multiple `Input`, split by `,`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Save the same audit file to `/tmp/audit-1/xxx` and `/tmp/audit-2/xxx`. Replay with `./replayer --command-start-time 2025-09-14T13:53:58+08:00 --format audit_log_plugin --log-file ./replay.log --input /tmp/audit-1,/tmp/audit-2`, and the same query will be executed two times.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
