### PR TITLE
replay: add more fields to replay logs

### DIFF
--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -31,9 +31,13 @@ type ReplayStats struct {
 	PendingCmds atomic.Int64
 	// FilteredCmds is the number of filtered commands.
 	FilteredCmds atomic.Uint64
-	// TotalWaitTime is the total wait time of all commands.
+	// TotalWaitTime is the total wait time (ns) of all commands.
 	TotalWaitTime atomic.Int64
-	// The timestamp of the first command.
+	// ReplayStartTs is the start time (ns) of replay.
+	ReplayStartTs atomic.Int64
+	// ExtraWaitTime is the extra wait time (ns) of replay.
+	ExtraWaitTime atomic.Int64
+	// The timestamp (ns) of the first command.
 	FirstCmdTs atomic.Int64
 	// The current decoded command timestamp.
 	CurCmdTs atomic.Int64


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #904

Problem Summary:
Add more logs so we can know the bottleneck.

What is changed and how it works:
Added more log fields

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```
[2025/09/17 16:11:40.305 +08:00] [INFO] [main.replay.replay] [replay/replay.go:476] [replay progress]  [replayed_cmds=423974] [pending_cmds=55260] [filtered_cmds=0] [decoded_cmds=479234] [total_wait_time=27.045359264s] [extra_wait_time=0s] [replay_elapsed=50.041051125s] [decode_elapsed=29.763948709s]
[2025/09/17 16:11:46.898 +08:00] [INFO] [main.replay.replay] [replay/replay.go:533] [replay finished]  [start_time=2025-09-17 16:10:50.264865 +0800 CST] [end_time=2025-09-17 16:11:46.898992 +0800 CST] [command_start_time=2025-09-14 19:10:49 +0800 CST] [format=audit_log_plugin] [username=root] [ignore_errs=false] [speed=1] [read_only=false] [decoded_cmds=479234] [replayed_cmds=479234] [filtered_cmds=0] [replay_elapsed=56.63425375s] [decode_elapsed=29.763948709s] [extra_wait_time=0s]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
