### PR TITLE
replay: remove the sort/heap logic in buffer logic, use FIFO buffer instead

### DIFF
--- a/pkg/sqlreplay/replay/buf_decoder.go
+++ b/pkg/sqlreplay/replay/buf_decoder.go
@@ -4,17 +4,10 @@
 package replay
 
 import (
-	"container/heap"
 	"context"
-	"sync"
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 )
-
-type closableDecoder interface {
-	decoder
-	Close()
-}
 
 var _ decoder = (*bufferedDecoder)(nil)
 
@@ -24,116 +17,54 @@ var _ decoder = (*bufferedDecoder)(nil)
 type bufferedDecoder struct {
 	decoder decoder
 
-	bufSize int
-	buf     heap.Interface
+	ctx context.Context
+	ch  chan *cmd.Command
 
-	cond   *sync.Cond
-	mu     *sync.Mutex
-	err    error
-	ctx    context.Context
-	cancel func()
+	err error
 }
 
 func newBufferedDecoder(ctx context.Context, decoder decoder, bufSize int) *bufferedDecoder {
-	ctx, cancel := context.WithCancel(ctx)
-	buf := make(cmdQueue, 0, bufSize)
-	mu := &sync.Mutex{}
 	bufferedDecoder := &bufferedDecoder{
 		decoder: decoder,
-		bufSize: bufSize,
-		buf:     &buf,
-		cond:    sync.NewCond(mu),
-		mu:      mu,
 		ctx:     ctx,
-		cancel:  cancel,
+		ch:      make(chan *cmd.Command, bufSize),
 	}
 
 	go bufferedDecoder.fillBuffer()
-	go func() {
-		<-ctx.Done()
-		bufferedDecoder.cond.Broadcast()
-	}()
 	return bufferedDecoder
 }
 
 func (d *bufferedDecoder) fillBuffer() {
+	defer close(d.ch)
+
 	for {
 		cmd, err := d.decoder.Decode()
 		if err != nil {
-			d.mu.Lock()
 			d.err = err
-			d.cond.Signal()
-			d.mu.Unlock()
 			return
 		}
 
-		d.mu.Lock()
-		for d.buf.Len() >= d.bufSize && d.ctx.Err() == nil {
-			d.cond.Wait()
-		}
-
-		if d.ctx.Err() != nil {
-			d.mu.Unlock()
+		select {
+		case d.ch <- cmd:
+		case <-d.ctx.Done():
 			return
 		}
-
-		heap.Push(d.buf, cmd)
-		d.cond.Signal()
-		d.mu.Unlock()
 	}
 }
 
 // Decode returns the command with the smallest StartTS from the buffer.
 func (d *bufferedDecoder) Decode() (*cmd.Command, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	for d.buf.Len() == 0 && d.err == nil && d.ctx.Err() == nil {
-		d.cond.Wait()
-	}
-
-	// Then either there is at least one command in the buffer, or an error occurred.
-	if d.ctx.Err() != nil {
+	select {
+	case cmd := <-d.ch:
+		if cmd == nil {
+			// The `fillBuffer` goroutine should have exited, reading `d.err` is safe here.
+			if d.err == nil {
+				return nil, d.ctx.Err()
+			}
+			return nil, d.err
+		}
+		return cmd, nil
+	case <-d.ctx.Done():
 		return nil, d.ctx.Err()
 	}
-
-	if d.buf.Len() > 0 {
-		cmd := heap.Pop(d.buf).(*cmd.Command)
-		d.cond.Signal()
-		return cmd, nil
-	}
-
-	return nil, d.err
-}
-
-func (d *bufferedDecoder) Close() {
-	d.cancel()
-}
-
-type cmdQueue []*cmd.Command
-
-func (cq cmdQueue) Len() int { return len(cq) }
-
-func (cq cmdQueue) Less(i, j int) bool {
-	return cq[i].StartTs.Before(cq[j].StartTs)
-}
-
-func (cq cmdQueue) Swap(i, j int) {
-	cq[i], cq[j] = cq[j], cq[i]
-}
-
-func (cq *cmdQueue) Push(x any) {
-	*cq = append(*cq, x.(*cmd.Command))
-}
-
-func (cq *cmdQueue) Pop() any {
-	length := len(*cq)
-	if length == 0 {
-		return nil
-	}
-
-	item := (*cq)[length-1]
-	(*cq)[length-1] = nil
-	*cq = (*cq)[0 : length-1]
-	return item
 }

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -240,9 +240,6 @@ func (r *replay) readCommands(ctx context.Context) {
 		r.stop(err)
 		return
 	}
-	if c, ok := decoder.(closableDecoder); ok {
-		defer c.Close()
-	}
 
 	var captureStartTs, replayStartTs time.Time
 	conns := make(map[uint64]conn.Conn) // both alive and dead connections


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #894

Problem Summary:

There are two issues in the process:
1. The PREPARE/EXECUTE may be re-ordered. This PR used an index to make sure when the commands have the same `StartTs`, they will be placed in order.
2. The `use xxx` may be re-ordered. This PR adds an extra decoder to add `use xxx`  automatically to solve this issue.

Let's remove the re-ordering logic, use FIFO directly.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
