### PR TITLE
sqlreplay, cmd: support dry-run mode in traffic replay

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -52,6 +52,7 @@ func main() {
 	bufSize := rootCmd.PersistentFlags().Int("bufsize", 100000, "the size of buffer for reordering commands from audit files. 0 means no buffering.")
 	pprofAddr := rootCmd.PersistentFlags().String("pprof-addr", "", "the address to listen on for pprof, e.g. localhost:6060. By default pprof is disabled.")
 	psCloseStrategy := rootCmd.PersistentFlags().String("ps-close", "directed", "the strategy to close prepared statements. Supported values: directed (close when the original prepared statement closed), always (close the prepared statement right after it's executed), never (never close prepared statements). Default is directed.")
+	dryRun := rootCmd.PersistentFlags().Bool("dry-run", false, "dry run, don't connect to TiDB")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// set up general managers
@@ -122,6 +123,7 @@ func main() {
 			IgnoreErrs:       *ignoreErrs,
 			BufSize:          *bufSize,
 			PSCloseStrategy:  replaycmd.PSCloseStrategy(*psCloseStrategy),
+			DryRun:           *dryRun,
 		}
 		if err := r.StartReplay(replayCfg); err != nil {
 			cancel()

--- a/pkg/sqlreplay/replay/dry_run.go
+++ b/pkg/sqlreplay/replay/dry_run.go
@@ -1,0 +1,51 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
+	"github.com/pingcap/tiproxy/pkg/sqlreplay/report"
+)
+
+type nopConn struct {
+	closeCh chan uint64
+	connID  uint64
+	stats   *conn.ReplayStats
+}
+
+func (c *nopConn) ExecuteCmd(command *cmd.Command) {
+	c.stats.ReplayedCmds.Add(1)
+}
+
+func (c *nopConn) Run(ctx context.Context) {
+}
+
+func (c *nopConn) Stop() {
+	c.closeCh <- c.connID
+}
+
+var _ report.Report = (*mockReport)(nil)
+
+type mockReport struct {
+	exceptionCh chan conn.Exception
+}
+
+func newMockReport(exceptionCh chan conn.Exception) *mockReport {
+	return &mockReport{
+		exceptionCh: exceptionCh,
+	}
+}
+
+func (mr *mockReport) Start(ctx context.Context, cfg report.ReportConfig) error {
+	return nil
+}
+
+func (mr *mockReport) Stop(err error) {
+}
+
+func (mr *mockReport) Close() {
+}

--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -14,7 +14,6 @@ import (
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/conn"
-	"github.com/pingcap/tiproxy/pkg/sqlreplay/report"
 )
 
 var _ conn.Conn = (*mockConn)(nil)
@@ -200,28 +199,6 @@ func newMockCommand(connID uint64) *cmd.Command {
 		Type:    pnet.ComQuery,
 		Payload: append([]byte{pnet.ComQuery.Byte()}, []byte("select 1")...),
 	}
-}
-
-var _ report.Report = (*mockReport)(nil)
-
-type mockReport struct {
-	exceptionCh chan conn.Exception
-}
-
-func newMockReport(exceptionCh chan conn.Exception) *mockReport {
-	return &mockReport{
-		exceptionCh: exceptionCh,
-	}
-}
-
-func (mr *mockReport) Start(ctx context.Context, cfg report.ReportConfig) error {
-	return nil
-}
-
-func (mr *mockReport) Stop(err error) {
-}
-
-func (mr *mockReport) Close() {
 }
 
 // endlessReader always returns the same line.


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #938

Problem Summary:
Sometimes we need to verify whether the S3 bucket is accessible or the reading speed is fast enough, but the TiDB cluster is not created yet. We can only read the commands but not replay them.

What is changed and how it works:
- Add `dry-run` in the replayer arguments
- Mock conn and report so that they don't connect to TiDB

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Run with `dry-run=true` and then check the logs. It runs perfectly.
```sh
bin/replayer --addr "127.1:4000" --input="/Users/zhangming/Downloads/audit" --format="audit_log_plugin" --log-file=/Users/zhangming/gopath/src/github.com/pingcap/tiproxy/replay-log --ps-close=always --pprof-addr="localhost:6060" --dry-run=true
```

```
[2025/10/11 10:05:09.255 +08:00] [INFO] [main.replay] [replay/replay.go:568] [replay finished]  [start_time=2025-10-11 10:03:43.387111 +0800 CST] [end_time=2025-10-11 10:05:09.255935 +0800 CST] [command_start_time=0001-01-01 00:00:00 +0000 UTC] [format=audit_log_plugin] [username=root] [ignore_errs=false] [speed=1] [read_only=false] [decoded_cmds=480758] [replayed_cmds=480758] [filtered_cmds=0] [exceptions=0] [replay_elapsed=1m25.8682875s] [decode_elapsed=1m25.855039s] [extra_wait_time=0s] [last_cmd_start_ts=2025-09-14 19:11:18.764892584 +0800 CST]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
