### PR TITLE
replayer: modify the default value of comand-start-time to zero time

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -40,7 +40,7 @@ func main() {
 	readonly := rootCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
 	format := rootCmd.PersistentFlags().String("format", "", "the format of traffic files")
 	logFile := rootCmd.PersistentFlags().String("log-file", "", "the output log file")
-	cmdStartTime := rootCmd.PersistentFlags().Time("command-start-time", time.Now(), []string{time.RFC3339, time.RFC3339Nano}, "the start time to replay the traffic, format is RFC3339. The command before this start time will be ignored.")
+	cmdStartTime := rootCmd.PersistentFlags().Time("command-start-time", time.Time{}, []string{time.RFC3339, time.RFC3339Nano}, "the start time to replay the traffic, format is RFC3339. The command before this start time will be ignored.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		replayCfg := replay.ReplayConfig{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #882

Problem Summary:

What is changed and how it works:

Modify the default value of `command-start-time` to zero time.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
