### PR TITLE
proxyprotocol: unify the ip family before sending Proxy Protocol

### DIFF
--- a/pkg/proxy/net/proxy_test.go
+++ b/pkg/proxy/net/proxy_test.go
@@ -56,7 +56,11 @@ func TestProxyReadWrite(t *testing.T) {
 			n, err := prw.Read(data)
 			require.NoError(t, err)
 			require.Equal(t, len(message), n)
-			require.Equal(t, p.SrcAddress, prw.Proxy().SrcAddress)
+
+			parsedAddr, ok := prw.Proxy().SrcAddress.(*net.TCPAddr)
+			require.True(t, ok)
+			require.Equal(t, addr.IP.To4(), parsedAddr.IP)
+			require.Equal(t, addr.Port, parsedAddr.Port)
 			require.Equal(t, addr.String(), prw.RemoteAddr().String())
 			require.Equal(t, proxyAddr, prw.ProxyAddr().String())
 		}, 1)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #346 

Problem Summary:

If only one of the `saddr` or `daddr` is IPv6 (and the other one is IPv4), the proxy protocol will be in a wrong format.

What is changed and how it works:

This PR introduced a new function: `unifyIPFamily`. If both of the two IPs are IPv4 (or IPv4 mapped IPv6), return the IPv4 addresses; Else return IPv6 addresses.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
