### PR TITLE
replay, cmd: support ignoring errors in replay

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -44,6 +44,7 @@ func main() {
 	format := rootCmd.PersistentFlags().String("format", "", "the format of traffic files")
 	logFile := rootCmd.PersistentFlags().String("log-file", "", "the output log file")
 	cmdStartTime := rootCmd.PersistentFlags().Time("command-start-time", time.Time{}, []string{time.RFC3339, time.RFC3339Nano}, "the start time to replay the traffic, format is RFC3339. The command before this start time will be ignored.")
+	ignoreErrs := rootCmd.PersistentFlags().Bool("ignore-errs", false, "ignore errors when replaying")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		replayCfg := replay.ReplayConfig{
@@ -55,6 +56,7 @@ func main() {
 			ReadOnly:         *readonly,
 			StartTime:        time.Now(),
 			CommandStartTime: *cmdStartTime,
+			IgnoreErrs:       *ignoreErrs,
 		}
 
 		r := &replayer{}

--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -65,6 +65,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 	readonly := replayCmd.PersistentFlags().Bool("read-only", false, "only replay read-only queries, default is false")
 	format := replayCmd.PersistentFlags().String("format", "", "the format of traffic files")
 	cmdStartTime := replayCmd.PersistentFlags().String("command-start-time", "", "the start time to replay the traffic, format is RFC3339 or RFC3339Nano. The command before this start time will be ignored.")
+	ignoreErrors := replayCmd.PersistentFlags().Bool("ignore-errs", false, "ignore errors when replaying")
 	replayCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		username := *username
 		if len(username) == 0 {
@@ -87,6 +88,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 			"readonly":     strconv.FormatBool(*readonly),
 			"format":       *format,
 			"cmdstarttime": *cmdStartTime,
+			"ignore-errs":  strconv.FormatBool(*ignoreErrors),
 		})
 		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/replay", reader)
 		if err != nil {

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -101,6 +101,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 	cfg.Password = c.PostForm("password")
 	cfg.Format = c.PostForm("format")
 	cfg.ReadOnly = strings.EqualFold(c.PostForm("readonly"), "true")
+	cfg.IgnoreErrs = strings.EqualFold(c.PostForm("ignore-errs"), "true")
 	cfg.KeyFile = globalCfg.Security.EncryptionKeyPath
 	// By default, if `cmdstarttime` is not specified, use zero time
 	if cmdStartTimeStr := c.PostForm("cmdstarttime"); cmdStartTimeStr != "" {

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -130,9 +130,13 @@ func newMockNormalLoader() *mockNormalLoader {
 	return &mockNormalLoader{}
 }
 
-func (m *mockNormalLoader) writeCommand(command *cmd.Command) {
-	encoder := cmd.NewCmdEncoder(cmd.FormatNative)
+func (m *mockNormalLoader) writeCommand(command *cmd.Command, format string) {
+	encoder := cmd.NewCmdEncoder(format)
 	_ = encoder.Encode(command, &m.buf)
+}
+
+func (m *mockNormalLoader) write(data []byte) {
+	_, _ = m.buf.Write(data)
 }
 
 func (m *mockNormalLoader) Read(data []byte) (string, int, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #889 

Problem Summary:
Ignore decode errors so that it's more robust.

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
