### PR TITLE
replay: each sub decoder uses their own goroutine to decode

### DIFF
--- a/pkg/sqlreplay/replay/buf_decoder_test.go
+++ b/pkg/sqlreplay/replay/buf_decoder_test.go
@@ -91,7 +91,7 @@ func TestBufferedDecoderBasicFunctionality(t *testing.T) {
 
 	mockDec := newMockDecoder(commands)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, mockDec, 5)
+	bufDec := newBufferedDecoder(ctx, mockDec, 5, false)
 
 	for i, expected := range commands {
 		cmd, err := bufDec.Decode()
@@ -114,7 +114,7 @@ func TestBufferedDecoderAsyncFilling(t *testing.T) {
 
 	slowDec := newMockSlowDecoder(commands, 50*time.Millisecond)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, slowDec, 2)
+	bufDec := newBufferedDecoder(ctx, slowDec, 2, false)
 
 	start := time.Now()
 	cmd1, err := bufDec.Decode()
@@ -137,7 +137,7 @@ func TestBufferedDecoderBufferSizeLimit(t *testing.T) {
 
 	fastDec := newMockSlowDecoder(commands, 1*time.Millisecond)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, fastDec, 3)
+	bufDec := newBufferedDecoder(ctx, fastDec, 3, false)
 
 	for i := 0; i < 3; i++ {
 		cmd, err := bufDec.Decode()
@@ -163,7 +163,7 @@ func TestBufferedDecoderBlockingBehavior(t *testing.T) {
 
 	slowDec := newMockSlowDecoder(commands, 200*time.Millisecond)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, slowDec, 1)
+	bufDec := newBufferedDecoder(ctx, slowDec, 1, false)
 
 	start := time.Now()
 	cmd, err := bufDec.Decode()
@@ -184,7 +184,7 @@ func TestBufferedDecoderErrorPropagation(t *testing.T) {
 	testErr := errors.New("test decoder error")
 	errDec := newMockErrorDecoder(commands, 1, testErr)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, errDec, 5)
+	bufDec := newBufferedDecoder(ctx, errDec, 5, false)
 
 	// First command should succeed
 	cmd, err := bufDec.Decode()
@@ -204,7 +204,7 @@ func TestBufferedDecoderImmediateError(t *testing.T) {
 	testErr := errors.New("immediate error")
 	errDec := newMockErrorDecoder([]*cmd.Command{}, 0, testErr)
 	ctx := context.Background()
-	bufDec := newBufferedDecoder(ctx, errDec, 5)
+	bufDec := newBufferedDecoder(ctx, errDec, 5, false)
 
 	_, err := bufDec.Decode()
 	require.Equal(t, testErr, err)
@@ -222,7 +222,7 @@ func TestBufferedDecoderContextCancellation(t *testing.T) {
 
 	slowDec := newMockSlowDecoder(commands, time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
-	bufDec := newBufferedDecoder(ctx, slowDec, 5)
+	bufDec := newBufferedDecoder(ctx, slowDec, 5, false)
 
 	done := make(chan struct{})
 	go func() {
@@ -252,7 +252,7 @@ func TestBufferedDecoderContextCancellationBeforeStart(t *testing.T) {
 
 	cancel()
 
-	bufDec := newBufferedDecoder(ctx, mockDec, 5)
+	bufDec := newBufferedDecoder(ctx, mockDec, 5, false)
 
 	time.Sleep(50 * time.Millisecond)
 
@@ -289,7 +289,7 @@ func BenchmarkBufferedDecoder(b *testing.B) {
 				connID: 1,
 			}
 			if bufSize > 0 {
-				dec = newBufferedDecoder(ctx, dec, bufSize)
+				dec = newBufferedDecoder(ctx, dec, bufSize, false)
 			}
 
 			b.ResetTimer()

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -189,3 +189,25 @@ func (mr *mockReport) Stop(err error) {
 
 func (mr *mockReport) Close() {
 }
+
+// endlessReader always returns the same line.
+// The `Read` implementations is not correct, so use it only with audit log format.
+type endlessReader struct {
+	line string
+}
+
+func (er *endlessReader) ReadLine() ([]byte, string, int, error) {
+	return []byte(er.line), "", 0, nil
+}
+
+func (er *endlessReader) Read(data []byte) (string, int, error) {
+	n := copy(data, []byte(er.line))
+	return "", n, nil
+}
+
+func (er *endlessReader) Close() {
+}
+
+func (er *endlessReader) String() string {
+	return "endlessReader"
+}

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -39,6 +39,12 @@ const (
 	maxSpeed       = 10.0
 )
 
+var (
+	// chanBufForEachDecoder is the buffer size for each reader's channel. If it's set to -1,
+	// it'll use synchronized implementation for each reader.
+	chanBufForEachDecoder = 64
+)
+
 type Replay interface {
 	// Start starts the replay
 	Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler backend.HandshakeHandler, bcConfig *backend.BCConfig) error
@@ -332,7 +338,7 @@ func (r *replay) readCommands(ctx context.Context) {
 	r.stop(err)
 }
 
-func (r *replay) constructMergeDecoders(readers []cmd.LineReader) (decoder, error) {
+func (r *replay) constructMergeDecoders(ctx context.Context, readers []cmd.LineReader) (decoder, error) {
 	var decoders []decoder
 	for _, reader := range readers {
 		cmdDecoder := cmd.NewCmdDecoder(r.cfg.Format)
@@ -341,7 +347,13 @@ func (r *replay) constructMergeDecoders(readers []cmd.LineReader) (decoder, erro
 		// impossible for decoder to know whether `use xxx` will be executed, and thus cannot maintain
 		// the current session state correctly.
 		cmdDecoder.SetCommandStartTime(r.cfg.CommandStartTime)
-		decoders = append(decoders, newSingleDecoder(cmdDecoder, reader))
+
+		var decoder decoder
+		decoder = newSingleDecoder(cmdDecoder, reader)
+		if chanBufForEachDecoder >= 0 {
+			decoder = newBufferedDecoder(ctx, decoder, chanBufForEachDecoder, r.cfg.IgnoreErrs)
+		}
+		decoders = append(decoders, decoder)
 	}
 	if len(decoders) == 0 {
 		return nil, errors.New("no decoder")
@@ -354,13 +366,13 @@ func (r *replay) constructMergeDecoders(readers []cmd.LineReader) (decoder, erro
 }
 
 func (r *replay) constructDecoder(ctx context.Context, readers []cmd.LineReader) (decoder, error) {
-	decoder, err := r.constructMergeDecoders(readers)
+	decoder, err := r.constructMergeDecoders(ctx, readers)
 	if err != nil {
 		return nil, err
 	}
 
 	if r.cfg.BufSize > 0 {
-		decoder = newBufferedDecoder(ctx, decoder, r.cfg.BufSize)
+		decoder = newBufferedDecoder(ctx, decoder, r.cfg.BufSize, r.cfg.IgnoreErrs)
 	}
 	return decoder, nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #898

Problem Summary:

Add a `bufferedDecoder` for each sub readers, so that they can be read in different goroutines. But in pure CPU scenario, the performance doesn't have big difference, but it may have improvement for reading S3 (but not sure).

```

goos: linux
goarch: amd64
pkg: github.com/pingcap/tiproxy/pkg/sqlreplay/replay
cpu: AMD Ryzen 9 9900X 12-Core Processor            
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount1-24         	  698106	      1666 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount2-24         	  682191	      1731 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount4-24         	  650468	      1801 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount8-24         	  667599	      1766 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount16-24        	  725595	      1669 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize-1/ReaderCount32-24        	  666027	      1772 ns/op	    3025 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount1-24          	  594332	      1701 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount2-24          	  589702	      1716 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount4-24          	  618633	      1700 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount8-24          	  629616	      1660 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount16-24         	  660014	      1642 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize0/ReaderCount32-24         	  729428	      1650 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount1-24          	  656992	      1658 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount2-24          	  689806	      1674 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount4-24          	  653821	      1668 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount8-24          	  675820	      1673 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount16-24         	  656260	      1690 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize1/ReaderCount32-24         	  635378	      1685 ns/op	    3025 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount1-24          	  743311	      1633 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount2-24          	  736365	      1653 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount4-24          	  719229	      1667 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount8-24          	  683718	      1656 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount16-24         	  681998	      1639 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize2/ReaderCount32-24         	  623446	      1653 ns/op	    3025 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount1-24          	  687133	      1636 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount2-24          	  694894	      1613 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount4-24          	  715995	      1641 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount8-24          	  695145	      1643 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount16-24         	  678380	      1674 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize4/ReaderCount32-24         	  667362	      1653 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount1-24          	  759505	      1624 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount2-24          	  687255	      1651 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount4-24          	  715004	      1631 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount8-24          	  752504	      1616 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount16-24         	  700501	      1622 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize8/ReaderCount32-24         	  708728	      1630 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount1-24         	  718428	      1629 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount2-24         	  712011	      1653 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount4-24         	  688293	      1690 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount8-24         	  716642	      1630 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount16-24        	  697894	      1627 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize16/ReaderCount32-24        	  701196	      1626 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount1-24         	  760311	      1616 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount2-24         	  729879	      1608 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount4-24         	  726015	      1603 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount8-24         	  756703	      1639 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount16-24        	  749253	      1649 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize32/ReaderCount32-24        	  726226	      1626 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount1-24         	  756985	      1624 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount2-24         	  722805	      1657 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount4-24         	  741176	      1691 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount8-24         	  735118	      1641 ns/op	    3018 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount16-24        	  740056	      1638 ns/op	    3019 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize64/ReaderCount32-24        	  743408	      1640 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount1-24        	  741956	      1607 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount2-24        	  752956	      1646 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount4-24        	  707613	      1610 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount8-24        	  739046	      1631 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount16-24       	  724792	      1616 ns/op	    3019 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize128/ReaderCount32-24       	  697516	      1633 ns/op	    3024 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount1-24        	  729441	      1644 ns/op	    3015 B/op	      16 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount2-24        	  739042	      1641 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount4-24        	  781234	      1636 ns/op	    3016 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount8-24        	  768552	      1611 ns/op	    3017 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount16-24       	  680514	      1638 ns/op	    3020 B/op	      17 allocs/op
BenchmarkMultiBufferedDecoder/BufSize256/ReaderCount32-24       	  709044	      1652 ns/op	    3024 B/op	      17 allocs/op
```

I personally think I should work on improving `parseLog`. It may have more significant change.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
