### PR TITLE
replay: implement a buffered asynchronous decoder

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -45,6 +45,7 @@ func main() {
 	logFile := rootCmd.PersistentFlags().String("log-file", "", "the output log file")
 	cmdStartTime := rootCmd.PersistentFlags().Time("command-start-time", time.Time{}, []string{time.RFC3339, time.RFC3339Nano}, "the start time to replay the traffic, format is RFC3339. The command before this start time will be ignored.")
 	ignoreErrs := rootCmd.PersistentFlags().Bool("ignore-errs", false, "ignore errors when replaying")
+	bufSize := rootCmd.PersistentFlags().Int("bufsize", 100000, "the size of buffer for reordering commands from audit files. 0 means no buffering.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		replayCfg := replay.ReplayConfig{
@@ -57,6 +58,7 @@ func main() {
 			StartTime:        time.Now(),
 			CommandStartTime: *cmdStartTime,
 			IgnoreErrs:       *ignoreErrs,
+			BufSize:          *bufSize,
 		}
 
 		r := &replayer{}

--- a/lib/cli/traffic.go
+++ b/lib/cli/traffic.go
@@ -66,6 +66,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 	format := replayCmd.PersistentFlags().String("format", "", "the format of traffic files")
 	cmdStartTime := replayCmd.PersistentFlags().String("command-start-time", "", "the start time to replay the traffic, format is RFC3339 or RFC3339Nano. The command before this start time will be ignored.")
 	ignoreErrors := replayCmd.PersistentFlags().Bool("ignore-errs", false, "ignore errors when replaying")
+	bufSize := replayCmd.PersistentFlags().Int("bufsize", 100000, "the size of buffer for reordering commands from audit files. 0 means no buffering.")
 	replayCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		username := *username
 		if len(username) == 0 {
@@ -89,6 +90,7 @@ func GetTrafficReplayCmd(ctx *Context) *cobra.Command {
 			"format":       *format,
 			"cmdstarttime": *cmdStartTime,
 			"ignore-errs":  strconv.FormatBool(*ignoreErrors),
+			"bufsize":      strconv.Itoa(*bufSize),
 		})
 		resp, err := doRequest(cmd.Context(), ctx, http.MethodPost, "/api/traffic/replay", reader)
 		if err != nil {

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -115,6 +115,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 		}
 		cfg.CommandStartTime = cmdStartTime
 	}
+	cfg.BufSize, _ = strconv.Atoi(c.PostForm("bufsize"))
 
 	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())

--- a/pkg/sqlreplay/replay/buf_decoder.go
+++ b/pkg/sqlreplay/replay/buf_decoder.go
@@ -1,0 +1,139 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+)
+
+type closableDecoder interface {
+	decoder
+	Close()
+}
+
+var _ decoder = (*bufferedDecoder)(nil)
+
+// bufferedDecoder is a decoder that buffers commands from another decoder.
+// The returned commands are ordered by StartTs, but the order is not strictly
+// guaranteed if the `reorder` happens longer than the buffer size.
+type bufferedDecoder struct {
+	decoder decoder
+
+	bufSize int
+	buf     heap.Interface
+
+	cond   *sync.Cond
+	mu     *sync.Mutex
+	err    error
+	ctx    context.Context
+	cancel func()
+}
+
+func newBufferedDecoder(ctx context.Context, decoder decoder, bufSize int) *bufferedDecoder {
+	ctx, cancel := context.WithCancel(ctx)
+	buf := make(cmdQueue, 0, bufSize)
+	mu := &sync.Mutex{}
+	bufferedDecoder := &bufferedDecoder{
+		decoder: decoder,
+		bufSize: bufSize,
+		buf:     &buf,
+		cond:    sync.NewCond(mu),
+		mu:      mu,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	go bufferedDecoder.fillBuffer()
+	go func() {
+		<-ctx.Done()
+		bufferedDecoder.cond.Broadcast()
+	}()
+	return bufferedDecoder
+}
+
+func (d *bufferedDecoder) fillBuffer() {
+	for {
+		cmd, err := d.decoder.Decode()
+		if err != nil {
+			d.mu.Lock()
+			d.err = err
+			d.cond.Signal()
+			d.mu.Unlock()
+			return
+		}
+
+		d.mu.Lock()
+		for d.buf.Len() >= d.bufSize && d.ctx.Err() == nil {
+			d.cond.Wait()
+		}
+
+		if d.ctx.Err() != nil {
+			d.mu.Unlock()
+			return
+		}
+
+		heap.Push(d.buf, cmd)
+		d.cond.Signal()
+		d.mu.Unlock()
+	}
+}
+
+// Decode returns the command with the smallest StartTS from the buffer.
+func (d *bufferedDecoder) Decode() (*cmd.Command, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for d.buf.Len() == 0 && d.err == nil && d.ctx.Err() == nil {
+		d.cond.Wait()
+	}
+
+	// Then either there is at least one command in the buffer, or an error occurred.
+	if d.ctx.Err() != nil {
+		return nil, d.ctx.Err()
+	}
+
+	if d.buf.Len() > 0 {
+		cmd := heap.Pop(d.buf).(*cmd.Command)
+		d.cond.Signal()
+		return cmd, nil
+	}
+
+	return nil, d.err
+}
+
+func (d *bufferedDecoder) Close() {
+	d.cancel()
+}
+
+type cmdQueue []*cmd.Command
+
+func (cq cmdQueue) Len() int { return len(cq) }
+
+func (cq cmdQueue) Less(i, j int) bool {
+	return cq[i].StartTs.Before(cq[j].StartTs)
+}
+
+func (cq cmdQueue) Swap(i, j int) {
+	cq[i], cq[j] = cq[j], cq[i]
+}
+
+func (cq *cmdQueue) Push(x any) {
+	*cq = append(*cq, x.(*cmd.Command))
+}
+
+func (cq *cmdQueue) Pop() any {
+	length := len(*cq)
+	if length == 0 {
+		return nil
+	}
+
+	item := (*cq)[length-1]
+	(*cq)[length-1] = nil
+	*cq = (*cq)[0 : length-1]
+	return item
+}

--- a/pkg/sqlreplay/replay/buf_decoder_test.go
+++ b/pkg/sqlreplay/replay/buf_decoder_test.go
@@ -1,0 +1,353 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSlowDecoder simulates a decoder with configurable delays
+type mockSlowDecoder struct {
+	commands []*cmd.Command
+	index    int
+	delay    time.Duration
+	mu       sync.Mutex
+}
+
+func newMockSlowDecoder(commands []*cmd.Command, delay time.Duration) *mockSlowDecoder {
+	return &mockSlowDecoder{
+		commands: commands,
+		index:    0,
+		delay:    delay,
+	}
+}
+
+func (d *mockSlowDecoder) Decode() (*cmd.Command, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.delay > 0 {
+		time.Sleep(d.delay)
+	}
+
+	if d.index >= len(d.commands) {
+		return nil, io.EOF
+	}
+
+	cmd := d.commands[d.index]
+	d.index++
+	return cmd, nil
+}
+
+// mockErrorDecoder returns an error after a specified number of commands
+type mockErrorDecoder struct {
+	commands   []*cmd.Command
+	index      int
+	errorAfter int
+	testError  error
+}
+
+func newMockErrorDecoder(commands []*cmd.Command, errorAfter int, err error) *mockErrorDecoder {
+	return &mockErrorDecoder{
+		commands:   commands,
+		index:      0,
+		errorAfter: errorAfter,
+		testError:  err,
+	}
+}
+
+func (d *mockErrorDecoder) Decode() (*cmd.Command, error) {
+	if d.index >= d.errorAfter {
+		return nil, d.testError
+	}
+
+	if d.index >= len(d.commands) {
+		return nil, io.EOF
+	}
+
+	cmd := d.commands[d.index]
+	d.index++
+	return cmd, nil
+}
+
+func TestBufferedDecoderBasicFunctionality(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(20 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(30 * time.Millisecond)},
+	}
+
+	mockDec := newMockDecoder(commands)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, mockDec, 5)
+	defer bufDec.Close()
+
+	for i, expected := range commands {
+		cmd, err := bufDec.Decode()
+		require.NoError(t, err, "decode %d", i)
+		require.Equal(t, expected.ConnID, cmd.ConnID, "decode %d", i)
+		require.Equal(t, expected.StartTs, cmd.StartTs, "decode %d", i)
+	}
+
+	_, err := bufDec.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestBufferedDecoderAsyncFilling(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(20 * time.Millisecond)},
+		{ConnID: 1, StartTs: now.Add(30 * time.Millisecond)},
+	}
+
+	slowDec := newMockSlowDecoder(commands, 50*time.Millisecond)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, slowDec, 2)
+	defer bufDec.Close()
+
+	start := time.Now()
+	cmd1, err := bufDec.Decode()
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, commands[0].ConnID, cmd1.ConnID)
+	require.Less(t, elapsed, 100*time.Millisecond)
+}
+
+func TestBufferedDecoderBufferSizeLimit(t *testing.T) {
+	now := time.Now()
+	commands := make([]*cmd.Command, 10)
+	for i := range commands {
+		commands[i] = &cmd.Command{
+			ConnID:  uint64(i + 1),
+			StartTs: now.Add(time.Duration(i*10) * time.Millisecond),
+		}
+	}
+
+	fastDec := newMockSlowDecoder(commands, 1*time.Millisecond)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, fastDec, 3)
+	defer bufDec.Close()
+
+	for i := 0; i < 3; i++ {
+		cmd, err := bufDec.Decode()
+		require.NoError(t, err)
+		require.Equal(t, uint64(i+1), cmd.ConnID)
+	}
+
+	for i := 3; i < 10; i++ {
+		cmd, err := bufDec.Decode()
+		require.NoError(t, err)
+		require.Equal(t, uint64(i+1), cmd.ConnID)
+	}
+
+	_, err := bufDec.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestBufferedDecoderBlockingBehavior(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+	}
+
+	slowDec := newMockSlowDecoder(commands, 200*time.Millisecond)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, slowDec, 1)
+	defer bufDec.Close()
+
+	start := time.Now()
+	cmd, err := bufDec.Decode()
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Equal(t, commands[0].ConnID, cmd.ConnID)
+	require.GreaterOrEqual(t, elapsed, 150*time.Millisecond)
+}
+
+func TestBufferedDecoderOrdering(t *testing.T) {
+	now := time.Now()
+
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(30 * time.Millisecond)},
+		{ConnID: 2, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 3, StartTs: now.Add(20 * time.Millisecond)},
+		{ConnID: 4, StartTs: now.Add(40 * time.Millisecond)},
+		{ConnID: 5, StartTs: now.Add(5 * time.Millisecond)},
+	}
+
+	mockDec := newMockDecoder(commands)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, mockDec, 10)
+	defer bufDec.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	expectedOrder := []uint64{5, 2, 3, 1, 4}
+	expectedTimes := []time.Time{
+		now.Add(5 * time.Millisecond),
+		now.Add(10 * time.Millisecond),
+		now.Add(20 * time.Millisecond),
+		now.Add(30 * time.Millisecond),
+		now.Add(40 * time.Millisecond),
+	}
+
+	for i, expectedConnID := range expectedOrder {
+		cmd, err := bufDec.Decode()
+		require.NoError(t, err, "decode %d", i)
+		require.Equal(t, expectedConnID, cmd.ConnID, "decode %d", i)
+		require.Equal(t, expectedTimes[i], cmd.StartTs, "decode %d", i)
+	}
+
+	_, err := bufDec.Decode()
+	require.Equal(t, io.EOF, err)
+}
+
+func TestBufferedDecoderErrorPropagation(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+		{ConnID: 2, StartTs: now.Add(20 * time.Millisecond)},
+	}
+
+	testErr := errors.New("test decoder error")
+	errDec := newMockErrorDecoder(commands, 1, testErr)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, errDec, 5)
+	defer bufDec.Close()
+
+	// First command should succeed
+	cmd, err := bufDec.Decode()
+	require.NoError(t, err)
+	require.Equal(t, commands[0].ConnID, cmd.ConnID)
+
+	// Second decode should return the error
+	_, err = bufDec.Decode()
+	require.Equal(t, testErr, err)
+
+	// Subsequent calls should also return the same error
+	_, err = bufDec.Decode()
+	require.Equal(t, testErr, err)
+}
+
+func TestBufferedDecoderImmediateError(t *testing.T) {
+	testErr := errors.New("immediate error")
+	errDec := newMockErrorDecoder([]*cmd.Command{}, 0, testErr)
+	ctx := context.Background()
+	bufDec := newBufferedDecoder(ctx, errDec, 5)
+	defer bufDec.Close()
+
+	_, err := bufDec.Decode()
+	require.Equal(t, testErr, err)
+}
+
+func TestBufferedDecoderContextCancellation(t *testing.T) {
+	now := time.Now()
+	commands := make([]*cmd.Command, 10)
+	for i := range commands {
+		commands[i] = &cmd.Command{
+			ConnID:  uint64(i + 1),
+			StartTs: now.Add(time.Duration(i*10) * time.Millisecond),
+		}
+	}
+
+	slowDec := newMockSlowDecoder(commands, time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	bufDec := newBufferedDecoder(ctx, slowDec, 5)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := bufDec.Decode()
+		require.Error(t, err)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Decode operation did not respond to context cancellation")
+	}
+}
+
+func TestBufferedDecoderContextCancellationBeforeStart(t *testing.T) {
+	now := time.Now()
+	commands := []*cmd.Command{
+		{ConnID: 1, StartTs: now.Add(10 * time.Millisecond)},
+	}
+
+	mockDec := newMockDecoder(commands)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cancel()
+
+	bufDec := newBufferedDecoder(ctx, mockDec, 5)
+	defer bufDec.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	_, err := bufDec.Decode()
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 100*time.Millisecond)
+	require.Error(t, err)
+}
+
+type randomStartTsDecoder struct {
+	now    time.Time
+	connID uint64
+}
+
+func (d *randomStartTsDecoder) Decode() (*cmd.Command, error) {
+	cmd := &cmd.Command{
+		ConnID:  d.connID,
+		StartTs: d.now.Add(time.Duration(rand.Intn(1000)) * time.Millisecond),
+	}
+	return cmd, nil
+}
+
+func BenchmarkBufferedDecoder(b *testing.B) {
+	bufferSizes := []int{0, 1, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000}
+
+	for _, bufSize := range bufferSizes {
+		b.Run(fmt.Sprintf("BufSize%d", bufSize), func(b *testing.B) {
+			ctx := context.Background()
+			var dec decoder
+			dec = &randomStartTsDecoder{
+				now:    time.Now(),
+				connID: 1,
+			}
+			if bufSize > 0 {
+				dec = newBufferedDecoder(ctx, dec, bufSize)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := dec.Decode()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			if closable, ok := dec.(closableDecoder); ok {
+				closable.Close()
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #888

Problem Summary:

The commands may out of order if it's consumed one-by-one. This PR used a heap to order them and also work as a buffer.

```
BenchmarkBufferedDecoder/BufSize0-24         	29355400	        40.74 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize1-24         	 4793107	       248.7 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize10-24        	10880355	       108.3 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize50-24        	 9806090	       115.7 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize100-24       	 9282368	       126.9 ns/op	     159 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize500-24       	 7030334	       148.6 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize1000-24      	 6390556	       164.9 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize5000-24      	 6342470	       182.0 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize10000-24     	 6216324	       191.8 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize50000-24     	 5896324	       179.7 ns/op	     160 B/op	       1 allocs/op
BenchmarkBufferedDecoder/BufSize100000-24    	 6549610	       183.0 ns/op	     160 B/op	       1 allocs/op
```

What is changed and how it works:

I gave the default value 100000, as tested in benchmark the result looks good.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
