### PR TITLE
balance, config: add a config `route-policy` to specify routing policy

### DIFF
--- a/lib/config/balance.go
+++ b/lib/config/balance.go
@@ -10,8 +10,8 @@ const (
 	BalancePolicyLocation   = "location"
 	BalancePolicyConnection = "connection"
 
-	RoutePolicyIdlest = "idlest"
-	RoutePolicyRandom = "random"
+	RoutePolicyPreferIdle = "prefer-idle"
+	RoutePolicyRandom     = "random"
 )
 
 type Balance struct {
@@ -31,10 +31,10 @@ func (b *Balance) Check() error {
 		return errors.Wrapf(ErrInvalidConfigValue, "invalid balance.policy")
 	}
 	switch b.RoutePolicy {
-	case RoutePolicyIdlest, RoutePolicyRandom:
+	case RoutePolicyPreferIdle, RoutePolicyRandom:
 		return nil
 	case "":
-		b.RoutePolicy = RoutePolicyIdlest
+		b.RoutePolicy = RoutePolicyPreferIdle
 	default:
 		return errors.Wrapf(ErrInvalidConfigValue, "invalid balance.route-policy")
 	}
@@ -44,6 +44,6 @@ func (b *Balance) Check() error {
 func DefaultBalance() Balance {
 	return Balance{
 		Policy:      BalancePolicyResource,
-		RoutePolicy: RoutePolicyIdlest,
+		RoutePolicy: RoutePolicyPreferIdle,
 	}
 }

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -196,7 +196,7 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 	case config.RoutePolicyRandom:
 		return fbb.routeRandom(scoredBackends, &fields)
 	default:
-		return fbb.routeIdlest(scoredBackends, &fields)
+		return fbb.routePreferIdle(scoredBackends, &fields)
 	}
 }
 
@@ -230,7 +230,7 @@ func (fbb *FactorBasedBalance) routeRandom(scoredBackends []scoredBackend, field
 	return scoredBackends[idx].BackendCtx
 }
 
-func (fbb *FactorBasedBalance) routeIdlest(scoredBackends []scoredBackend, fields *[]zap.Field) policy.BackendCtx {
+func (fbb *FactorBasedBalance) routePreferIdle(scoredBackends []scoredBackend, fields *[]zap.Field) policy.BackendCtx {
 	if !fbb.canBeRouted(scoredBackends[0].scoreBits) {
 		return nil
 	}

--- a/pkg/balance/factor/factor_balance_test.go
+++ b/pkg/balance/factor/factor_balance_test.go
@@ -63,32 +63,32 @@ func TestRouteWithOneFactor(t *testing.T) {
 		{
 			scores:   []int{10},
 			idxRange: []int{0},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{10, 20},
 			idxRange: []int{0},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{10, 20, 30},
 			idxRange: []int{0},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{30, 20, 10},
 			idxRange: []int{2},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{30, 11, 10},
 			idxRange: []int{1, 2},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{11, 11, 10},
 			idxRange: []int{0, 1, 2},
-			policy:   config.RoutePolicyIdlest,
+			policy:   config.RoutePolicyPreferIdle,
 		},
 		{
 			scores:   []int{10, 20},
@@ -117,7 +117,7 @@ func TestRouteWithOneFactor(t *testing.T) {
 func TestRouteIdlestWith2Factors(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	fm := NewFactorBasedBalance(lg, newMockMetricsReader())
-	fm.routePolicy = config.RoutePolicyIdlest
+	fm.routePolicy = config.RoutePolicyPreferIdle
 	factor1 := &mockFactor{bitNum: 4, balanceCount: 1, threshold: 1, canBeRouted: true}
 	factor2 := &mockFactor{bitNum: 12, balanceCount: 1, threshold: 1, canBeRouted: true}
 	fm.factors = []Factor{factor1, factor2}
@@ -639,7 +639,7 @@ func TestSetConfigsConcurrently(t *testing.T) {
 	wg.Run(func() {
 		defer wg.Done()
 		policies := []string{config.BalancePolicyConnection, config.BalancePolicyResource, config.BalancePolicyLocation}
-		routePolicies := []string{config.RoutePolicyRandom, config.RoutePolicyIdlest}
+		routePolicies := []string{config.RoutePolicyRandom, config.RoutePolicyPreferIdle}
 		for i := 0; ctx.Err() != nil; i++ {
 			cfg.Balance = config.Balance{
 				Policy:      policies[i%len(policies)],


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1026 

Problem Summary:
- For various workloads, we can update the config to workaround, instead of building a hotfix
- For the random policy, the connection count on the new backend can not catch up with the others

What is changed and how it works:
- Add a config `balance.route-policy`. The options are `prefer-idle` and `random`. Default is `prefer-idle`.
- For the random policy, the idlest backend has a 10% higher priority than others, so that its connection count can finally catch up.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test random:
The CPS is fine:
<img width="1402" height="454" alt="image" src="https://github.com/user-attachments/assets/0497cb63-9109-4b31-b4be-9b21c877445c" />

But it still takes a long time to totally balance:
<img width="1410" height="512" alt="image" src="https://github.com/user-attachments/assets/5874a785-18e9-4f1f-a04a-9bbb39cf1c43" />


Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
