### PR TITLE
router: support reloading TiDB CIDRs online

### DIFF
--- a/lib/config/label.go
+++ b/lib/config/label.go
@@ -8,6 +8,7 @@ const (
 	// We use `zone` because the follower read in TiDB also uses `zone` to decide location.
 	LocationLabelName = "zone"
 	KeyspaceLabelName = "keyspace"
+	CidrLabelName     = "cidr"
 )
 
 func (cfg *Config) GetLocation() string {

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -4,6 +4,7 @@
 package router
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -173,6 +174,27 @@ func (b *backendWrapper) Keyspace() string {
 		return ""
 	}
 	return labels[config.KeyspaceLabelName]
+}
+
+func (b *backendWrapper) Cidr() []string {
+	labels := b.getHealth().Labels
+	if len(labels) == 0 {
+		return nil
+	}
+	cidr := labels[config.CidrLabelName]
+	if len(cidr) == 0 {
+		return nil
+	}
+	cidrs := strings.Split(cidr, ",")
+	for i := len(cidrs) - 1; i >= 0; i-- {
+		cidr = strings.TrimSpace(cidrs[i])
+		if len(cidr) == 0 {
+			cidrs = append(cidrs[:i], cidrs[i+1:]...)
+		} else {
+			cidrs[i] = cidr
+		}
+	}
+	return cidrs
 }
 
 func (b *backendWrapper) String() string {

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"math/rand"
 	"reflect"
-	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -1074,6 +1073,20 @@ func TestGroupBackends(t *testing.T) {
 			backendCount: 5,
 			cidrs:        []string{"1.1.1.1/32"},
 		},
+		{
+			addr:         "1",
+			labels:       map[string]string{"cidr": "1.1.1.1/32, 1.1.4.1/32"},
+			groupCount:   2,
+			backendCount: 5,
+			cidrs:        []string{"1.1.1.1/32", "1.1.4.1/32"},
+		},
+		{
+			addr:         "3",
+			labels:       map[string]string{"cidr": "1.1.2.1/32"},
+			groupCount:   2,
+			backendCount: 5,
+			cidrs:        []string{"1.1.2.1/32", "1.1.3.1/32"},
+		},
 	}
 
 	for i, test := range tests {
@@ -1092,7 +1105,7 @@ func TestGroupBackends(t *testing.T) {
 			if test.cidrs == nil {
 				return group == nil
 			}
-			return slices.Equal(test.cidrs, group.values)
+			return group.EqualValues(test.cidrs)
 		}, 3*time.Second, 10*time.Millisecond, "test %d", i)
 	}
 }

--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -49,13 +49,16 @@ func TestProxyReadWrite(t *testing.T) {
 		},
 		func(t *testing.T, c net.Conn) {
 			prw := newProxyServer(newBasicReadWriter(c, DefaultConnBufferSize))
-			require.Equal(t, c.RemoteAddr().String(), prw.RemoteAddr().String())
+			proxyAddr := c.RemoteAddr().String()
+			require.NotEqual(t, proxyAddr, addr.String())
+			require.Equal(t, proxyAddr, prw.RemoteAddr().String())
 			data := make([]byte, len(message))
 			n, err := prw.Read(data)
 			require.NoError(t, err)
 			require.Equal(t, len(message), n)
 			require.Equal(t, p.SrcAddress, prw.Proxy().SrcAddress)
 			require.Equal(t, addr.String(), prw.RemoteAddr().String())
+			require.Equal(t, proxyAddr, prw.ProxyAddr().String())
 		}, 1)
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -150,7 +150,7 @@ func (s *SQLServer) onConn(ctx context.Context, conn net.Conn, addr string) {
 		maxConns := s.mu.maxConnections
 		// 'maxConns == 0' => unlimited connections
 		if maxConns != 0 && conns >= maxConns {
-			s.logger.Warn("too many connections", zap.Uint64("max connections", maxConns), zap.String("client_addr", conn.RemoteAddr().Network()), zap.Error(conn.Close()))
+			s.logger.Warn("too many connections", zap.Uint64("max connections", maxConns), zap.Stringer("client_addr", conn.RemoteAddr()), zap.Error(conn.Close()))
 			return false, nil, 0, nil
 		}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #932 

Problem Summary:
In next-gen, backend cidrs may increase or decrease but they stay in the same group.
E.g. enable public endpoint (3 cidrs) -> enable private endpoint (6 cidrs) -> disable public endpoint (3 cidrs).
But now TiProxy router only supports static CIDR lists.

What is changed and how it works:
- Match a group with TiDB CIDR by intersection instead of equality.
- Refresh group CIDR list periodically.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
