### PR TITLE
balance: fix connScore may be wrong when redirecting while closing the connection

### DIFF
--- a/pkg/manager/router/router.go
+++ b/pkg/manager/router/router.go
@@ -22,7 +22,7 @@ type ConnEventReceiver interface {
 	OnRedirectFail(from, to string, conn RedirectableConn) error
 	OnPauseSucceed(addr string, conn RedirectableConn) error
 	OnPauseFail(addr string, conn RedirectableConn) error
-	OnConnClosed(addr string, conn RedirectableConn) error
+	OnConnClosed(addr, redirectingAddr string, conn RedirectableConn) error
 }
 
 // Router routes client connections to backends.
@@ -52,6 +52,8 @@ const (
 	phasePauseNotify
 	// The session failed to pause last time.
 	phasePauseFail
+	// The connection is closed.
+	phaseClosed
 )
 
 const (
@@ -149,8 +151,6 @@ func (b *backendWrapper) String() string {
 // connWrapper wraps RedirectableConn.
 type connWrapper struct {
 	RedirectableConn
-	// Reference to the target backend if it's redirecting, otherwise nil.
-	redirectingBackend *backendWrapper
 	// Last redirect start time of this connection.
 	lastRedirect monotime.Time
 	phase        connPhase

--- a/pkg/manager/router/router_static.go
+++ b/pkg/manager/router/router_static.go
@@ -78,7 +78,7 @@ func (r *StaticRouter) OnPauseFail(addr string, conn RedirectableConn) error {
 	return nil
 }
 
-func (r *StaticRouter) OnConnClosed(addr string, conn RedirectableConn) error {
+func (r *StaticRouter) OnConnClosed(addr, redirectingAddr string, conn RedirectableConn) error {
 	r.cnt--
 	return nil
 }

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -780,8 +780,12 @@ func (mgr *BackendConnManager) Close() error {
 		if len(mgr.redirectResCh) > 0 {
 			mgr.notifyRedirectResult(context.Background(), <-mgr.redirectResCh)
 		}
-		// Just notify it with the current address.
-		if err := eventReceiver.OnConnClosed(addr, mgr); err != nil {
+		// The connection may have just received the redirecting signal.
+		var redirectingAddr string
+		if redirectingBackend := mgr.redirectInfo.Load(); redirectingBackend != nil {
+			redirectingAddr = (*redirectingBackend).Addr()
+		}
+		if err := eventReceiver.OnConnClosed(addr, redirectingAddr, mgr); err != nil {
 			mgr.logger.Error("close connection error", zap.String("backend_addr", addr), zap.NamedError("notify_err", err))
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->
This is a manual cherry-pick of #798
The original automatic cherry pick has too many conflicts, so I cherry-pick them manually.

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #779 

Problem Summary:
When these happen, the connScore, connCount, and pending migrations will be wrong, and a backend will never be removed:
1. A connection finishes redirecting, and the signal loop tries to notify the router, but blocks at the router lock
2. The connection is closing and gets the router lock. It checks the pending redirection result but finds nothing
3. The onConnClosed clears the connection and the scores, and then releases the router lock
4. The onRedirectFinished is called and makes the scores and the connection counts wrong

What is changed and how it works:
Properly fixing the concurrency problem requires refactoring. Considering that this fix will be merged into a stable version, I'm fixing it temporarily.

- Move the redirectingAddr from the router to the backendConnMgr because the one on the router may be out of date if the redirection finishes
- In onRedirectFinished, do not update the connection if the connection is closed

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
