### PR TITLE
sqlreplay: support replaying with ps-close=never

### DIFF
--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -150,9 +150,7 @@ func (cfg *ReplayConfig) Validate() ([]storage.ExternalStorage, error) {
 		return storages, errors.New("only `directed` prepared statement close strategy is supported for `native` format")
 	}
 	switch cfg.PSCloseStrategy {
-	case cmd.PSCloseStrategyAlways, cmd.PSCloseStrategyDirected:
-	case cmd.PSCloseStrategyNever:
-		return storages, errors.New("`never` prepared statement close strategy is not supported yet")
+	case cmd.PSCloseStrategyAlways, cmd.PSCloseStrategyDirected, cmd.PSCloseStrategyNever:
 	default:
 		return storages, errors.Errorf("invalid prepared statement close strategy %s", cfg.PSCloseStrategy)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #922

Problem Summary:
In most benchmarks, the prepared statements are never closed.

What is changed and how it works:
- Support `--ps-close=never` to never close prepared statements
- Add a map in the conn info to reuse the prepared statements

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

With `ps-close=always`:
```
[2025/09/18 20:58:12.837 +08:00] [INFO] [main.replay] [replay/replay.go:548] [replay finished]  [start_time=2025-09-18 20:57:24.411305 +0800 CST] [end_time=2025-09-18 20:58:12.837126 +0800 CST] [command_start_time=2025-09-14 19:10:49 +0800 CST] [format=audit_log_plugin] [username=root] [ignore_errs=false] [speed=1] [read_only=false] [decoded_cmds=479234] [replayed_cmds=479234] [filtered_cmds=0] [exceptions=16175] [replay_elapsed=48.424760959s] [decode_elapsed=29.763948709s] [extra_wait_time=0s]
```

With `ps-close=never`:
```
[2025/09/23 15:41:02.139 +08:00] [INFO] [main.replay] [replay/replay.go:546] [replay finished]  [start_time=2025-09-23 15:40:24.362248 +0800 CST] [end_time=2025-09-23 15:41:02.139147 +0800 CST] [command_start_time=2025-09-14 19:10:49 +0800 CST] [format=audit_log_plugin] [username=root] [ignore_errs=false] [speed=1] [read_only=false] [decoded_cmds=175815] [replayed_cmds=175815] [filtered_cmds=0] [exceptions=16175] [replay_elapsed=37.777201375s] [decode_elapsed=29.763948709s] [extra_wait_time=0s]
```

The command count reduced about 2/3.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
