### PR TITLE
store: add cache for file name and size

### DIFF
--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -216,12 +216,7 @@ func (r *rotateReader) nextReader() error {
 		return io.EOF
 	}
 	// storage.Open(ctx) stores the context internally for subsequent reads, so don't set a short timeout.
-	fileReader, err := r.storage.Open(context.Background(), minFileName, &storage.ReaderOption{
-		// Add `PrefetchSize` will start a goroutine in the background to prefetch data, which will make
-		// reading asynchronous and improve performance.
-		// 4MB might not be a perfect value, need to tune it in the real world.
-		PrefetchSize: 4 * 1024 * 1024,
-	})
+	fileReader, err := r.storage.Open(context.Background(), minFileName, &storage.ReaderOption{})
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #917

Problem Summary:

What is changed and how it works:

Add a cache for the S3 file lists.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
