### PR TITLE
proxy, metrics: add metrics on QPS distribution and connection lifetime

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,6 +107,8 @@ func init() {
 		KeepAliveCounter,
 		QueryTotalCounter,
 		QueryDurationHistogram,
+		QueryTimeSinceConnCreationHistogram,
+		ConnLifetimeHistogram,
 		HandshakeDurationHistogram,
 		BackendStatusGauge,
 		GetBackendHistogram,

--- a/pkg/metrics/session.go
+++ b/pkg/metrics/session.go
@@ -39,4 +39,22 @@ var (
 			Help:      "Bucketed histogram of processing time (s) of handshakes.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblBackend})
+
+	QueryTimeSinceConnCreationHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelSession,
+			Name:      "query_time_since_conn_creation_seconds",
+			Help:      "Bucketed histogram of query start time (s) since connection creation.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 21), // 1s ~ 24days
+		})
+
+	ConnLifetimeHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: ModuleProxy,
+			Subsystem: LabelSession,
+			Name:      "conn_lifetime_seconds",
+			Help:      "Bucketed histogram of connection lifetime (s).",
+			Buckets:   prometheus.ExponentialBuckets(0.1, 2, 25), // 1s ~ 38days
+		})
 )

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -376,6 +376,7 @@ func (mgr *BackendConnManager) ExecuteCmd(ctx context.Context, request []byte) (
 		}
 		mgr.lastActiveTime = now
 		mgr.processLock.Unlock()
+		metrics.QueryTimeSinceConnCreationHistogram.Observe(startTime.Sub(mgr.createTime).Seconds())
 	}()
 	if len(request) < 1 {
 		err = mysql.ErrMalformPacket
@@ -835,6 +836,7 @@ func (mgr *BackendConnManager) Close() error {
 		mgr.cpt.Capture([]byte{pnet.ComQuit.Byte()}, time.Now(), mgr.connectionID, nil)
 	}
 	mgr.closeStatus.Store(statusClosed)
+	metrics.ConnLifetimeHistogram.Observe(time.Since(mgr.createTime).Seconds())
 	return errors.Collect(ErrCloseConnMgr, connErr, handErr)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1039

Problem Summary:
Add metrics on QPS distribution since connection creation so that we can know whether the queries are on the newest connections or the oldest connections. If the queries are on the newest connections, we should use `balance.routing-policy="random"`. If the queries are on the oldest connections, we should use `balance.conn-count.migrations-per-second=0.01`.

The connection lifetime can tell us whether the connections are short-lived, or long-lived, or both.

What is changed and how it works:
- Add metrics on QPS distribution since connection creation
- Add metrics on connection lifetime

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Run TPCC for 10m and check the grafana:

<img width="2154" height="1148" alt="image" src="https://github.com/user-attachments/assets/ff982744-67bc-4f96-a489-db43da7797f6" />


Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
