### PR TITLE
sqlreplay: do not close the statement if it's not prepared

### DIFF
--- a/pkg/sqlreplay/cmd/audit_log_plugin.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin.go
@@ -43,7 +43,7 @@ type auditLogPluginConnCtx struct {
 	currentDB string
 	lastPsID  uint32
 
-	// preparedStmt contains the prepared statement IDs that are not closed yet.
+	// preparedStmt contains the prepared statement IDs that are not closed yet, only used for `ps-close=directed`.
 	preparedStmt map[uint32]struct{}
 	// preparedStmtSql contains the prepared statement SQLs, only used for `ps-close=never`.
 	// It doesn't require the prepared statement IDs to be contained in the audit logs.
@@ -373,8 +373,7 @@ func (decoder *AuditLogPluginDecoder) parseGeneralEvent(kvs map[string]string, c
 			Payload:  append([]byte{pnet.ComQuery.Byte()}, hack.Slice(sql)...),
 		})
 	case "Close stmt":
-		if decoder.psCloseStrategy == PSCloseStrategyAlways {
-			// always close prepared statement, so it doesn't need to care the close command.
+		if decoder.psCloseStrategy != PSCloseStrategyDirected {
 			break
 		}
 		stmtID, err := parseStmtID(kvs[auditPluginKeyPreparedStmtID])

--- a/pkg/sqlreplay/cmd/audit_log_plugin_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin_test.go
@@ -1153,6 +1153,21 @@ func TestDecodeAuditLogInDirectedMode(t *testing.T) {
 				},
 			},
 		},
+		{
+			// CLOSE
+			lines: `[2025/09/18 17:51:56.999 +08:10] [INFO] [logger.go:77] [ID=175818911610038] [TIMESTAMP=2025/09/18 17:48:20.614 +08:10] [EVENT_CLASS=TABLE_ACCESS] [EVENT_SUBCLASS=Select] [STATUS_CODE=0] [COST_TIME=48.86] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[sbtest1]"] [SQL_TEXT="SELECT c FROM sbtest1 WHERE id=?"] [ROWS=0] [CONNECTION_ID=3807050215081378201] [CLIENT_PORT=50112] [PID=542193] [COMMAND="Close stmt"] [SQL_STATEMENTS=Select] [EXECUTE_PARAMS="[\"KindInt64 500350\"]"] [CURRENT_DB=test] [EVENT=COMPLETED] [PREPARED_STMT_ID=1]`,
+			cmds: []*Command{
+				{
+					Type:         pnet.ComInitDB,
+					ConnID:       3807050215081378201,
+					StartTs:      time.Date(2025, 9, 18, 17, 48, 20, 613951140, time.FixedZone("", 8*3600+600)),
+					Payload:      append([]byte{pnet.ComInitDB.Byte()}, []byte("test")...),
+					CapturedPsID: 0,
+					Line:         1,
+					Success:      true,
+				},
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #931 

Problem Summary:
If the first command is `Close stmt`, do not send a CLOSE command because it's not prepared in TiDB.

What is changed and how it works:
- If the prepared statement ID of a `Close stmt` is not in the map, ignore it.
- Ignore `Close stmt` also when `ps-close=never`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
