### PR TITLE
replay: support automatically save checkpoint file and load it to config

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -54,6 +54,7 @@ func main() {
 	pprofAddr := rootCmd.PersistentFlags().String("pprof-addr", "", "the address to listen on for pprof, e.g. localhost:6060. By default pprof is disabled.")
 	psCloseStrategy := rootCmd.PersistentFlags().String("ps-close", "directed", "the strategy to close prepared statements. Supported values: directed (close when the original prepared statement closed), always (close the prepared statement right after it's executed), never (never close prepared statements). Default is directed.")
 	dryRun := rootCmd.PersistentFlags().Bool("dry-run", false, "dry run, don't connect to TiDB")
+	checkPointFilePath := rootCmd.PersistentFlags().String("checkpoint-path", "", "the file path to store replay checkpoint information. If the file exists and not empty, the internal state will be loaded from the file to resume replaying.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		// set up general managers
@@ -113,19 +114,20 @@ func main() {
 
 		// start replay
 		replayCfg := replay.ReplayConfig{
-			Input:            *input,
-			Speed:            *speed,
-			Username:         *username,
-			Password:         *password,
-			Format:           *format,
-			ReadOnly:         *readonly,
-			StartTime:        time.Now(),
-			CommandStartTime: *cmdStartTime,
-			CommandEndTime:   *cmdEndTime,
-			IgnoreErrs:       *ignoreErrs,
-			BufSize:          *bufSize,
-			PSCloseStrategy:  replaycmd.PSCloseStrategy(*psCloseStrategy),
-			DryRun:           *dryRun,
+			Input:              *input,
+			Speed:              *speed,
+			Username:           *username,
+			Password:           *password,
+			Format:             *format,
+			ReadOnly:           *readonly,
+			StartTime:          time.Now(),
+			CommandStartTime:   *cmdStartTime,
+			CommandEndTime:     *cmdEndTime,
+			IgnoreErrs:         *ignoreErrs,
+			BufSize:            *bufSize,
+			PSCloseStrategy:    replaycmd.PSCloseStrategy(*psCloseStrategy),
+			DryRun:             *dryRun,
+			CheckPointFilePath: *checkPointFilePath,
 		}
 		if err := r.StartReplay(replayCfg); err != nil {
 			cancel()

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -135,6 +135,8 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 		cfg.PSCloseStrategy = cmd.PSCloseStrategyDirected
 	}
 
+	cfg.CheckPointFilePath = c.PostForm("checkpointpath")
+
 	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #950

This PR is based on https://github.com/pingcap/tiproxy/pull/965. Please merge it first.

Problem Summary:

What is changed and how it works:

1. Add a loop to automatically save the checkpoint file for each 100ms.
2. Save the checkpoint file before exiting the replay program.
3. Load the checkpoint file and overwrite the config.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
