### PR TITLE
security: log the cert expiration when the cert rotates

### DIFF
--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -277,15 +277,17 @@ func TestReload(t *testing.T) {
 	require.NotNil(t, tcfg)
 	expire1 := ci.getExpireTime()
 	require.Equal(t, 1, strings.Count(text.String(), "update cert expiration"))
+	require.Equal(t, 1, strings.Count(text.String(), "cert will expire"))
 
 	// Replace the cert and then reload. Check that the expiration is different.
-	err = CreateTLSCertificates(lg, certPath, keyPath, caPath, 1024, 2*time.Hour, "")
+	err = CreateTLSCertificates(lg, certPath, keyPath, caPath, 1024, 25*time.Hour, "")
 	require.NoError(t, err)
 	_, err = ci.Reload(lg)
 	require.NoError(t, err)
 	expire2 := ci.getExpireTime()
 	require.NotEqual(t, expire1, expire2)
 	require.Equal(t, 2, strings.Count(text.String(), "update cert expiration"))
+	require.Equal(t, 1, strings.Count(text.String(), "cert will expire"))
 }
 
 func TestAutoCerts(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1015 

Problem Summary:
It's hard to know whether TiProxy has reloaded the latest certificate after the certificate rotates.

What is changed and how it works:
- Log the previous and current certificate expiration when it changes
- Give a warning when the expiration time is less than 24 hours
- Update the log level of other certificate events from Info to Debug

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Start with a certificate and then update the certificate
```
[2025/12/08 15:52:13.191 +08:00] [INFO] [main.cert] [security/cert.go:57] [update cert expiration]  [prev=0001-01-01 00:00:00 +0000 UTC] [cur=2026-12-08 07:51:19 +0000 UTC] [cfg="{\"cert\":\"/Users/zhangming/gopath/src/github.com/pingcap/tiproxy/server.crt\",\"key\":\"/Users/zhangming/gopath/src/github.com/pingcap/tiproxy/server.key\",\"min-tls-version\":\"1.2\"}"]
[2025/12/08 15:52:21.212 +08:00] [INFO] [main.cert] [security/cert.go:57] [update cert expiration]  [prev=2026-12-08 07:51:19 +0000 UTC] [cur=2026-12-08 07:52:20 +0000 UTC] [cfg="{\"cert\":\"/Users/zhangming/gopath/src/github.com/pingcap/tiproxy/server.crt\",\"key\":\"/Users/zhangming/gopath/src/github.com/pingcap/tiproxy/server.key\",\"min-tls-version\":\"1.2\"}"]
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
