### PR TITLE
cmd: break the replayer when received signals

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
@@ -91,9 +90,8 @@ func main() {
 }
 
 type replayer struct {
-	closeOnce sync.Once
-	lgMgr     *logger.LoggerManager
-	replay    mgrrp.JobManager
+	lgMgr  *logger.LoggerManager
+	replay mgrrp.JobManager
 }
 
 func (r *replayer) initComponents(addr, logFile string) error {
@@ -127,10 +125,8 @@ func (r *replayer) stop() {
 }
 
 func (r *replayer) close() {
-	r.closeOnce.Do(func() {
-		r.replay.Close()
-		_ = r.lgMgr.Close()
-	})
+	r.replay.Close()
+	_ = r.lgMgr.Close()
 }
 
 var _ mgrrp.CertManager = &nopCertManager{}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #876 

Problem Summary:
We can only stop the replayer by `kill -9`. It's better to break for `Ctrl+C`.

What is changed and how it works:
Stop the replayer when received SIGINT.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
