### PR TITLE
server: fix metering data is not written

### DIFF
--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -105,7 +105,7 @@ func (g *Group) Match(clientInfo ClientInfo) bool {
 		}
 		value := addr.String()
 		ipStr, _, err := net.SplitHostPort(value)
-		if err == nil {
+		if err != nil {
 			g.lg.Error("parsing address failed", zap.String("addr", value), zap.Error(err))
 		}
 		ip := net.ParseIP(ipStr)

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -107,6 +107,7 @@ func (g *Group) Match(clientInfo ClientInfo) bool {
 		ipStr, _, err := net.SplitHostPort(value)
 		if err != nil {
 			g.lg.Error("parsing address failed", zap.String("addr", value), zap.Error(err))
+			return false
 		}
 		ip := net.ParseIP(ipStr)
 		if ip == nil {

--- a/pkg/manager/meter/meter.go
+++ b/pkg/manager/meter/meter.go
@@ -79,6 +79,7 @@ func (m *Meter) Start(ctx context.Context) {
 }
 
 func (m *Meter) flushLoop(ctx context.Context) {
+	m.lg.Info("metering is started")
 	// Control the writing timestamp accurately enough so that the previous round won't be overwritten by the next round.
 	curTime := time.Now().Unix()
 	nextTime := curTime/writeInterval*writeInterval + writeInterval

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -176,7 +176,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		if err != nil {
 			return
 		}
-		srv.meter.Start(ctx)
+		if srv.meter != nil {
+			srv.meter.Start(ctx)
+		}
 	}
 
 	// setup proxy server

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -176,6 +176,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		if err != nil {
 			return
 		}
+		srv.meter.Start(ctx)
 	}
 
 	// setup proxy server


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #906 

Problem Summary:
Metering data is not written.

What is changed and how it works:
Start the metering loop

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

smoke test

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
