### PR TITLE
meter, config: meter public and private response traffic independently

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -61,6 +61,8 @@ type ProxyServerOnline struct {
 	// In k8s, the pod terminationGracePeriodSeconds can be set to very long so that these configs can be updated online.
 	GracefulWaitBeforeShutdown int `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty" reloadable:"true"`
 	GracefulCloseConnTimeout   int `yaml:"graceful-close-conn-timeout,omitempty" toml:"graceful-close-conn-timeout,omitempty" json:"graceful-close-conn-timeout,omitempty" reloadable:"true"`
+	// Public and private traffic are metered separately.
+	PublicEndpoints []string `yaml:"public-endpoints,omitempty" toml:"public-endpoints,omitempty" json:"public-endpoints,omitempty" reloadable:"true"`
 }
 
 type ProxyServer struct {

--- a/pkg/balance/router/group_test.go
+++ b/pkg/balance/router/group_test.go
@@ -26,7 +26,7 @@ func TestParseCIDR(t *testing.T) {
 	}{
 		{
 			cidrs:   []string{"1.1.1.1"},
-			success: false,
+			success: true,
 		},
 		{
 			cidrs:   []string{"1.1.1.1/32"},

--- a/pkg/proxy/backend/mock_proxy_test.go
+++ b/pkg/proxy/backend/mock_proxy_test.go
@@ -160,18 +160,24 @@ func (mc *mockCapture) Close() {
 var _ Meter = (*mockMeter)(nil)
 
 type mockMeter struct {
-	crossAZBytes map[string]int64
-	respBytes    map[string]int64
+	crossAZBytes     map[string]int64
+	privateRespBytes map[string]int64
+	publicRespBytes  map[string]int64
 }
 
 func newMeter() *mockMeter {
 	return &mockMeter{
-		crossAZBytes: make(map[string]int64),
-		respBytes:    make(map[string]int64),
+		crossAZBytes:     make(map[string]int64),
+		publicRespBytes:  make(map[string]int64),
+		privateRespBytes: make(map[string]int64),
 	}
 }
 
-func (m *mockMeter) IncTraffic(clusterID string, respBytes, crossAZBytes int64) {
+func (m *mockMeter) IncTraffic(clusterID string, respBytes, crossAZBytes int64, fromPublicEndpoint bool) {
 	m.crossAZBytes[clusterID] += crossAZBytes
-	m.respBytes[clusterID] += respBytes
+	if fromPublicEndpoint {
+		m.publicRespBytes[clusterID] += respBytes
+	} else {
+		m.privateRespBytes[clusterID] += respBytes
+	}
 }

--- a/pkg/util/netutil/netutil.go
+++ b/pkg/util/netutil/netutil.go
@@ -1,0 +1,50 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netutil
+
+import (
+	"net"
+	"reflect"
+	"strings"
+
+	"github.com/pingcap/tiproxy/lib/util/errors"
+)
+
+func ParseCIDRList(strList []string) ([]*net.IPNet, error) {
+	cidrList := make([]*net.IPNet, 0, len(strList))
+	var parseErr error
+	for _, v := range strList {
+		if !strings.Contains(v, "/") {
+			v = v + "/32"
+		}
+		_, cidr, err := net.ParseCIDR(v)
+		if err == nil {
+			cidrList = append(cidrList, cidr)
+		} else {
+			parseErr = err
+		}
+	}
+	return cidrList, parseErr
+}
+
+func CIDRContainsIP(cidrList []*net.IPNet, addr net.Addr) (bool, error) {
+	if addr == nil || reflect.ValueOf(addr).IsNil() {
+		return false, errors.New("address is nil")
+	}
+	value := addr.String()
+	ipStr, _, err := net.SplitHostPort(value)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse address '%s'", value)
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false, errors.Errorf("failed to parse IP '%s'", value)
+	}
+	for _, cidr := range cidrList {
+		if cidr.Contains(ip) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/util/netutil/netutil_test.go
+++ b/pkg/util/netutil/netutil_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package netutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCIDR(t *testing.T) {
+	tests := []struct {
+		cidrs   []string
+		success bool
+	}{
+		{
+			cidrs:   []string{"1.1.1.1"},
+			success: true,
+		},
+		{
+			cidrs:   []string{"1.1.1.1/32"},
+			success: true,
+		},
+		{
+			cidrs:   []string{"1.1.1.1/33"},
+			success: false,
+		},
+		{
+			cidrs:   []string{"1.1.1.1/31"},
+			success: true,
+		},
+		{
+			cidrs:   []string{"1.1.1.1/30", "abc"},
+			success: false,
+		},
+	}
+
+	for _, test := range tests {
+		list, err := ParseCIDRList(test.cidrs)
+		if test.success {
+			require.NoError(t, err)
+			require.Equal(t, len(test.cidrs), len(list))
+		} else {
+			require.Error(t, err)
+		}
+	}
+}
+
+func TestContainIP(t *testing.T) {
+	tests := []struct {
+		ip      string
+		cidrs   []string
+		success bool
+	}{
+		{
+			ip:      "1.1.1.1",
+			cidrs:   []string{"1.1.1.1/32"},
+			success: true,
+		},
+		{
+			ip:      "1.1.1.1",
+			cidrs:   []string{"1.1.1.1"},
+			success: true,
+		},
+		{
+			ip:      "1.1.1.2",
+			cidrs:   []string{"1.1.1.1"},
+			success: false,
+		},
+		{
+			ip:      "1.1.1.2",
+			cidrs:   []string{"1.1.1.1/30"},
+			success: true,
+		},
+		{
+			ip:      "1.1.1.100",
+			cidrs:   []string{"1.1.1.1/30"},
+			success: false,
+		},
+		{
+			ip:      "1.1.1.100",
+			cidrs:   []string{"1.1.1.1/30", "1.1.1.101/30"},
+			success: true,
+		},
+	}
+
+	for _, test := range tests {
+		list, err := ParseCIDRList(test.cidrs)
+		require.NoError(t, err, "ip: %s, cidrs: %v", test.ip, test.cidrs)
+		contain, _ := CIDRContainsIP(list, &net.TCPAddr{IP: net.ParseIP(test.ip), Port: 1000})
+		require.Equal(t, test.success, contain, "ip: %s, cidrs: %v", test.ip, test.cidrs)
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #990 

Problem Summary:
The costs for public endpoint and private endpoint traffic are different, so meter them independently.

What is changed and how it works:
- Add a config `proxy.public-endpoints` to pass in the public NLB IP or CIDR.
- Move the parsing CIDR and matching CIDR functions into `netutil`.
- Update `outBound_bytes` to `private_outBound_bytes` and `public_outBound_tytes` of the metering system.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
