### PR TITLE
replay: fix the issue that the replayStats is not cleaned for each replay

### DIFF
--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -49,18 +49,6 @@ type ReplayStats struct {
 	ExceptionCmds atomic.Uint64
 }
 
-func (s *ReplayStats) Reset() {
-	s.ReplayedCmds.Store(0)
-	s.PendingCmds.Store(0)
-	s.FilteredCmds.Store(0)
-	s.TotalWaitTime.Store(0)
-	s.ExtraWaitTime.Store(0)
-	s.ReplayStartTs.Store(0)
-	s.FirstCmdTs.Store(0)
-	s.CurCmdTs.Store(0)
-	s.ExceptionCmds.Store(0)
-}
-
 type ExecInfo struct {
 	Command   *cmd.Command
 	StartTime time.Time

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -317,7 +317,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.progress = 0
 	r.decodedCmds.Store(0)
 	r.err = nil
-	r.replayStats.Reset()
+	r.replayStats = conn.ReplayStats{}
 	r.dedup = cmd.NewDeDup()
 	r.exceptionCh = make(chan conn.Exception, maxPendingExceptions)
 	r.closeConnCh = make(chan uint64, maxPendingCloseRequests)
@@ -742,7 +742,7 @@ func (r *replay) constructReaderForDir(storage storage.ExternalStorage, dir stri
 		FileNameFilterTime: filterTime,
 		WaitOnEOF:          r.cfg.WaitOnEOF,
 	}
-	if r.cfg.CommandEndTime.IsZero() {
+	if cfg.FileNameFilterTime.IsZero() {
 		cfg.FileNameFilterTime = r.cfg.CommandStartTime
 	}
 	reader, err := store.NewReader(r.lg.Named("loader"), storage, cfg)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1022 

Problem Summary:

1. The `ReplayStats` is not cleaned for each replay.

What is changed and how it works:

1. The `ReplayStats` is now fully re-initialized for each replay.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

```release-note
None
```
