### PR TITLE
Fix 951 skip ca tls

### DIFF
--- a/lib/util/security/cert.go
+++ b/lib/util/security/cert.go
@@ -234,14 +234,7 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 		lg.Warn("specified auto-certs in a client tls config, ignored")
 	}
 
-	if !cfg.HasCA() {
-		if cfg.SkipCA {
-			// still enable TLS without verify server certs
-			return &tls.Config{
-				InsecureSkipVerify: true,
-				MinVersion:         GetMinTLSVer(cfg.MinTLSVersion, lg),
-			}, nil
-		}
+	if !cfg.HasCA() && !cfg.SkipCA {
 		lg.Debug("no CA to verify server connections, disable TLS")
 		return nil, nil
 	}
@@ -251,30 +244,38 @@ func (ci *CertInfo) buildClientConfig(lg *zap.Logger) (*tls.Config, error) {
 		GetCertificate:       ci.getCert,
 		GetClientCertificate: ci.getClientCert,
 		InsecureSkipVerify:   true,
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	}
+
+	if cfg.HasCA() {
+		tcfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			return ci.verifyCA(rawCerts)
-		},
+		}
+		caPEM, err := os.ReadFile(cfg.CA)
+		if err != nil {
+			return nil, err
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(caPEM) {
+			return nil, errors.New("failed to append ca certs")
+		}
+		ci.ca.Store(certPool)
+		tcfg.RootCAs = certPool
 	}
 
-	caPEM, err := os.ReadFile(cfg.CA)
-	if err != nil {
-		return nil, err
+	hasCert := cfg.Cert != ""
+	hasKey := cfg.Key != ""
+	if hasCert != hasKey {
+		return nil, errors.New("invalid TLS configuration: both cert and key must be provided, got only one")
 	}
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(caPEM) {
-		return nil, errors.New("failed to append ca certs")
-	}
-	ci.ca.Store(certPool)
-	tcfg.RootCAs = certPool
-
-	if !cfg.HasCert() {
+	if !hasCert {
+		ci.cert.Store((*tls.Certificate)(nil))
 		lg.Debug("no certificates, server may reject the connection")
 		return tcfg, nil
 	}
 
 	cert, err := tls.LoadX509KeyPair(cfg.Cert, cfg.Key)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	ci.cert.Store(&cert)
 

--- a/lib/util/security/cert_test.go
+++ b/lib/util/security/cert_test.go
@@ -187,6 +187,7 @@ func TestCertServer(t *testing.T) {
 				require.Nil(t, c.RootCAs)
 				require.Nil(t, ci.cert.Load())
 				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
+				require.NotNil(t, c.GetClientCertificate, "skip-ca should set GetClientCertificate")
 			},
 		},
 		{
@@ -195,12 +196,7 @@ func TestCertServer(t *testing.T) {
 				Cert:       certPath,
 				RSAKeySize: 1024,
 			},
-			checker: func(t *testing.T, c *tls.Config, ci *CertInfo) {
-				require.NotNil(t, c)
-				require.Nil(t, c.RootCAs)
-				require.Nil(t, ci.cert.Load())
-				require.Equal(t, tls.VersionTLS12, int(c.MinVersion))
-			},
+			checker: nil, // Expect error: both cert and key must be provided
 		},
 		{
 			TLSConfig: config.TLSConfig{
@@ -249,8 +245,10 @@ func TestCertServer(t *testing.T) {
 		ci := NewCert(tc.server)
 		ci.SetConfig(tc.TLSConfig)
 		tcfg, err := ci.Reload(logger)
-		require.NoError(t, err, "case %d", i)
-		if tc.checker != nil {
+		if tc.checker == nil {
+			require.Error(t, err, "case %d", i)
+		} else {
+			require.NoError(t, err, "case %d", i)
 			tc.checker(t, tcfg, ci)
 		}
 	}
@@ -336,6 +334,7 @@ func TestSetConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tcfg)
 	require.True(t, tcfg.InsecureSkipVerify)
+	require.NotNil(t, tcfg.GetClientCertificate, "skip-ca should set GetClientCertificate")
 
 	cfg = config.TLSConfig{
 		SkipCA: false,

--- a/lib/util/security/tls.go
+++ b/lib/util/security/tls.go
@@ -204,28 +204,24 @@ func CreateTLSConfigForTest() (serverTLSConf *tls.Config, clientTLSConf *tls.Con
 
 func BuildClientTLSConfig(logger *zap.Logger, cfg config.TLSConfig) (*tls.Config, error) {
 	logger = logger.With(zap.String("tls", "client"))
-	if !cfg.HasCA() {
-		if cfg.SkipCA {
-			// still enable TLS without verify server certs
-			return &tls.Config{
-				InsecureSkipVerify: true,
-				MinVersion:         tls.VersionTLS11,
-			}, nil
-		}
+	if !cfg.HasCA() && !cfg.SkipCA {
 		logger.Info("no CA to verify server connections, disable TLS")
 		return nil, nil
 	}
 
 	tcfg := &tls.Config{
 		MinVersion: tls.VersionTLS11,
+		InsecureSkipVerify: cfg.SkipCA,
 	}
-	tcfg.RootCAs = x509.NewCertPool()
-	certBytes, err := os.ReadFile(cfg.CA)
-	if err != nil {
-		return nil, errors.Errorf("failed to read CA: %w", err)
-	}
-	if !tcfg.RootCAs.AppendCertsFromPEM(certBytes) {
-		return nil, errors.Errorf("failed to append CA")
+	if cfg.HasCA() {
+		tcfg.RootCAs = x509.NewCertPool()
+		certBytes, err := os.ReadFile(cfg.CA)
+		if err != nil {
+			return nil, errors.Errorf("failed to read CA: %w", err)
+		}
+		if !tcfg.RootCAs.AppendCertsFromPEM(certBytes) {
+			return nil, errors.Errorf("failed to append CA")
+		}
 	}
 
 	if !cfg.HasCert() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #951

Problem Summary:
Issue - 951

What is changed and how it works:
Removed the early return in `buildClientConfig` and `BuildClientTLSConfig` to ensure the full TLS config (with certificate hooks) is built even when CA verification is skipped.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
