### PR TITLE
replay: fix replayer stucks at closing connections when it quits

### DIFF
--- a/pkg/sqlreplay/replay/mock_test.go
+++ b/pkg/sqlreplay/replay/mock_test.go
@@ -234,6 +234,9 @@ func (cr *customizedReader) ReadLine() ([]byte, string, int, error) {
 		line, err := cr.buf.ReadBytes('\n')
 		if errors.Is(err, io.EOF) {
 			command := cr.getCmd()
+			if command == nil {
+				return nil, "", 0, io.EOF
+			}
 			_ = encoder.Encode(command, &cr.buf)
 		} else {
 			return line[:len(line)-1], "", 0, err
@@ -247,6 +250,9 @@ func (cr *customizedReader) Read(data []byte) (string, int, error) {
 		_, err := cr.buf.Read(data)
 		if errors.Is(err, io.EOF) {
 			command := cr.getCmd()
+			if command == nil {
+				return "", 0, io.EOF
+			}
 			_ = encoder.Encode(command, &cr.buf)
 		} else {
 			return "", 0, err


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #942 

Problem Summary:
When the replayer quits, the closeConnCh is full when 1024 connections close at the same time and then the other connections stuck.

What is changed and how it works:
- Increase the channel size
- Read from the channel while appending to the channel

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Ctrl+C to quit the replayer and it doesn't stuck.

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
