### PR TITLE
router, backend: fix that an unhealthy backend may be never removed

### DIFF
--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -501,13 +501,12 @@ func (mgr *BackendConnManager) processSignals(ctx context.Context) {
 // NOTE: processLock should be held before calling this function.
 func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 	start := time.Now()
-	if mgr.closeStatus.Load() >= statusNotifyClose || ctx.Err() != nil {
-		return
-	}
 	backendInst := mgr.redirectInfo.Load()
+	// No redirection signal or redirection is finished.
 	if backendInst == nil {
 		return
 	}
+	// Redirection will be retried after the next command finishes.
 	if !mgr.cmdProcessor.finishedTxn() {
 		return
 	}
@@ -525,6 +524,10 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 		rs.duration = time.Since(start)
 		mgr.redirectResCh <- rs
 	}()
+	// Even if the connection is closing, the redirection result must still be sent to recover the connection scores.
+	if mgr.closeStatus.Load() >= statusNotifyClose || ctx.Err() != nil {
+		return
+	}
 	// It may have been too long since the redirection signal was sent, and the target backend may be unhealthy now.
 	if !(*backendInst).Healthy() {
 		rs.err = ErrTargetUnhealthy

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -607,8 +607,8 @@ func TestCloseWhileRedirect(t *testing.T) {
 				})
 				// Make sure the process goroutine finishes.
 				ts.mp.wg.Wait()
-				// Redirect() should not panic after Close().
-				ts.mp.Redirect(newMockBackendInst(ts))
+				// Redirect() should not panic after Close() and it returns false.
+				require.False(t, ts.mp.Redirect(newMockBackendInst(ts)))
 				eventReceiver.checkEvent(t, eventRedirectSucceed)
 				wg.Wait()
 				eventReceiver.checkEvent(t, eventClose)


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->
This is a manual cherry-pick of #697
The original automatic cherry pick has too many conflicts so I cherry pick them manullay.

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #663

Problem Summary:
If a redirection happens when the connection is about to close, the connScore may be incorrectly set. The source backend may have a negative connScore and the target backend has an unexpectedly higher score. The target backend will never be removed.

What is changed and how it works:
- Notify the router even when a connection is closing
- The router doesn't update the score if the connection refuses to redirect

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
