### PR TITLE
replay: filter audit log by the time in filename

### DIFF
--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -214,6 +214,7 @@ func (r *replay) readCommands(ctx context.Context) {
 			Dir:              r.cfg.Input,
 			EncryptionKey:    r.cfg.encryptionKey,
 			EncryptionMethod: r.meta.EncryptMethod,
+			CommandStartTime: r.cfg.CommandStartTime,
 		})
 		if err != nil {
 			r.stop(err)

--- a/pkg/sqlreplay/store/line.go
+++ b/pkg/sqlreplay/store/line.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
@@ -32,6 +33,8 @@ type ReaderCfg struct {
 	Format           string
 	EncryptionMethod string
 	EncryptionKey    []byte
+	// Reader will skip the files whose end time is before CommandStartTime.
+	CommandStartTime time.Time
 }
 
 var _ cmd.LineReader = (*loader)(nil)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #883

Problem Summary:

What is changed and how it works:

Filter the file according to the argument `command-start-time`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
