### PR TITLE
sqlreplay: add logs for replay progress

### DIFF
--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -31,12 +31,21 @@ type ReplayStats struct {
 	PendingCmds atomic.Int64
 	// FilteredCmds is the number of filtered commands.
 	FilteredCmds atomic.Uint64
+	// TotalWaitTime is the total wait time of all commands.
+	TotalWaitTime atomic.Int64
+	// The timestamp of the first command.
+	FirstCmdTs atomic.Int64
+	// The current decoded command timestamp.
+	CurCmdTs atomic.Int64
 }
 
 func (s *ReplayStats) Reset() {
 	s.ReplayedCmds.Store(0)
 	s.PendingCmds.Store(0)
 	s.FilteredCmds.Store(0)
+	s.TotalWaitTime.Store(0)
+	s.FirstCmdTs.Store(0)
+	s.CurCmdTs.Store(0)
 }
 
 type Conn interface {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -34,9 +34,10 @@ const (
 	// slowDownFactor is the factor to slow down when there are too many pending commands.
 	slowDownFactor = 100 * time.Nanosecond
 	// abortThreshold is the threshold of pending commands to abort.
-	abortThreshold = 1 << 21
-	minSpeed       = 0.1
-	maxSpeed       = 10.0
+	abortThreshold    = 1 << 21
+	minSpeed          = 0.1
+	maxSpeed          = 10.0
+	reportLogInterval = time.Second
 )
 
 type Replay interface {
@@ -79,6 +80,7 @@ type ReplayConfig struct {
 	abortThreshold    int64
 	slowDownThreshold int64
 	slowDownFactor    time.Duration
+	reportLogInterval time.Duration
 }
 
 func (cfg *ReplayConfig) Validate() ([]storage.ExternalStorage, error) {
@@ -132,6 +134,9 @@ func (cfg *ReplayConfig) Validate() ([]storage.ExternalStorage, error) {
 	}
 	if cfg.slowDownFactor == 0 {
 		cfg.slowDownFactor = slowDownFactor
+	}
+	if cfg.reportLogInterval == 0 {
+		cfg.reportLogInterval = reportLogInterval
 	}
 	return storages, nil
 }
@@ -220,6 +225,9 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.wg.RunWithRecover(func() {
 		r.readCommands(childCtx)
 	}, nil, r.lg)
+	r.wg.RunWithRecover(func() {
+		r.reportLoop(childCtx)
+	}, nil, r.lg)
 	return nil
 }
 
@@ -245,7 +253,7 @@ func (r *replay) readCommands(ctx context.Context) {
 	conns := make(map[uint64]conn.Conn) // both alive and dead connections
 	connCount := 0                      // alive connection count
 	maxPendingCmds := int64(0)
-	totalWaitTime := time.Duration(0)
+	extraWaitTime := time.Duration(0)
 	for ctx.Err() == nil {
 		for hasCloseEvent := true; hasCloseEvent; {
 			select {
@@ -271,10 +279,12 @@ func (r *replay) readCommands(ctx context.Context) {
 				break
 			}
 		}
+		r.replayStats.CurCmdTs.Store(command.StartTs.UnixNano())
 		if captureStartTs.IsZero() {
 			// first command
 			captureStartTs = command.StartTs
 			replayStartTs = time.Now()
+			r.replayStats.FirstCmdTs.Store(command.StartTs.UnixNano())
 		} else {
 			pendingCmds := r.replayStats.PendingCmds.Load()
 			if pendingCmds > maxPendingCmds {
@@ -298,11 +308,12 @@ func (r *replay) readCommands(ctx context.Context) {
 			// If there are too many pending commands, slow it down to reduce memory usage.
 			if pendingCmds > r.cfg.slowDownThreshold {
 				extraWait := time.Duration(pendingCmds-r.cfg.slowDownThreshold) * r.cfg.slowDownFactor
-				totalWaitTime += extraWait
+				extraWaitTime += extraWait
 				expectedInterval += extraWait
-				metrics.ReplayWaitTime.Set(float64(totalWaitTime.Nanoseconds()))
+				metrics.ReplayWaitTime.Set(float64(extraWaitTime.Nanoseconds()))
 			}
 			if expectedInterval > time.Microsecond {
+				r.replayStats.TotalWaitTime.Add(expectedInterval.Nanoseconds())
 				select {
 				case <-ctx.Done():
 				case <-time.After(expectedInterval):
@@ -314,7 +325,7 @@ func (r *replay) readCommands(ctx context.Context) {
 		}
 	}
 	r.lg.Info("finished decoding commands, draining connections", zap.Int64("max_pending_cmds", maxPendingCmds),
-		zap.Duration("total_wait_time", totalWaitTime), zap.Int("alive_conns", connCount))
+		zap.Duration("extra_wait_time", extraWaitTime), zap.Int("alive_conns", connCount))
 
 	// Notify the connections that the commands are finished.
 	for _, conn := range conns {
@@ -437,6 +448,31 @@ func (r *replay) readMeta() *store.Meta {
 		}
 	}
 	return m
+}
+
+func (r *replay) reportLoop(ctx context.Context) {
+	ticker := time.NewTicker(r.cfg.reportLogInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			replayedCmds := r.replayStats.ReplayedCmds.Load()
+			pendingCmds := r.replayStats.PendingCmds.Load()
+			filteredCmds := r.replayStats.FilteredCmds.Load()
+			decodedCmds := r.decodedCmds.Load()
+			totalWaitTime := time.Duration(r.replayStats.TotalWaitTime.Load())
+			decodeElapsed := r.replayStats.CurCmdTs.Load() - r.replayStats.FirstCmdTs.Load()
+			r.lg.Info("replay progress", zap.Uint64("replayed_cmds", replayedCmds),
+				zap.Int64("pending_cmds", pendingCmds), // if too many, replay is slower than decode
+				zap.Uint64("filtered_cmds", filteredCmds),
+				zap.Uint64("decoded_cmds", decodedCmds),
+				zap.Duration("total_wait_time", totalWaitTime), // if too short, decode is low
+				zap.Duration("replay_elapsed", time.Since(r.startTime)),
+				zap.Duration("decode_elapsed", time.Duration(decodeElapsed))) // if shorter than replay_elapsed, decode is slow
+		}
+	}
 }
 
 func (r *replay) stop(err error) {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -37,7 +37,7 @@ const (
 	abortThreshold    = 1 << 21
 	minSpeed          = 0.1
 	maxSpeed          = 10.0
-	reportLogInterval = time.Second
+	reportLogInterval = 10 * time.Second
 )
 
 type Replay interface {

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -277,8 +277,9 @@ func TestPendingCmds(t *testing.T) {
 	require.True(t, done)
 	require.Contains(t, err.Error(), "too many pending commands")
 	logs := text.String()
-	require.Contains(t, logs, `"total_wait_time": "150ms"`)
+	require.Contains(t, logs, `"extra_wait_time": "150ms"`)
 	require.Contains(t, logs, "too many pending commands")
+	require.Greater(t, replay.replayStats.PendingCmds.Load(), 15)
 }
 
 func TestLoadEncryptionKey(t *testing.T) {

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -279,7 +279,6 @@ func TestPendingCmds(t *testing.T) {
 	logs := text.String()
 	require.Contains(t, logs, `"extra_wait_time": "150ms"`)
 	require.Contains(t, logs, "too many pending commands")
-	require.Greater(t, replay.replayStats.PendingCmds.Load(), 15)
 }
 
 func TestLoadEncryptionKey(t *testing.T) {

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -224,7 +224,7 @@ func (r *rotateReader) nextReader() error {
 	if err != nil {
 		return err
 	}
-	r.lg.Info("reading next file", zap.String("file", minFileName))
+	r.lg.Info("reading next file", zap.String("prefix", r.storage.URI()), zap.String("file", minFileName))
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #904 

Problem Summary:
In the client mode, no metrics are available so we can only add logs

What is changed and how it works:
- Report the status every 10s
- Add the log file directory

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
[2025/09/16 19:09:10.225 +08:00] [INFO] [main.replay.replay] [replay/replay.go:453] [replay progress]  [replayed_cmds=273803] [pending_cmds=201777] [filtered_cmds=0] [decoded_cmds=475580] [total_wait_time=25.658075998s] [replay_elapsed=30.017181333s] [decode_elapsed=29.529031292s]
[2025/09/16 19:09:10.247 +08:00] [INFO] [main.replay.replay.loader] [store/rotate.go:222] [reading next file]  [prefix=file:///Users/zhangming/Downloads/audit] [file=tidb-audit-2025-09-14T19-11-18.766.log]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
