### PR TITLE
store: fix the issue that marker doesn't have path prefix

### DIFF
--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -242,16 +242,16 @@ func (r *rotateReader) walkFile(ctx context.Context, fn func(string, int64) erro
 // many files.
 // Most of the code is copied from storage/s3.go's WalkDir implementation.
 func (r *rotateReader) walkS3ForAuditLogFile(ctx context.Context, s3api s3iface.S3API, options *backuppb.S3, fn func(string, int64) error) error {
-	prefix := options.Prefix
-	if len(prefix) > 0 && !strings.HasSuffix(prefix, "/") {
-		prefix += "/"
+	pathPrefix := options.Prefix
+	if len(pathPrefix) > 0 && !strings.HasSuffix(pathPrefix, "/") {
+		pathPrefix += "/"
 	}
 
-	prefix += getFileNamePrefix(r.cfg.Format)
+	prefix := pathPrefix + getFileNamePrefix(r.cfg.Format)
 
 	var marker string
 	if r.curFileName != "" {
-		marker = r.curFileName
+		marker = pathPrefix + r.curFileName
 	} else if !r.cfg.CommandStartTime.IsZero() {
 		t := r.cfg.CommandStartTime.In(time.Local)
 		marker = fmt.Sprintf("%s%s", prefix, t.Format(logTimeLayout))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #908

Problem Summary:

The `marker` doesn't have prefix after the first iteration.

What is changed and how it works:

Add path prefix for them.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
