### PR TITLE
store: fix the timezone issue in parsing file name

### DIFF
--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -292,7 +292,10 @@ func parseFileTime(name, fileNamePrefix string) time.Time {
 		return time.Time{}
 	}
 	endIdx -= len(fileNameSuffix)
-	ts, err := time.Parse(logTimeLayout, name[startIdx:endIdx])
+	// The `TimeZone` part is not included in the audit log file name, so we use the `time.Local` here.
+	// It's always possible to workaround it by adjusting the commandStartTime, so just using `time.Local`
+	// here is acceptable. Using the timezone from `commandStartTime` is another option, but it's a bit tricky.
+	ts, err := time.ParseInLocation(logTimeLayout, name[startIdx:endIdx], time.Local)
 	if err != nil {
 		return time.Time{}
 	}

--- a/pkg/sqlreplay/store/rotate_test.go
+++ b/pkg/sqlreplay/store/rotate_test.go
@@ -123,13 +123,16 @@ func TestParseFileIdx(t *testing.T) {
 }
 
 func TestParseFileTime(t *testing.T) {
+	// Calculate the current timezone shift
+	_, offset := time.Now().Zone()
+
 	tests := []struct {
 		fileName string
 		fileIdx  int64
 	}{
-		{"tidb-audit-2025-09-10T17-01-56.073.log", 1757523716073},
-		{"tidb-audit-2025-09-10T17-01-56.172.log.gz", 1757523716172},
-		{"tidb-audit-2025-09-10T17-01-56.log.gz", 1757523716000},
+		{"tidb-audit-2025-09-10T17-01-56.073.log", 1757523716073 - int64(offset*1000)},
+		{"tidb-audit-2025-09-10T17-01-56.172.log.gz", 1757523716172 - int64(offset*1000)},
+		{"tidb-audit-2025-09-10T17-01-56.log.gz", 1757523716000 - int64(offset*1000)},
 		{"traffic-2025-09-10T17-01-56.172.log", 0},
 		{"traffic-2025-09-10T17-01-56.172.log.gz", 0},
 		{"tidb-audit-.log", 0},
@@ -370,7 +373,7 @@ func TestCompressAndEncrypt(t *testing.T) {
 }
 
 func TestFilterFileNameByStartTime(t *testing.T) {
-	commandStartTime, err := time.Parse(logTimeLayout, "2025-09-10T17-01-56.050")
+	commandStartTime, err := time.ParseInLocation(logTimeLayout, "2025-09-10T17-01-56.050", time.Local)
 	require.NoError(t, err)
 	tests := []struct {
 		fileName        string


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #893 

Problem Summary:

The filename should be parsed in `Local` timezone. It's more intuitive to use.

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
