### PR TITLE
cmd, sqlreplay: add service mode and support to set address in replay config

### DIFF
--- a/pkg/proxy/backend/static_handshake_handler.go
+++ b/pkg/proxy/backend/static_handshake_handler.go
@@ -1,0 +1,54 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backend
+
+import (
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/pingcap/tiproxy/pkg/balance/router"
+	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
+)
+
+// StaticHandshakeHandler always returns a static router.
+var _ HandshakeHandler = (*StaticHandshakeHandler)(nil)
+
+type StaticHandshakeHandler struct {
+	rt router.Router
+}
+
+// NewStaticHandshakeHandler creates a StaticHandshakeHandler.
+func NewStaticHandshakeHandler(addr string) *StaticHandshakeHandler {
+	return &StaticHandshakeHandler{
+		rt: router.NewStaticRouter([]string{addr}),
+	}
+}
+
+func (handler *StaticHandshakeHandler) HandleHandshakeResp(ConnContext, *pnet.HandshakeResp) error {
+	return nil
+}
+
+func (handler *StaticHandshakeHandler) HandleHandshakeErr(ConnContext, *mysql.MyError) bool {
+	return false
+}
+
+func (handler *StaticHandshakeHandler) GetRouter(ConnContext, *pnet.HandshakeResp) (router.Router, error) {
+	return handler.rt, nil
+}
+
+func (handler *StaticHandshakeHandler) OnHandshake(ConnContext, string, error, ErrorSource) {
+}
+
+func (handler *StaticHandshakeHandler) OnTraffic(ConnContext) {
+}
+
+func (handler *StaticHandshakeHandler) OnConnClose(ConnContext, ErrorSource) error {
+	return nil
+}
+
+func (handler *StaticHandshakeHandler) GetCapability() pnet.Capability {
+	return SupportedServerCapabilities
+}
+
+func (handler *StaticHandshakeHandler) GetServerVersion() string {
+	return pnet.ServerVersion
+}

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -154,6 +154,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 		cfg.ReplayerIndex = replayerIndex
 	}
 	cfg.OutputPath = c.PostForm("outputpath")
+	cfg.Addr = c.PostForm("addr")
 
 	if err := h.mgr.ReplayJobMgr.StartReplay(cfg); err != nil {
 		c.String(http.StatusInternalServerError, err.Error())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -173,7 +173,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 
 	// setup capture and replay job manager
 	{
-		srv.replay = mgrrp.NewJobManager(lg.Named("replay"), srv.configManager.GetConfig(), srv.certManager, idMgr, hsHandler)
+		srv.replay = mgrrp.NewJobManager(lg.Named("replay"), srv.configManager.GetConfig(), srv.certManager, idMgr, hsHandler, false)
 	}
 
 	{

--- a/pkg/sqlreplay/manager/job.go
+++ b/pkg/sqlreplay/manager/job.go
@@ -135,6 +135,7 @@ type replayJob4Marshal struct {
 	Format    string  `json:"format,omitempty"`
 	Speed     float64 `json:"speed,omitempty"`
 	ReadOnly  bool    `json:"readonly,omitempty"`
+	Addr      string  `json:"addr,omitempty"`
 }
 
 func (job *replayJob) Type() JobType {
@@ -152,6 +153,7 @@ func (job *replayJob) MarshalJSON() ([]byte, error) {
 		Speed:       job.cfg.Speed,
 		ReadOnly:    job.cfg.ReadOnly,
 		Format:      job.cfg.Format,
+		Addr:        job.cfg.Addr,
 	}
 	return json.Marshal(r)
 }

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -120,6 +120,8 @@ type ReplayConfig struct {
 	ReplayerIndex uint64
 	// OutputPath is the path to output replayed sql.
 	OutputPath string
+	// Addr is the downstream address to connect to
+	Addr string
 	// the following fields are for testing
 	readers           []cmd.LineReader
 	report            report.Report


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #970

Problem Summary:

What is changed and how it works:

1. Add a service mode for `replayer`, which will do nothing but wait for the API call.
2. Allow to set the `addr` in replay config.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
