### PR TITLE
router: fix the cluster_id is wrong in the metering data

### DIFF
--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -172,7 +172,7 @@ func (b *backendWrapper) Keyspace() string {
 	if labels == nil {
 		return ""
 	}
-	return labels[config.LocationLabelName]
+	return labels[config.KeyspaceLabelName]
 }
 
 func (b *backendWrapper) String() string {

--- a/pkg/balance/router/router_test.go
+++ b/pkg/balance/router/router_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiproxy/pkg/balance/observer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendWrapper(t *testing.T) {
+	b := &backendWrapper{}
+	b.mu.BackendHealth = observer.BackendHealth{
+		Healthy:            true,
+		ServerVersion:      "1.0",
+		SupportRedirection: false,
+		Local:              false,
+		BackendInfo: observer.BackendInfo{
+			Labels: map[string]string{
+				"keyspace": "a",
+				"zone":     "b",
+			},
+		},
+	}
+	require.Equal(t, "a", b.Keyspace())
+	require.Equal(t, "1.0", b.ServerVersion())
+	require.True(t, b.Healthy())
+	require.False(t, b.SupportRedirection())
+	require.False(t, b.Local())
+	require.Equal(t, "a", b.GetBackendInfo().Labels["keyspace"])
+	require.Equal(t, "b", b.GetBackendInfo().Labels["zone"])
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #909 

Problem Summary:
The cluster id in metering data should be keyspace but is zone

What is changed and how it works:
Fix the label key

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
