### PR TITLE
replay: fix the overflow issue in replayer cordination of dynamic mode.

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -56,8 +56,8 @@ func main() {
 	dryRun := rootCmd.PersistentFlags().Bool("dry-run", false, "dry run, don't connect to TiDB")
 	checkPointFilePath := rootCmd.PersistentFlags().String("checkpoint-path", "", "the file path to store replay checkpoint information. If the file exists and not empty, the internal state will be loaded from the file to resume replaying.")
 	dynamicInput := rootCmd.PersistentFlags().Bool("dynamic-input", false, "enable dynamic input mode, which watches the input directory for new traffic folders and replays them automatically.")
-	replayerCount := rootCmd.PersistentFlags().Int("replayer-count", 1, "the total number of replayer instances running concurrently. Used only when dynamic-input is enabled.")
-	replayerIndex := rootCmd.PersistentFlags().Int("replayer-index", 0, "the index of this replayer instance. Used only when dynamic-input is enabled.")
+	replayerCount := rootCmd.PersistentFlags().Uint64("replayer-count", 1, "the total number of replayer instances running concurrently. Used only when dynamic-input is enabled.")
+	replayerIndex := rootCmd.PersistentFlags().Uint64("replayer-index", 0, "the index of this replayer instance. Used only when dynamic-input is enabled.")
 	outputPath := rootCmd.PersistentFlags().String("output-path", "", "the file path to store replayed sql. Empty indicates do not output replayed sql.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -138,7 +138,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 	cfg.CheckPointFilePath = c.PostForm("checkpointpath")
 	cfg.DynamicInput = strings.EqualFold(c.PostForm("dynamicinput"), "true")
 	if replayerCountStr := c.PostForm("replayercount"); replayerCountStr != "" {
-		replayerCount, err := strconv.Atoi(replayerCountStr)
+		replayerCount, err := strconv.ParseUint(replayerCountStr, 10, 64)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return
@@ -146,7 +146,7 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 		cfg.ReplayerCount = replayerCount
 	}
 	if replayerIndexStr := c.PostForm("replayerindex"); replayerIndexStr != "" {
-		replayerIndex, err := strconv.Atoi(replayerIndexStr)
+		replayerIndex, err := strconv.ParseUint(replayerIndexStr, 10, 64)
 		if err != nil {
 			c.String(http.StatusBadRequest, err.Error())
 			return

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -115,9 +115,9 @@ type ReplayConfig struct {
 	DynamicInput bool
 	// ReplayerCount is the total number of replayers which share the same dynamic input. The count
 	// and index is used to determine whether this replayer should process a new
-	ReplayerCount int
+	ReplayerCount uint64
 	// ReplayerIndex is the index of this replayer among all replayers.
-	ReplayerIndex int
+	ReplayerIndex uint64
 	// OutputPath is the path to output replayed sql.
 	OutputPath string
 	// the following fields are for testing
@@ -210,7 +210,7 @@ func (cfg *ReplayConfig) Validate() ([]storage.ExternalStorage, error) {
 		if cfg.ReplayerCount <= 0 {
 			return storages, errors.New("dynamic input requires a valid replayer count")
 		}
-		if cfg.ReplayerIndex < 0 || cfg.ReplayerIndex >= cfg.ReplayerCount {
+		if cfg.ReplayerIndex >= cfg.ReplayerCount {
 			return storages, errors.New("dynamic input requires a valid replayer index")
 		}
 	}
@@ -597,11 +597,11 @@ func (r *replay) constructDynamicDecoder(ctx context.Context) (decoder, error) {
 		// error is never returned for Hash
 		_, _ = h.Write([]byte(filename))
 		sum := h.Sum64()
-		expectedReplayerIndex := int(sum) % r.cfg.ReplayerCount
+		expectedReplayerIndex := sum % r.cfg.ReplayerCount
 		if expectedReplayerIndex != r.cfg.ReplayerIndex {
 			r.lg.Info("dir watcher skip new directory for other replayer", zap.String("dir", filename),
-				zap.Int("expected_replayer_index", expectedReplayerIndex),
-				zap.Int("replayer_index", r.cfg.ReplayerIndex))
+				zap.Uint64("expected_replayer_index", expectedReplayerIndex),
+				zap.Uint64("replayer_index", r.cfg.ReplayerIndex))
 			return nil
 		}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #977

Problem Summary:

What is changed and how it works:

1. Change the type of `ReplayerCount` and `ReplayerIndex` to `uint64`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
