### PR TITLE
metricsreader: move cluster-scoped metrics lifecycle into backend clusters

### DIFF
--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -24,6 +24,8 @@ var (
 	ErrInvalidConfigValue              = errors.New("invalid config value")
 )
 
+const DefaultBackendClusterName = "default"
+
 type Config struct {
 	Proxy               ProxyServer           `yaml:"proxy,omitempty" toml:"proxy,omitempty" json:"proxy,omitempty"`
 	API                 API                   `yaml:"api,omitempty" toml:"api,omitempty" json:"api,omitempty"`
@@ -249,7 +251,7 @@ func (cfg *Config) GetBackendClusters() []BackendCluster {
 		return nil
 	}
 	return []BackendCluster{{
-		Name:    "default",
+		Name:    DefaultBackendClusterName,
 		PDAddrs: cfg.Proxy.PDAddrs,
 	}}
 }

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -326,7 +326,7 @@ func TestGetBackendClusters(t *testing.T) {
 
 	clusters := cfg.GetBackendClusters()
 	require.Len(t, clusters, 1)
-	require.Equal(t, "default", clusters[0].Name)
+	require.Equal(t, DefaultBackendClusterName, clusters[0].Name)
 	require.Equal(t, cfg.Proxy.PDAddrs, clusters[0].PDAddrs)
 
 	cfg.Proxy.BackendClusters = []BackendCluster{

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -30,7 +30,7 @@ type FactorBasedBalance struct {
 	factors []Factor
 	// to reduce memory allocation
 	cachedList      []scoredBackend
-	mr              metricsreader.MetricsReader
+	mr              metricsreader.MetricsQuerier
 	lg              *zap.Logger
 	factorStatus    *FactorStatus
 	factorLabel     *FactorLabel
@@ -44,7 +44,7 @@ type FactorBasedBalance struct {
 	routePolicy     string
 }
 
-func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsReader) *FactorBasedBalance {
+func NewFactorBasedBalance(lg *zap.Logger, mr metricsreader.MetricsQuerier) *FactorBasedBalance {
 	return &FactorBasedBalance{
 		lg:         lg,
 		mr:         mr,

--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -95,13 +95,13 @@ type FactorCPU struct {
 	lastMetricTime time.Time
 	// The estimated average CPU usage used by one connection.
 	usagePerConn        float64
-	mr                  metricsreader.MetricsReader
+	mr                  metricsreader.MetricsQuerier
 	bitNum              int
 	migrationsPerSecond float64
 	lg                  *zap.Logger
 }
 
-func NewFactorCPU(mr metricsreader.MetricsReader, lg *zap.Logger) *FactorCPU {
+func NewFactorCPU(mr metricsreader.MetricsQuerier, lg *zap.Logger) *FactorCPU {
 	fc := &FactorCPU{
 		mr:       mr,
 		bitNum:   5,
@@ -146,6 +146,7 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 	now := time.Now()
 	for _, backend := range backends {
 		addr := backend.Addr()
+		key := backend.ID()
 		// If a backend exists in metrics but not in the backend list, ignore it for this round.
 		// The backend will be in the next round if it's healthy.
 		pairs := qr.GetSamplePair4Backend(backend)
@@ -155,7 +156,7 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 		updateTime := time.UnixMilli(int64(pairs[len(pairs)-1].Timestamp))
 		// The time point of updating each backend is different, so only partial of the backends are updated every time.
 		// If this backend is not updated, ignore it.
-		snapshot := fc.snapshot[addr]
+		snapshot := fc.snapshot[key]
 		if !snapshot.updatedTime.Before(updateTime) {
 			continue
 		}
@@ -164,7 +165,7 @@ func (fc *FactorCPU) updateSnapshot(qr metricsreader.QueryResult, backends []sco
 			continue
 		}
 		metrics.BackendMetricGauge.WithLabelValues(addr, "cpu").Set(avgUsage)
-		fc.snapshot[addr] = cpuBackendSnapshot{
+		fc.snapshot[key] = cpuBackendSnapshot{
 			avgUsage:    avgUsage,
 			latestUsage: latestUsage,
 			connCount:   backend.ConnCount(),
@@ -239,7 +240,7 @@ func (fc *FactorCPU) updateCpuPerConn() {
 
 // Estimate the current cpu usage by the latest CPU usage, the latest connection count, and the current connection count.
 func (fc *FactorCPU) getUsage(backend scoredBackend) (avgUsage, latestUsage float64) {
-	snapshot, ok := fc.snapshot[backend.Addr()]
+	snapshot, ok := fc.snapshot[backend.ID()]
 	if !ok || snapshot.avgUsage < 0 || latestUsage < 0 {
 		// The metric has missed for minutes.
 		return 1, 1
@@ -260,11 +261,11 @@ func (fc *FactorCPU) BalanceCount(from, to scoredBackend) (BalanceAdvice, float6
 	fields := []zap.Field{
 		zap.Float64("from_avg_usage", fromAvgUsage),
 		zap.Float64("from_latest_usage", fromLatestUsage),
-		zap.Int("from_snapshot_conn", fc.snapshot[from.Addr()].connCount),
+		zap.Int("from_snapshot_conn", fc.snapshot[from.ID()].connCount),
 		zap.Int("from_conn", from.ConnScore()),
 		zap.Float64("to_avg_usage", toAvgUsage),
 		zap.Float64("to_latest_usage", toLatestUsage),
-		zap.Int("to_snapshot_conn", fc.snapshot[to.Addr()].connCount),
+		zap.Int("to_snapshot_conn", fc.snapshot[to.ID()].connCount),
 		zap.Int("to_conn", to.ConnScore()),
 		zap.Float64("usage_per_conn", fc.usagePerConn),
 	}

--- a/pkg/balance/factor/factor_cpu_test.go
+++ b/pkg/balance/factor/factor_cpu_test.go
@@ -301,6 +301,34 @@ func TestCPUResultNotUpdated(t *testing.T) {
 	}
 }
 
+func TestCPUSnapshotUsesBackendID(t *testing.T) {
+	now := model.Now()
+	backends := []scoredBackend{
+		createBackendWithAddrID("shared:4000", "cluster-a/shared:4000", "10.0.0.1", 10080, 10, 10),
+		createBackendWithAddrID("shared:4000", "cluster-b/shared:4000", "10.0.0.2", 10080, 20, 20),
+	}
+	mmr := &mockMetricsReader{
+		qrs: map[string]metricsreader.QueryResult{
+			"cpu": {
+				UpdateTime: time.Now(),
+				Value: model.Matrix([]*model.SampleStream{
+					createSampleStreamForInstance([]float64{0.2, 0.2}, "10.0.0.1:10080", now),
+					createSampleStreamForInstance([]float64{0.6, 0.6}, "10.0.0.2:10080", now),
+				}),
+			},
+		},
+	}
+	fc := NewFactorCPU(mmr, zap.NewNop())
+
+	fc.UpdateScore(backends)
+
+	require.Len(t, fc.snapshot, 2)
+	require.Contains(t, fc.snapshot, "cluster-a/shared:4000")
+	require.Contains(t, fc.snapshot, "cluster-b/shared:4000")
+	require.Equal(t, 0.2, fc.snapshot["cluster-a/shared:4000"].latestUsage)
+	require.Equal(t, 0.6, fc.snapshot["cluster-b/shared:4000"].latestUsage)
+}
+
 func TestCPUQueryRule(t *testing.T) {
 	tests := []struct {
 		text       string

--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -187,13 +187,13 @@ type errIndicator struct {
 type FactorHealth struct {
 	snapshot            map[string]healthBackendSnapshot
 	indicators          []errIndicator
-	mr                  metricsreader.MetricsReader
+	mr                  metricsreader.MetricsQuerier
 	bitNum              int
 	migrationsPerSecond float64
 	lg                  *zap.Logger
 }
 
-func NewFactorHealth(mr metricsreader.MetricsReader, lg *zap.Logger) *FactorHealth {
+func NewFactorHealth(mr metricsreader.MetricsQuerier, lg *zap.Logger) *FactorHealth {
 	return &FactorHealth{
 		mr:         mr,
 		snapshot:   make(map[string]healthBackendSnapshot),
@@ -203,7 +203,7 @@ func NewFactorHealth(mr metricsreader.MetricsReader, lg *zap.Logger) *FactorHeal
 	}
 }
 
-func initErrIndicator(mr metricsreader.MetricsReader) []errIndicator {
+func initErrIndicator(mr metricsreader.MetricsQuerier) []errIndicator {
 	indicators := make([]errIndicator, 0, len(errDefinitions))
 	for _, def := range errDefinitions {
 		indicator := errIndicator{
@@ -268,7 +268,7 @@ func (fh *FactorHealth) UpdateScore(backends []scoredBackend) {
 		fh.updateSnapshot(backends)
 	}
 	for i := range backends {
-		score := fh.caclErrScore(backends[i].Addr())
+		score := fh.caclErrScore(backends[i].ID())
 		backends[i].addScore(score, fh.bitNum)
 	}
 }
@@ -281,6 +281,7 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 	now := time.Now()
 	for _, backend := range backends {
 		addr := backend.Addr()
+		key := backend.ID()
 		// Get the current value range.
 		updatedTime, valueRange, indicator, failureValue, totalValue := time.Time{}, valueRangeNormal, "", 0.0, 0.0
 		for _, ind := range fh.indicators {
@@ -310,7 +311,7 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 			}
 		}
 		// If the metric is unavailable, try to reuse the latest one.
-		snapshot := fh.snapshot[addr]
+		snapshot := fh.snapshot[key]
 		if updatedTime.IsZero() {
 			continue
 		}
@@ -335,7 +336,7 @@ func (fh *FactorHealth) updateSnapshot(backends []scoredBackend) {
 				zap.Float64("balance_count", balanceCount),
 				zap.Int("conn_score", backend.ConnScore()))
 		}
-		fh.snapshot[addr] = healthBackendSnapshot{
+		fh.snapshot[key] = healthBackendSnapshot{
 			updatedTime:  updatedTime,
 			valueRange:   valueRange,
 			indicator:    indicator,
@@ -391,9 +392,9 @@ func calcValueRange(failureSample, totalSample *model.Sample, indicator errIndic
 	return failureValue, totalValue, valueRangeMid
 }
 
-func (fh *FactorHealth) caclErrScore(addr string) int {
+func (fh *FactorHealth) caclErrScore(key string) int {
 	// If the backend has no metrics (not in snapshot), take it as healthy.
-	return int(fh.snapshot[addr].valueRange)
+	return int(fh.snapshot[key].valueRange)
 }
 
 func (fh *FactorHealth) ScoreBitNum() int {
@@ -402,9 +403,9 @@ func (fh *FactorHealth) ScoreBitNum() int {
 
 func (fh *FactorHealth) BalanceCount(from, to scoredBackend) (BalanceAdvice, float64, []zap.Field) {
 	// Only migrate connections when one is valueRangeNormal and the other is valueRangeAbnormal.
-	fromScore := fh.caclErrScore(from.Addr())
-	toScore := fh.caclErrScore(to.Addr())
-	snapshot := fh.snapshot[from.Addr()]
+	fromScore := fh.caclErrScore(from.ID())
+	toScore := fh.caclErrScore(to.ID())
+	snapshot := fh.snapshot[from.ID()]
 	var fields []zap.Field
 	if snapshot.indicator != "" {
 		fields = append(fields,

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -310,6 +310,40 @@ func TestHealthBalanceCount(t *testing.T) {
 	}
 }
 
+func TestHealthSnapshotUsesBackendID(t *testing.T) {
+	backends := []scoredBackend{
+		createBackendWithAddrID("shared:4000", "cluster-a/shared:4000", "10.0.0.1", 10080, 10, 10),
+		createBackendWithAddrID("shared:4000", "cluster-b/shared:4000", "10.0.0.2", 10080, 20, 20),
+	}
+	mmr := &mockMetricsReader{
+		qrs: map[string]metricsreader.QueryResult{
+			"failure_pd": {
+				UpdateTime: time.Now(),
+				Value: model.Vector([]*model.Sample{
+					createSampleForInstance(0, "10.0.0.1:10080"),
+					createSampleForInstance(100, "10.0.0.2:10080"),
+				}),
+			},
+			"total_pd": {
+				UpdateTime: time.Now(),
+				Value: model.Vector([]*model.Sample{
+					createSampleForInstance(100, "10.0.0.1:10080"),
+					createSampleForInstance(100, "10.0.0.2:10080"),
+				}),
+			},
+		},
+	}
+	fh := NewFactorHealth(mmr, zap.NewNop())
+
+	fh.UpdateScore(backends)
+
+	require.Len(t, fh.snapshot, 2)
+	require.Contains(t, fh.snapshot, "cluster-a/shared:4000")
+	require.Contains(t, fh.snapshot, "cluster-b/shared:4000")
+	require.Equal(t, valueRangeNormal, fh.snapshot["cluster-a/shared:4000"].valueRange)
+	require.Equal(t, valueRangeAbnormal, fh.snapshot["cluster-b/shared:4000"].valueRange)
+}
+
 func TestHealthQueryRule(t *testing.T) {
 	tests := []struct {
 		text       string

--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -107,13 +107,13 @@ type FactorMemory struct {
 	snapshot map[string]memBackendSnapshot
 	// The updated time of the metric that we've read last time.
 	lastMetricTime      time.Time
-	mr                  metricsreader.MetricsReader
+	mr                  metricsreader.MetricsQuerier
 	bitNum              int
 	migrationsPerSecond float64
 	lg                  *zap.Logger
 }
 
-func NewFactorMemory(mr metricsreader.MetricsReader, lg *zap.Logger) *FactorMemory {
+func NewFactorMemory(mr metricsreader.MetricsQuerier, lg *zap.Logger) *FactorMemory {
 	bitNum := 0
 	for levels := len(oomRiskLevels); ; bitNum++ {
 		if levels == 0 {
@@ -155,9 +155,9 @@ func (fm *FactorMemory) UpdateScore(backends []scoredBackend) {
 	}
 
 	for i := range backends {
-		addr := backends[i].Addr()
+		key := backends[i].ID()
 		// If the backend is new or the backend misses metrics, take it safe.
-		score := fm.snapshot[addr].riskLevel
+		score := fm.snapshot[key].riskLevel
 		backends[i].addScore(score, fm.bitNum)
 	}
 }
@@ -170,7 +170,8 @@ func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []
 	now := time.Now()
 	for _, backend := range backends {
 		addr := backend.Addr()
-		snapshot := fm.snapshot[addr]
+		key := backend.ID()
+		snapshot := fm.snapshot[key]
 		// If a backend exists in metrics but not in the backend list, ignore it for this round.
 		// The backend will be in the next round if it's healthy.
 		pairs := qr.GetSamplePair4Backend(backend)
@@ -202,7 +203,7 @@ func (fm *FactorMemory) updateSnapshot(qr metricsreader.QueryResult, backends []
 				zap.Float64("balance_count", balanceCount),
 				zap.Int("conn_score", backend.ConnScore()))
 		}
-		fm.snapshot[addr] = memBackendSnapshot{
+		fm.snapshot[key] = memBackendSnapshot{
 			updatedTime:  updateTime,
 			memUsage:     latestUsage,
 			timeToOOM:    timeToOOM,
@@ -265,7 +266,7 @@ func (fm *FactorMemory) calcBalanceCount(backend scoredBackend, riskLevel int, t
 	}
 	balanceCount := float64(backend.ConnScore()) / seconds
 	// If the migration started eariler, reuse the balance count.
-	if snapshot := fm.snapshot[backend.Addr()]; snapshot.balanceCount > balanceCount {
+	if snapshot := fm.snapshot[backend.ID()]; snapshot.balanceCount > balanceCount {
 		return snapshot.balanceCount
 	}
 	return balanceCount
@@ -279,8 +280,8 @@ func (fm *FactorMemory) BalanceCount(from, to scoredBackend) (BalanceAdvice, flo
 	// The risk level may change frequently, e.g. last time timeToOOM was 30s and connections were migrated away,
 	// then this time it becomes 60s and the connections are migrated back.
 	// So we only rebalance when the difference of risk levels of 2 backends is big enough.
-	fromSnapshot := fm.snapshot[from.Addr()]
-	toSnapshot := fm.snapshot[to.Addr()]
+	fromSnapshot := fm.snapshot[from.ID()]
+	toSnapshot := fm.snapshot[to.ID()]
 	fields := []zap.Field{
 		zap.Duration("from_time_to_oom", fromSnapshot.timeToOOM),
 		zap.Float64("from_mem_usage", fromSnapshot.memUsage),

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -352,6 +352,34 @@ func TestMemoryBalanceCount(t *testing.T) {
 	}
 }
 
+func TestMemorySnapshotUsesBackendID(t *testing.T) {
+	now := model.Now()
+	backends := []scoredBackend{
+		createBackendWithAddrID("shared:4000", "cluster-a/shared:4000", "10.0.0.1", 10080, 10, 10),
+		createBackendWithAddrID("shared:4000", "cluster-b/shared:4000", "10.0.0.2", 10080, 20, 20),
+	}
+	mmr := &mockMetricsReader{
+		qrs: map[string]metricsreader.QueryResult{
+			"memory": {
+				UpdateTime: time.Now(),
+				Value: model.Matrix([]*model.SampleStream{
+					createSampleStreamForInstance([]float64{0.2, 0.2}, "10.0.0.1:10080", now),
+					createSampleStreamForInstance([]float64{0.85, 0.85}, "10.0.0.2:10080", now),
+				}),
+			},
+		},
+	}
+	fm := NewFactorMemory(mmr, zap.NewNop())
+
+	fm.UpdateScore(backends)
+
+	require.Len(t, fm.snapshot, 2)
+	require.Contains(t, fm.snapshot, "cluster-a/shared:4000")
+	require.Contains(t, fm.snapshot, "cluster-b/shared:4000")
+	require.Equal(t, 0.2, fm.snapshot["cluster-a/shared:4000"].memUsage)
+	require.Equal(t, 0.85, fm.snapshot["cluster-b/shared:4000"].memUsage)
+}
+
 func TestMemoryQueryRule(t *testing.T) {
 	tests := []struct {
 		text       string

--- a/pkg/balance/factor/factor_status.go
+++ b/pkg/balance/factor/factor_status.go
@@ -63,15 +63,16 @@ func (fs *FactorStatus) updateSnapshot(backends []scoredBackend) {
 	now := time.Now()
 	for i := range backends {
 		addr := backends[i].Addr()
+		key := backends[i].ID()
 		if backends[i].Healthy() {
-			delete(fs.snapshot, addr)
+			delete(fs.snapshot, key)
 			continue
 		}
-		snapshot := fs.snapshot[addr]
+		snapshot := fs.snapshot[key]
 		// The rebalance was already started, don't update it.
 		if snapshot.balanceCount > 0.0001 {
 			snapshot.lastAccess = now
-			fs.snapshot[addr] = snapshot
+			fs.snapshot[key] = snapshot
 			continue
 		}
 		balanceCount := float64(backends[i].ConnScore()) / balanceSeconds4Status
@@ -82,7 +83,7 @@ func (fs *FactorStatus) updateSnapshot(backends []scoredBackend) {
 				zap.Float64("balance_count", balanceCount),
 				zap.Int("conn_score", backends[i].ConnScore()))
 		}
-		fs.snapshot[addr] = statusBackendSnapshot{
+		fs.snapshot[key] = statusBackendSnapshot{
 			balanceCount: balanceCount,
 			lastAccess:   now,
 		}
@@ -105,7 +106,7 @@ func (fs *FactorStatus) BalanceCount(from, to scoredBackend) (BalanceAdvice, flo
 	if fs.migrationsPerSecond > 0 {
 		return AdvicePositive, fs.migrationsPerSecond, nil
 	}
-	return AdvicePositive, fs.snapshot[from.Addr()].balanceCount, nil
+	return AdvicePositive, fs.snapshot[from.ID()].balanceCount, nil
 }
 
 func (fs *FactorStatus) SetConfig(cfg *config.Config) {

--- a/pkg/balance/factor/factor_status_test.go
+++ b/pkg/balance/factor/factor_status_test.go
@@ -109,6 +109,24 @@ func TestMissBackendInStatus(t *testing.T) {
 	require.Equal(t, 100/balanceSeconds4Status, count)
 }
 
+func TestStatusSnapshotUsesBackendID(t *testing.T) {
+	backends := []scoredBackend{
+		createBackendWithAddrID("shared:4000", "cluster-a/shared:4000", "10.0.0.1", 10080, 10, 10),
+		createBackendWithAddrID("shared:4000", "cluster-b/shared:4000", "10.0.0.2", 10080, 20, 20),
+	}
+	backends[0].BackendCtx.(*mockBackend).healthy = false
+	backends[1].BackendCtx.(*mockBackend).healthy = false
+
+	fs := NewFactorStatus(zap.NewNop())
+	fs.UpdateScore(backends)
+
+	require.Len(t, fs.snapshot, 2)
+	require.Contains(t, fs.snapshot, "cluster-a/shared:4000")
+	require.Contains(t, fs.snapshot, "cluster-b/shared:4000")
+	require.Equal(t, 10/balanceSeconds4Status, fs.snapshot["cluster-a/shared:4000"].balanceCount)
+	require.Equal(t, 20/balanceSeconds4Status, fs.snapshot["cluster-b/shared:4000"].balanceCount)
+}
+
 func TestFactorStatusConfig(t *testing.T) {
 	tests := []struct {
 		migrations float64

--- a/pkg/balance/factor/mock_test.go
+++ b/pkg/balance/factor/mock_test.go
@@ -21,6 +21,7 @@ var _ policy.BackendCtx = (*mockBackend)(nil)
 
 type mockBackend struct {
 	observer.BackendInfo
+	id        string
 	addr      string
 	connScore int
 	connCount int
@@ -42,6 +43,13 @@ func (mb *mockBackend) Healthy() bool {
 
 func (mb *mockBackend) ConnScore() int {
 	return mb.connScore
+}
+
+func (mb *mockBackend) ID() string {
+	if mb.id != "" {
+		return mb.id
+	}
+	return mb.addr
 }
 
 func (mb *mockBackend) Addr() string {
@@ -172,6 +180,22 @@ func createBackend(backendIdx, connCount, connScore int) scoredBackend {
 	}
 }
 
+func createBackendWithAddrID(addr, id, ip string, statusPort uint, connCount, connScore int) scoredBackend {
+	return scoredBackend{
+		BackendCtx: &mockBackend{
+			BackendInfo: observer.BackendInfo{
+				IP:         ip,
+				StatusPort: statusPort,
+			},
+			id:        id,
+			addr:      addr,
+			connCount: connCount,
+			connScore: connScore,
+			healthy:   true,
+		},
+	}
+}
+
 func createSampleStream(values []float64, backendIdx int, curTime model.Time) *model.SampleStream {
 	host := strconv.Itoa(backendIdx)
 	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(host + ":10080")}
@@ -179,6 +203,16 @@ func createSampleStream(values []float64, backendIdx int, curTime model.Time) *m
 	for i, cpu := range values {
 		ts := curTime.Add(15 * time.Second * time.Duration(i-len(values)))
 		pairs = append(pairs, model.SamplePair{Timestamp: ts, Value: model.SampleValue(cpu)})
+	}
+	return &model.SampleStream{Metric: labelSet, Values: pairs}
+}
+
+func createSampleStreamForInstance(values []float64, instance string, curTime model.Time) *model.SampleStream {
+	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(instance)}
+	pairs := make([]model.SamplePair, 0, len(values))
+	for i, value := range values {
+		ts := curTime.Add(15 * time.Second * time.Duration(i-len(values)))
+		pairs = append(pairs, model.SamplePair{Timestamp: ts, Value: model.SampleValue(value)})
 	}
 	return &model.SampleStream{Metric: labelSet, Values: pairs}
 }
@@ -194,6 +228,12 @@ func createPairs(values []float64, ts []model.Time) []model.SamplePair {
 func createSample(value float64, backendIdx int) *model.Sample {
 	host := strconv.Itoa(backendIdx)
 	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(host + ":10080")}
+	ts := model.Time(time.Now().UnixMilli())
+	return &model.Sample{Metric: labelSet, Timestamp: ts, Value: model.SampleValue(value)}
+}
+
+func createSampleForInstance(value float64, instance string) *model.Sample {
+	labelSet := model.Metric{metricsreader.LabelNameInstance: model.LabelValue(instance)}
 	ts := model.Time(time.Now().UnixMilli())
 	return &model.Sample{Metric: labelSet, Timestamp: ts, Value: model.SampleValue(value)}
 }

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -35,8 +36,10 @@ import (
 
 const (
 	// readerOwnerKeyPrefix is the key prefix in etcd for backend reader owner election.
-	// For global owner, the key is "/tiproxy/metric_reader/owner".
-	// For zonal owner, the key is "/tiproxy/metric_reader/{zone}/owner".
+	// For the default cluster, the key is "/tiproxy/metric_reader/owner".
+	// For the default cluster with zones, the key is "/tiproxy/metric_reader/{zone}/owner".
+	// For a named cluster, the key is "/tiproxy/metric_reader/{cluster}/owner".
+	// For a named cluster with zones, the key is "/tiproxy/metric_reader/{cluster}/{zone}/owner".
 	readerOwnerKeyPrefix = "/tiproxy/metric_reader"
 	readerOwnerKeySuffix = "owner"
 	// sessionTTL is the session's TTL in seconds for backend reader owner election.
@@ -72,6 +75,7 @@ type BackendReader struct {
 	marshalledHistory []byte
 	cfgGetter         config.ConfigGetter
 	backendFetcher    TopologyFetcher
+	clusterName       string
 	lastZone          string
 	electionCfg       elect.ElectionConfig
 	election          elect.Election
@@ -85,6 +89,11 @@ type BackendReader struct {
 
 func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *http.Client, etcdCli *clientv3.Client,
 	backendFetcher TopologyFetcher, cfg *config.HealthCheck) *BackendReader {
+	return NewClusterBackendReader(lg, "", cfgGetter, httpCli, etcdCli, backendFetcher, cfg)
+}
+
+func NewClusterBackendReader(lg *zap.Logger, clusterName string, cfgGetter config.ConfigGetter, httpCli *http.Client, etcdCli *clientv3.Client,
+	backendFetcher TopologyFetcher, cfg *config.HealthCheck) *BackendReader {
 	return &BackendReader{
 		queryRules:        make(map[string]QueryRule),
 		queryResults:      make(map[string]QueryResult),
@@ -92,6 +101,7 @@ func NewBackendReader(lg *zap.Logger, cfgGetter config.ConfigGetter, httpCli *ht
 		lg:                lg,
 		cfgGetter:         cfgGetter,
 		backendFetcher:    backendFetcher,
+		clusterName:       strings.TrimSpace(clusterName),
 		cfg:               cfg,
 		wgp:               waitgroup.NewWaitGroupPool(goPoolSize, goMaxIdle),
 		electionCfg:       elect.DefaultElectionConfig(sessionTTL),
@@ -118,9 +128,9 @@ func (br *BackendReader) initElection(ctx context.Context, cfg *config.Config) e
 	br.lastZone = cfg.GetLocation()
 	if len(br.lastZone) > 0 {
 		// Zonal owners are responsible for the backends in the same zone or not in any TiProxy zone.
-		key = fmt.Sprintf("%s/%s/%s", readerOwnerKeyPrefix, br.lastZone, readerOwnerKeySuffix)
+		key = fmt.Sprintf("%s/%s/%s", readerOwnerKeyPrefixForCluster(br.clusterName), br.lastZone, readerOwnerKeySuffix)
 	} else {
-		key = fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+		key = fmt.Sprintf("%s/%s", readerOwnerKeyPrefixForCluster(br.clusterName), readerOwnerKeySuffix)
 	}
 	br.election = elect.NewElection(br.lg.Named("elect"), br.etcdCli, br.electionCfg, id, key, br)
 	br.election.Start(ctx)
@@ -213,7 +223,8 @@ func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []st
 	// Get all owner keys.
 	opts := []clientv3.OpOption{clientv3.WithPrefix()}
 	var kvs []*mvccpb.KeyValue
-	kvs, err = etcd.GetKVs(ctx, br.etcdCli, readerOwnerKeyPrefix, opts, br.electionCfg.Timeout, br.electionCfg.RetryIntvl, br.electionCfg.RetryCnt)
+	keyPrefix := readerOwnerKeyPrefixForCluster(br.clusterName)
+	kvs, err = etcd.GetKVs(ctx, br.etcdCli, keyPrefix, opts, br.electionCfg.Timeout, br.electionCfg.RetryIntvl, br.electionCfg.RetryCnt)
 	if err != nil {
 		return
 	}
@@ -227,7 +238,7 @@ func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []st
 	ownerMap := make(map[string]ownerInfo)
 	for _, kv := range kvs {
 		key := hack.String(kv.Key)
-		key = key[len(readerOwnerKeyPrefix):]
+		key = key[len(keyPrefix):]
 		if len(key) == 0 || key[0] != '/' {
 			continue
 		}
@@ -398,7 +409,10 @@ func (br *BackendReader) history2QueryResult() {
 				if len(beHistory.Step2History) == 0 {
 					continue
 				}
-				labels := map[model.LabelName]model.LabelValue{LabelNameInstance: model.LabelValue(backend)}
+				labels := map[model.LabelName]model.LabelValue{
+					LabelNameInstance: model.LabelValue(backend),
+					LabelNameCluster:  model.LabelValue(normalizeClusterMetricLabel(br.clusterName)),
+				}
 				// vector indicates returning the latest pair
 				lastPair := beHistory.Step2History[len(beHistory.Step2History)-1]
 				results = append(results, &model.Sample{Value: lastPair.Value, Timestamp: lastPair.Timestamp, Metric: labels})
@@ -410,7 +424,10 @@ func (br *BackendReader) history2QueryResult() {
 				if len(beHistory.Step2History) == 0 {
 					continue
 				}
-				labels := map[model.LabelName]model.LabelValue{LabelNameInstance: model.LabelValue(backend)}
+				labels := map[model.LabelName]model.LabelValue{
+					LabelNameInstance: model.LabelValue(backend),
+					LabelNameCluster:  model.LabelValue(normalizeClusterMetricLabel(br.clusterName)),
+				}
 				// matrix indicates returning the history
 				// copy a slice to avoid data race
 				pairs := make([]model.SamplePair, len(beHistory.Step2History))
@@ -466,7 +483,7 @@ func (br *BackendReader) GetBackendMetrics() []byte {
 // If every member queries directly from backends, the backends may suffer from too much pressure.
 func (br *BackendReader) readFromOwner(ctx context.Context, ownerAddr string) error {
 	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(br.cfg.RetryInterval), uint64(br.cfg.MaxRetries)), ctx)
-	resp, err := br.httpCli.Get(ownerAddr, ownerMetricPath, b, br.cfg.DialTimeout)
+	resp, err := br.httpCli.Get(ownerAddr, backendMetricOwnerPath(br.clusterName), b, br.cfg.DialTimeout)
 	if err != nil {
 		return err
 	}
@@ -568,6 +585,22 @@ func (br *BackendReader) Close() {
 	if br.election != nil {
 		br.election.Close()
 	}
+}
+
+func readerOwnerKeyPrefixForCluster(clusterName string) string {
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" || clusterName == config.DefaultBackendClusterName {
+		return readerOwnerKeyPrefix
+	}
+	return fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, clusterName)
+}
+
+func backendMetricOwnerPath(clusterName string) string {
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		return ownerMetricPath
+	}
+	return fmt.Sprintf("%s?cluster=%s", ownerMetricPath, url.QueryEscape(clusterName))
 }
 
 func purgeHistory(history []model.SamplePair, retention time.Duration, now time.Time) []model.SamplePair {

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -502,8 +502,8 @@ func TestHistory2QueryResult(t *testing.T) {
 				"key2": {ResultType: model.ValVector},
 			},
 			queryResult: map[string]model.Value{
-				"key1": model.Vector{{Value: model.SampleValue(2), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1"}}},
-				"key2": model.Vector{{Value: model.SampleValue(3), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				"key1": model.Vector{{Value: model.SampleValue(2), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}}},
+				"key2": model.Vector{{Value: model.SampleValue(3), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}}},
 			},
 		},
 		{
@@ -527,10 +527,10 @@ func TestHistory2QueryResult(t *testing.T) {
 				"key2": {ResultType: model.ValVector},
 			},
 			queryResult: map[string]model.Value{
-				"key1": model.Vector{{Value: model.SampleValue(2), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				"key1": model.Vector{{Value: model.SampleValue(2), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}}},
 				"key2": model.Vector{
-					{Value: model.SampleValue(4), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1"}},
-					{Value: model.SampleValue(6), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend2"}},
+					{Value: model.SampleValue(4), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}},
+					{Value: model.SampleValue(6), Timestamp: 2, Metric: model.Metric{LabelNameInstance: "backend2", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}},
 				},
 			},
 		},
@@ -555,10 +555,10 @@ func TestHistory2QueryResult(t *testing.T) {
 				"key2": {ResultType: model.ValMatrix},
 			},
 			queryResult: map[string]model.Value{
-				"key1": model.Vector{{Value: model.SampleValue(1), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1"}}},
+				"key1": model.Vector{{Value: model.SampleValue(1), Timestamp: 1, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}}},
 				"key2": model.Matrix{
-					{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend1"}},
-					{Values: []model.SamplePair{{Value: model.SampleValue(3), Timestamp: 1}, {Value: model.SampleValue(4), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend2"}},
+					{Values: []model.SamplePair{{Value: model.SampleValue(2), Timestamp: 1}}, Metric: model.Metric{LabelNameInstance: "backend1", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}},
+					{Values: []model.SamplePair{{Value: model.SampleValue(3), Timestamp: 1}, {Value: model.SampleValue(4), Timestamp: 2}}, Metric: model.Metric{LabelNameInstance: "backend2", LabelNameCluster: model.LabelValue(config.DefaultBackendClusterName)}},
 				},
 			},
 		},
@@ -1149,7 +1149,7 @@ func TestQueryAllOwners(t *testing.T) {
 	br := NewBackendReader(lg, nil, nil, suite.client, nil, nil)
 	for i, test := range tests {
 		for i, key := range test.keys {
-			key = fmt.Sprintf("%s%s", readerOwnerKeyPrefix, key)
+			key = fmt.Sprintf("%s%s", readerOwnerKeyPrefixForCluster(""), key)
 			suite.putKV(key, test.values[i])
 		}
 		zones, owners, err := br.queryAllOwners(context.Background())
@@ -1166,7 +1166,7 @@ func TestQueryAllOwners(t *testing.T) {
 			slices.Sort(zones)
 			require.Equal(t, test.zones, zones, "case %d", i)
 		}
-		suite.delKV(readerOwnerKeyPrefix)
+		suite.delKV(readerOwnerKeyPrefixForCluster(""))
 	}
 }
 
@@ -1184,7 +1184,7 @@ func TestUpdateLabel(t *testing.T) {
 	defer br.Close()
 
 	checkKeyPrefix := func(prefix string) bool {
-		kvs := suite.getKV(readerOwnerKeyPrefix)
+		kvs := suite.getKV(readerOwnerKeyPrefixForCluster(""))
 		if len(kvs) != 1 {
 			return false
 		}
@@ -1192,7 +1192,7 @@ func TestUpdateLabel(t *testing.T) {
 	}
 
 	// campaign for the global owner
-	prefix := fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	prefix := fmt.Sprintf("%s/%s", readerOwnerKeyPrefixForCluster(""), readerOwnerKeySuffix)
 	require.Eventually(t, func() bool {
 		return checkKeyPrefix(prefix)
 	}, 3*time.Second, 10*time.Millisecond)
@@ -1201,7 +1201,7 @@ func TestUpdateLabel(t *testing.T) {
 	cfg.Labels = map[string]string{config.LocationLabelName: "east"}
 	err = br.ReadMetrics(context.Background())
 	require.NoError(t, err)
-	prefix = fmt.Sprintf("%s/east/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	prefix = fmt.Sprintf("%s/east/%s", readerOwnerKeyPrefixForCluster(""), readerOwnerKeySuffix)
 	require.Eventually(t, func() bool {
 		return checkKeyPrefix(prefix)
 	}, 3*time.Second, 10*time.Millisecond)
@@ -1255,7 +1255,7 @@ func TestElection(t *testing.T) {
 	// setup etcd
 	suite := newEtcdTestSuite(t)
 	t.Cleanup(suite.close)
-	ownerKey := fmt.Sprintf("%s/%s", readerOwnerKeyPrefix, readerOwnerKeySuffix)
+	ownerKey := fmt.Sprintf("%s/%s", readerOwnerKeyPrefixForCluster(""), readerOwnerKeySuffix)
 	suite.putKV(ownerKey, addr)
 	require.Eventually(t, func() bool {
 		kvs := suite.getKV(ownerKey)
@@ -1329,4 +1329,38 @@ func setupTypicalBackendListener(t *testing.T, respBody string) (backendPort int
 	}
 	t.Cleanup(backendHttpHandler.Close)
 	return
+}
+
+func TestBackendMetricOwnerPath(t *testing.T) {
+	require.Equal(t, "/api/backend/metrics", backendMetricOwnerPath(""))
+	require.Equal(t, "/api/backend/metrics?cluster=cluster-a", backendMetricOwnerPath("cluster-a"))
+	require.Equal(t, "/api/backend/metrics?cluster=cluster+a%2Fb", backendMetricOwnerPath("cluster a/b"))
+}
+
+func TestReaderOwnerKeyPrefixForCluster(t *testing.T) {
+	require.Equal(t, "/tiproxy/metric_reader", readerOwnerKeyPrefixForCluster(""))
+	require.Equal(t, "/tiproxy/metric_reader", readerOwnerKeyPrefixForCluster(config.DefaultBackendClusterName))
+	require.Equal(t, "/tiproxy/metric_reader/cluster-a", readerOwnerKeyPrefixForCluster("cluster-a"))
+	require.Equal(t, "/tiproxy/metric_reader/cluster-a", readerOwnerKeyPrefixForCluster(" cluster-a "))
+}
+
+func TestQueryAllOwnersForNamedCluster(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	suite := newEtcdTestSuite(t)
+	defer suite.close()
+
+	suite.putKV("/tiproxy/metric_reader/owner/1000", "default-owner")
+	suite.putKV("/tiproxy/metric_reader/east/owner/1001", "default-east-owner")
+	suite.putKV("/tiproxy/metric_reader/cluster-a/owner/1002", "cluster-a-owner")
+	suite.putKV("/tiproxy/metric_reader/cluster-a/east/owner/1003", "cluster-a-east-owner")
+	suite.putKV("/tiproxy/metric_reader/cluster-b/owner/1004", "cluster-b-owner")
+
+	br := NewClusterBackendReader(lg, "cluster-a", nil, nil, suite.client, nil, nil)
+	zones, owners, err := br.queryAllOwners(context.Background())
+	require.NoError(t, err)
+
+	slices.Sort(zones)
+	slices.Sort(owners)
+	require.Equal(t, []string{"east"}, zones)
+	require.Equal(t, []string{"cluster-a-east-owner", "cluster-a-owner"}, owners)
 }

--- a/pkg/balance/metricsreader/metrics_reader.go
+++ b/pkg/balance/metricsreader/metrics_reader.go
@@ -32,19 +32,25 @@ type TopologyFetcher interface {
 	GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error)
 }
 
-type MetricsReader interface {
-	Start(ctx context.Context) error
+type MetricsQuerier interface {
 	AddQueryExpr(key string, queryExpr QueryExpr, queryRule QueryRule)
 	RemoveQueryExpr(key string)
 	GetQueryResult(key string) QueryResult
 	GetBackendMetrics() []byte
+}
+
+type MetricsReader interface {
+	MetricsQuerier
+
+	Start(ctx context.Context) error
 	PreClose()
 	Close()
 }
 
-var _ MetricsReader = (*DefaultMetricsReader)(nil)
+var _ MetricsReader = (*ClusterReader)(nil)
 
-type DefaultMetricsReader struct {
+// ClusterReader is the metrics reader owned by one backend cluster.
+type ClusterReader struct {
 	source        atomic.Int32
 	backendReader *BackendReader
 	promReader    *PromReader
@@ -54,17 +60,24 @@ type DefaultMetricsReader struct {
 	cfg           *config.HealthCheck
 }
 
-func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, backendFetcher TopologyFetcher, httpCli *http.Client,
-	etcdCli *clientv3.Client, cfg *config.HealthCheck, cfgGetter config.ConfigGetter) *DefaultMetricsReader {
-	return &DefaultMetricsReader{
+func NewClusterReader(lg *zap.Logger, clusterName string, promFetcher PromInfoFetcher, backendFetcher TopologyFetcher, httpCli *http.Client,
+	etcdCli *clientv3.Client, cfg *config.HealthCheck, cfgGetter config.ConfigGetter) *ClusterReader {
+	promReader := NewPromReader(lg.Named("prom_reader"), promFetcher, cfg)
+	promReader.clusterName = clusterName
+	return &ClusterReader{
 		lg:            lg,
 		cfg:           cfg,
-		promReader:    NewPromReader(lg.Named("prom_reader"), promFetcher, cfg),
-		backendReader: NewBackendReader(lg.Named("backend_reader"), cfgGetter, httpCli, etcdCli, backendFetcher, cfg),
+		promReader:    promReader,
+		backendReader: NewClusterBackendReader(lg.Named("backend_reader"), clusterName, cfgGetter, httpCli, etcdCli, backendFetcher, cfg),
 	}
 }
 
-func (dmr *DefaultMetricsReader) Start(ctx context.Context) error {
+func NewDefaultMetricsReader(lg *zap.Logger, promFetcher PromInfoFetcher, backendFetcher TopologyFetcher, httpCli *http.Client,
+	etcdCli *clientv3.Client, cfg *config.HealthCheck, cfgGetter config.ConfigGetter) *ClusterReader {
+	return NewClusterReader(lg, config.DefaultBackendClusterName, promFetcher, backendFetcher, httpCli, etcdCli, cfg, cfgGetter)
+}
+
+func (dmr *ClusterReader) Start(ctx context.Context) error {
 	if err := dmr.backendReader.Start(ctx); err != nil {
 		return err
 	}
@@ -86,7 +99,7 @@ func (dmr *DefaultMetricsReader) Start(ctx context.Context) error {
 }
 
 // readMetrics reads from Prometheus first. If it fails, fall back to read backends.
-func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
+func (dmr *ClusterReader) readMetrics(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -107,7 +120,7 @@ func (dmr *DefaultMetricsReader) readMetrics(ctx context.Context) {
 	dmr.lg.Warn("read metrics failed", zap.NamedError("prometheus", promErr), zap.NamedError("backends", backendErr))
 }
 
-func (dmr *DefaultMetricsReader) setSource(source int32, err error) {
+func (dmr *ClusterReader) setSource(source int32, err error) {
 	old := dmr.source.Load()
 	if old != source {
 		dmr.source.Store(source)
@@ -120,18 +133,18 @@ func (dmr *DefaultMetricsReader) setSource(source int32, err error) {
 	}
 }
 
-func (dmr *DefaultMetricsReader) AddQueryExpr(key string, queryExpr QueryExpr, queryRule QueryRule) {
+func (dmr *ClusterReader) AddQueryExpr(key string, queryExpr QueryExpr, queryRule QueryRule) {
 	dmr.promReader.AddQueryExpr(key, queryExpr)
 	dmr.backendReader.AddQueryRule(key, queryRule)
 }
 
-func (dmr *DefaultMetricsReader) RemoveQueryExpr(key string) {
+func (dmr *ClusterReader) RemoveQueryExpr(key string) {
 	dmr.promReader.RemoveQueryExpr(key)
 	dmr.backendReader.RemoveQueryRule(key)
 }
 
 // GetQueryResult returns an empty result if the key or the result is not found.
-func (dmr *DefaultMetricsReader) GetQueryResult(key string) QueryResult {
+func (dmr *ClusterReader) GetQueryResult(key string) QueryResult {
 	switch dmr.source.Load() {
 	case sourceProm:
 		return dmr.promReader.GetQueryResult(key)
@@ -142,11 +155,11 @@ func (dmr *DefaultMetricsReader) GetQueryResult(key string) QueryResult {
 	}
 }
 
-func (dmr *DefaultMetricsReader) GetBackendMetrics() []byte {
+func (dmr *ClusterReader) GetBackendMetrics() []byte {
 	return dmr.backendReader.GetBackendMetrics()
 }
 
-func (dmr *DefaultMetricsReader) PreClose() {
+func (dmr *ClusterReader) PreClose() {
 	// No need to update results in the graceful shutdown.
 	// Stop the loop before pre-closing the backend reader to avoid data race.
 	if dmr.cancel != nil {
@@ -157,7 +170,7 @@ func (dmr *DefaultMetricsReader) PreClose() {
 	dmr.backendReader.PreClose()
 }
 
-func (dmr *DefaultMetricsReader) Close() {
+func (dmr *ClusterReader) Close() {
 	if dmr.cancel != nil {
 		dmr.cancel()
 		dmr.cancel = nil

--- a/pkg/balance/metricsreader/mock_test.go
+++ b/pkg/balance/metricsreader/mock_test.go
@@ -138,6 +138,10 @@ func (mb *mockBackend) ConnCount() int {
 	return 0
 }
 
+func (mb *mockBackend) ID() string {
+	return mb.addr
+}
+
 func (mb *mockBackend) Addr() string {
 	return mb.addr
 }

--- a/pkg/balance/metricsreader/prom_reader.go
+++ b/pkg/balance/metricsreader/prom_reader.go
@@ -28,6 +28,7 @@ type PromReader struct {
 	queryExprs   map[string]QueryExpr
 	queryResults map[string]QueryResult
 	promFetcher  PromInfoFetcher
+	clusterName  string
 	lg           *zap.Logger
 	cfg          *config.HealthCheck
 }
@@ -64,6 +65,7 @@ func (pr *PromReader) ReadMetrics(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		qr = attachClusterLabel(qr, pr.clusterName)
 		qr.UpdateTime = time.Now()
 		results[id] = qr
 	}

--- a/pkg/balance/metricsreader/prom_reader_test.go
+++ b/pkg/balance/metricsreader/prom_reader_test.go
@@ -30,14 +30,14 @@ func TestReadPromMetrics(t *testing.T) {
 		{
 			promQL:         `tidb_server_connections`,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\", tiproxy_cluster=\"default\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
 			expectedType:   model.ValMatrix,
 		},
 		{
 			promQL:         `go_goroutines{%s="tidb"}`,
 			hasLabel:       true,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\", tiproxy_cluster=\"default\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
 			expectedType:   model.ValMatrix,
 		},
 		{
@@ -79,12 +79,12 @@ func TestMultiExprs(t *testing.T) {
 		{
 			promQL:         `tidb_server_connections`,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\", tiproxy_cluster=\"default\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
 		},
 		{
 			promQL:         `go_goroutines`,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+			expectedString: "go_goroutines{instance=\"127.0.0.1:10080\", job=\"tidb\", tiproxy_cluster=\"default\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
 		},
 		{
 			promQL:         `unknown`,
@@ -138,13 +138,13 @@ func TestBackendLabel(t *testing.T) {
 			promQL:         `tidb_server_connections`,
 			label:          `job`,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"tidb_server_connections","instance":"127.0.0.1:10080","job":"tidb"},"values":[[1712738879.406,"0"],[1712738894.406,"0"],[1712738909.406,"0"],[1712738924.406,"0"],[1712738939.406,"0"]]}]}}`,
-			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
+			expectedString: "tidb_server_connections{instance=\"127.0.0.1:10080\", job=\"tidb\", tiproxy_cluster=\"default\"} =>\n0 @[1712738879.406]\n0 @[1712738894.406]\n0 @[1712738909.406]\n0 @[1712738924.406]\n0 @[1712738939.406]",
 		},
 		{
 			promQL:         `go_goroutines`,
 			label:          `component`,
 			respBody:       `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"go_goroutines","instance":"127.0.0.1:10080","component":"tidb"},"values":[[1712742184.054,"229"],[1712742199.054,"229"],[1712742214.054,"229"],[1712742229.054,"229"],[1712742244.054,"229"]]}]}}`,
-			expectedString: "go_goroutines{component=\"tidb\", instance=\"127.0.0.1:10080\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
+			expectedString: "go_goroutines{component=\"tidb\", instance=\"127.0.0.1:10080\", tiproxy_cluster=\"default\"} =>\n229 @[1712742184.054]\n229 @[1712742199.054]\n229 @[1712742214.054]\n229 @[1712742229.054]\n229 @[1712742244.054]",
 		},
 	}
 

--- a/pkg/balance/metricsreader/query_result.go
+++ b/pkg/balance/metricsreader/query_result.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	dto "github.com/prometheus/client_model/go"
@@ -18,6 +19,7 @@ import (
 
 const (
 	LabelNameInstance = "instance"
+	LabelNameCluster  = "tiproxy_cluster"
 )
 
 // QueryExpr is used for querying Prometheus.
@@ -85,12 +87,16 @@ func (qr QueryResult) GetSamplePair4Backend(backend policy.BackendCtx) []model.S
 	}
 	matrix := qr.Value.(model.Matrix)
 	labelValue := getLabel4Backend(backend)
+	clusterValue := getLabel4Cluster(backend)
 	for _, m := range matrix {
-		if label, ok := m.Metric[LabelNameInstance]; ok {
-			if labelValue == (string)(label) {
-				return m.Values
-			}
+		label, ok := m.Metric[LabelNameInstance]
+		if !ok || labelValue != string(label) {
+			continue
 		}
+		if !matchClusterLabel(m.Metric, clusterValue) {
+			continue
+		}
+		return m.Values
 	}
 	return nil
 }
@@ -105,14 +111,25 @@ func (qr QueryResult) GetSample4Backend(backend policy.BackendCtx) *model.Sample
 	}
 	vector := qr.Value.(model.Vector)
 	labelValue := getLabel4Backend(backend)
+	clusterValue := getLabel4Cluster(backend)
 	for _, m := range vector {
-		if label, ok := m.Metric[LabelNameInstance]; ok {
-			if labelValue == (string)(label) {
-				return m
-			}
+		label, ok := m.Metric[LabelNameInstance]
+		if !ok || labelValue != string(label) {
+			continue
 		}
+		if !matchClusterLabel(m.Metric, clusterValue) {
+			continue
+		}
+		return m
 	}
 	return nil
+}
+
+func matchClusterLabel(metric model.Metric, clusterValue string) bool {
+	if label, ok := metric[LabelNameCluster]; ok {
+		return clusterValue == string(label)
+	}
+	return true
 }
 
 func getLabel4Backend(backend policy.BackendCtx) string {
@@ -126,6 +143,10 @@ func getLabel4Backend(backend policy.BackendCtx) string {
 	return net.JoinHostPort(backendInfo.IP, strconv.Itoa(int(backendInfo.StatusPort)))
 }
 
+func getLabel4Cluster(backend policy.BackendCtx) string {
+	return normalizeClusterMetricLabel(backend.GetBackendInfo().ClusterName)
+}
+
 // addr is the address of the backend status port.
 func getLabel4Addr(addr string) string {
 	if isOperatorDeployed(addr) {
@@ -134,6 +155,38 @@ func getLabel4Addr(addr string) string {
 	}
 	// In tiup deployment, the label value of `instance` is hostname:statusPort.
 	return addr
+}
+
+func normalizeClusterMetricLabel(clusterName string) string {
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		return config.DefaultBackendClusterName
+	}
+	return clusterName
+}
+
+func attachClusterLabel(qr QueryResult, clusterName string) QueryResult {
+	clusterValue := model.LabelValue(normalizeClusterMetricLabel(clusterName))
+	if qr.Value == nil || reflect.ValueOf(qr.Value).IsNil() {
+		return qr
+	}
+	switch value := qr.Value.(type) {
+	case model.Vector:
+		for _, sample := range value {
+			if sample.Metric == nil {
+				sample.Metric = model.Metric{}
+			}
+			sample.Metric[LabelNameCluster] = clusterValue
+		}
+	case model.Matrix:
+		for _, stream := range value {
+			if stream.Metric == nil {
+				stream.Metric = model.Metric{}
+			}
+			stream.Metric[LabelNameCluster] = clusterValue
+		}
+	}
+	return qr
 }
 
 func isOperatorDeployed(addr string) bool {

--- a/pkg/balance/metricsreader/query_result_test.go
+++ b/pkg/balance/metricsreader/query_result_test.go
@@ -44,6 +44,7 @@ func TestParseMatrix(t *testing.T) {
 func TestMatrixMatchLabel(t *testing.T) {
 	tests := []struct {
 		jsonRes       string
+		clusterName   string
 		addr          string
 		ip            string
 		port          uint
@@ -51,6 +52,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 	}{
 		{
 			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-a",
 			addr:          "10.10.11.1:4000",
 			ip:            "10.10.11.1",
 			port:          10080,
@@ -58,6 +60,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-a",
 			addr:          "10.10.11.1:4000",
 			ip:            "10.10.11.1",
 			port:          10082,
@@ -65,6 +68,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[]`,
+			clusterName:   "cluster-a",
 			addr:          "10.10.11.1:4000",
 			ip:            "10.10.11.1",
 			port:          10080,
@@ -72,6 +76,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-0:10080","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-1:10081","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-a",
 			addr:          "tidb-peer-0:4000",
 			ip:            "tidb-peer-0",
 			port:          10080,
@@ -79,6 +84,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-0","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-1","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-a",
 			addr:          "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
 			ip:            "tc-tidb-0.tc-tidb-peer.ns.svc",
 			port:          10080,
@@ -86,6 +92,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-0","job":"tidb"},"values":[[1712700000,"100"]]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-1","job":"tidb"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-a",
 			addr:          "tc-tidb-0.tc-tidb-peer.ns.svc.cluster.local:4000",
 			ip:            "tc-tidb-0.tc-tidb-peer.ns.svc.cluster.local",
 			port:          10080,
@@ -93,10 +100,19 @@ func TestMatrixMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:       `[]`,
+			clusterName:   "cluster-a",
 			addr:          "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
 			ip:            "tc-tidb-0.tc-tidb-peer.ns.svc",
 			port:          10080,
 			expectedPairs: nil,
+		},
+		{
+			jsonRes:       `[{"metric":{"instance":"10.10.11.1:10080","tiproxy_cluster":"cluster-a"},"values":[[1712700000,"100"]]}, {"metric":{"instance":"10.10.11.1:10080","tiproxy_cluster":"cluster-b"},"values":[[1712700000,"200"]]}]`,
+			clusterName:   "cluster-b",
+			addr:          "10.10.11.1:4000",
+			ip:            "10.10.11.1",
+			port:          10080,
+			expectedPairs: []model.SamplePair{{Timestamp: 1712700000000, Value: 200}},
 		},
 	}
 
@@ -107,6 +123,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 			Value: m,
 		}
 		backend := newMockBackend(test.addr, test.ip, test.port)
+		backend.ClusterName = test.clusterName
 		pairs := qr.GetSamplePair4Backend(backend)
 		require.Equal(t, test.expectedPairs, pairs, "test index %d", i)
 	}
@@ -115,6 +132,7 @@ func TestMatrixMatchLabel(t *testing.T) {
 func TestVectorMatchLabel(t *testing.T) {
 	tests := []struct {
 		jsonRes        string
+		clusterName    string
 		addr           string
 		ip             string
 		port           uint
@@ -122,6 +140,7 @@ func TestVectorMatchLabel(t *testing.T) {
 	}{
 		{
 			jsonRes:        `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"value":[1712700000,"100"]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-a",
 			addr:           "10.10.11.1:4000",
 			ip:             "10.10.11.1",
 			port:           10080,
@@ -129,6 +148,7 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10080","job":"tidb"},"value":[1712700000,"100"]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"10.10.11.1:10081","job":"tidb"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-a",
 			addr:           "10.10.11.1:4000",
 			ip:             "10.10.11.1",
 			port:           10082,
@@ -136,6 +156,7 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[]`,
+			clusterName:    "cluster-a",
 			addr:           "10.10.11.1:4000",
 			ip:             "10.10.11.1",
 			port:           10080,
@@ -143,6 +164,7 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-0:10080","job":"tidb"},"value":[1712700000,"100"]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tidb-peer-1:10081","job":"tidb"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-a",
 			addr:           "tidb-peer-0:4000",
 			ip:             "tidb-peer-0",
 			port:           10080,
@@ -150,6 +172,7 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-0","job":"tidb"},"value":[1712700000,"100"]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-1","job":"tidb"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-a",
 			addr:           "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
 			ip:             "tc-tidb-0.tc-tidb-peer.ns.svc",
 			port:           10080,
@@ -157,6 +180,7 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[{"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-0","job":"tidb"},"value":[1712700000,"100"]}, {"metric":{"__name__":"process_cpu_seconds_total","instance":"tc-tidb-1","job":"tidb"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-a",
 			addr:           "tc-tidb-0.tc-tidb-peer.ns.svc.cluster.local:4000",
 			ip:             "tc-tidb-0.tc-tidb-peer.ns.svc.cluster.local",
 			port:           10080,
@@ -164,10 +188,19 @@ func TestVectorMatchLabel(t *testing.T) {
 		},
 		{
 			jsonRes:        `[]`,
+			clusterName:    "cluster-a",
 			addr:           "tc-tidb-0.tc-tidb-peer.ns.svc:4000",
 			ip:             "tc-tidb-0.tc-tidb-peer.ns.svc",
 			port:           10080,
 			expectedSample: nil,
+		},
+		{
+			jsonRes:        `[{"metric":{"instance":"10.10.11.1:10080","tiproxy_cluster":"cluster-a"},"value":[1712700000,"100"]}, {"metric":{"instance":"10.10.11.1:10080","tiproxy_cluster":"cluster-b"},"value":[1712700000,"200"]}]`,
+			clusterName:    "cluster-b",
+			addr:           "10.10.11.1:4000",
+			ip:             "10.10.11.1",
+			port:           10080,
+			expectedSample: &model.Sample{Timestamp: 1712700000000, Value: 200},
 		},
 	}
 
@@ -178,6 +211,7 @@ func TestVectorMatchLabel(t *testing.T) {
 			Value: v,
 		}
 		backend := newMockBackend(test.addr, test.ip, test.port)
+		backend.ClusterName = test.clusterName
 		sample := qr.GetSample4Backend(backend)
 		if test.expectedSample == nil {
 			require.Nil(t, sample, "test index %d", i)

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -18,6 +18,7 @@ type BalancePolicy interface {
 }
 
 type BackendCtx interface {
+	ID() string
 	Addr() string
 	// ConnCount indicates the count of current connections.
 	ConnCount() int

--- a/pkg/balance/policy/mock_test.go
+++ b/pkg/balance/policy/mock_test.go
@@ -31,6 +31,10 @@ func (mb *mockBackend) ConnCount() int {
 	return mb.connScore
 }
 
+func (mb *mockBackend) ID() string {
+	return ""
+}
+
 func (mb *mockBackend) Addr() string {
 	return ""
 }

--- a/pkg/manager/backendcluster/cluster.go
+++ b/pkg/manager/backendcluster/cluster.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/util/etcd"
+	"github.com/pingcap/tiproxy/pkg/util/http"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
@@ -20,6 +22,7 @@ type Cluster struct {
 	cfg        config.BackendCluster
 	etcdCli    *clientv3.Client
 	infoSyncer *infosync.InfoSyncer
+	metrics    *metricsreader.ClusterReader
 }
 
 func (c *Cluster) Config() config.BackendCluster {
@@ -38,7 +41,16 @@ func (c *Cluster) GetPromInfo(ctx context.Context) (*infosync.PrometheusInfo, er
 	return c.infoSyncer.GetPromInfo(ctx)
 }
 
+func (c *Cluster) PreClose() {
+	if c.metrics != nil {
+		c.metrics.PreClose()
+	}
+}
+
 func (c *Cluster) Close() error {
+	if c.metrics != nil {
+		c.metrics.Close()
+	}
 	errs := []error{
 		c.infoSyncer.Close(),
 		c.etcdCli.Close(),
@@ -47,7 +59,15 @@ func (c *Cluster) Close() error {
 }
 
 // NewCluster creates a new Cluster instance based on the given configuration.
-func NewCluster(ctx context.Context, cfg *config.Config, clusterCfg config.BackendCluster, clusterTLS func() *tls.Config, logger *zap.Logger) (*Cluster, error) {
+func NewCluster(
+	ctx context.Context,
+	cfg *config.Config,
+	clusterCfg config.BackendCluster,
+	clusterTLS func() *tls.Config,
+	logger *zap.Logger,
+	cfgGetter config.ConfigGetter,
+	metricsQuerier *MetricsQuerier,
+) (*Cluster, error) {
 	clusterCfg = normalizeCluster(clusterCfg)
 	etcdCli, err := etcd.InitEtcdClientWithAddrs(
 		logger.With(zap.String("cluster", clusterCfg.Name)).Named("etcd"),
@@ -67,9 +87,32 @@ func NewCluster(ctx context.Context, cfg *config.Config, clusterCfg config.Backe
 		return nil, err
 	}
 
-	return &Cluster{
+	cluster := &Cluster{
 		cfg:        clusterCfg,
 		etcdCli:    etcdCli,
 		infoSyncer: infoSyncer,
-	}, nil
+	}
+	cluster.metrics = metricsreader.NewClusterReader(
+		logger.With(zap.String("cluster", clusterCfg.Name)).Named("metrics"),
+		clusterCfg.Name,
+		cluster,
+		cluster,
+		http.NewHTTPClient(clusterTLS),
+		etcdCli,
+		config.NewDefaultHealthCheckConfig(),
+		cfgGetter,
+	)
+	for key, query := range metricsQuerier.snapshot() {
+		cluster.metrics.AddQueryExpr(key, query.expr, query.rule)
+	}
+	if err := cluster.metrics.Start(ctx); err != nil {
+		_ = infoSyncer.Close()
+		if closeErr := etcdCli.Close(); closeErr != nil {
+			logger.Warn("close cluster etcd client failed after metrics init error",
+				zap.String("cluster", clusterCfg.Name), zap.Error(closeErr))
+		}
+		return nil, err
+	}
+
+	return cluster, nil
 }

--- a/pkg/manager/backendcluster/manager.go
+++ b/pkg/manager/backendcluster/manager.go
@@ -22,9 +22,11 @@ import (
 type Manager struct {
 	lg         *zap.Logger
 	clusterTLS func() *tls.Config
+	cfgGetter  config.ConfigGetter
 
-	wg     waitgroup.WaitGroup
-	cancel context.CancelFunc
+	wg      waitgroup.WaitGroup
+	cancel  context.CancelFunc
+	metrics *MetricsQuerier
 
 	mu struct {
 		sync.RWMutex
@@ -38,10 +40,12 @@ func NewManager(lg *zap.Logger, clusterTLS func() *tls.Config) *Manager {
 		clusterTLS: clusterTLS,
 	}
 	mgr.mu.clusters = make(map[string]*Cluster)
+	mgr.metrics = NewMetricsQuerier(mgr)
 	return mgr
 }
 
 func (m *Manager) Start(ctx context.Context, cfgGetter config.ConfigGetter, cfgCh <-chan *config.Config) error {
+	m.cfgGetter = cfgGetter
 	if err := m.syncClusters(ctx, cfgGetter.GetConfig()); err != nil {
 		return err
 	}
@@ -94,7 +98,7 @@ func (m *Manager) syncClusters(ctx context.Context, cfg *config.Config) error {
 				continue
 			}
 
-			cluster, err := NewCluster(ctx, cfg, clusterCfg, m.clusterTLS, m.lg)
+			cluster, err := NewCluster(ctx, cfg, clusterCfg, m.clusterTLS, m.lg, m.cfgGetter, m.metrics)
 			if err != nil {
 				if ok {
 					m.lg.Error("failed to update backend cluster, keep the old one",
@@ -160,7 +164,6 @@ func clusterReusable(cluster *Cluster, cfg config.BackendCluster) bool {
 		left.PDAddrs == right.PDAddrs &&
 		slices.Equal(left.NSServers, right.NSServers)
 }
-
 func (m *Manager) Snapshot() map[string]*Cluster {
 	m.mu.RLock()
 	snapshot := make(map[string]*Cluster, len(m.mu.clusters))
@@ -175,9 +178,12 @@ func (m *Manager) HasBackendClusters() bool {
 	return len(m.mu.clusters) > 0
 }
 
+func (m *Manager) MetricsQuerier() *MetricsQuerier {
+	return m.metrics
+}
+
 // PrimaryCluster returns the only configured cluster when the cluster count is exactly one.
-// It exists for features that are only well-defined in the single-cluster case, such as VIP,
-// and for temporary transition points that still require a unique cluster.
+// It exists for features that are only well-defined in the single-cluster case, such as VIP.
 func (m *Manager) PrimaryCluster() *Cluster {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -188,6 +194,12 @@ func (m *Manager) PrimaryCluster() *Cluster {
 		return cluster
 	}
 	return nil
+}
+
+func (m *Manager) PreClose() {
+	for _, cluster := range m.Snapshot() {
+		cluster.PreClose()
+	}
 }
 
 func (m *Manager) GetTiDBTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error) {

--- a/pkg/manager/backendcluster/metrics_querier.go
+++ b/pkg/manager/backendcluster/metrics_querier.go
@@ -1,0 +1,135 @@
+// Copyright 2026 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backendcluster
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/prometheus/common/model"
+)
+
+var _ metricsreader.MetricsQuerier = (*MetricsQuerier)(nil)
+
+// MetricsQuerier is a thin fan-out and merge view over cluster-scoped metrics readers.
+// It does not own any metrics collection lifecycle by itself.
+type MetricsQuerier struct {
+	manager *Manager
+	mu      sync.RWMutex
+	exprs   map[string]metricsreader.QueryExpr
+	rules   map[string]metricsreader.QueryRule
+}
+
+func NewMetricsQuerier(manager *Manager) *MetricsQuerier {
+	return &MetricsQuerier{
+		manager: manager,
+		exprs:   make(map[string]metricsreader.QueryExpr),
+		rules:   make(map[string]metricsreader.QueryRule),
+	}
+}
+
+func (mq *MetricsQuerier) AddQueryExpr(key string, queryExpr metricsreader.QueryExpr, queryRule metricsreader.QueryRule) {
+	mq.mu.Lock()
+	mq.exprs[key] = queryExpr
+	mq.rules[key] = queryRule
+	mq.mu.Unlock()
+
+	for _, cluster := range mq.manager.Snapshot() {
+		cluster.metrics.AddQueryExpr(key, queryExpr, queryRule)
+	}
+}
+
+func (mq *MetricsQuerier) RemoveQueryExpr(key string) {
+	mq.mu.Lock()
+	delete(mq.exprs, key)
+	delete(mq.rules, key)
+	mq.mu.Unlock()
+
+	for _, cluster := range mq.manager.Snapshot() {
+		cluster.metrics.RemoveQueryExpr(key)
+	}
+}
+
+func (mq *MetricsQuerier) GetQueryResult(key string) metricsreader.QueryResult {
+	results := make([]metricsreader.QueryResult, 0, len(mq.manager.Snapshot()))
+	for _, cluster := range mq.manager.Snapshot() {
+		result := cluster.metrics.GetQueryResult(key)
+		if result.Empty() {
+			continue
+		}
+		results = append(results, result)
+	}
+	return mergeQueryResults(results)
+}
+
+func (mq *MetricsQuerier) GetBackendMetrics() []byte {
+	return mq.GetBackendMetricsByCluster("")
+}
+
+func (mq *MetricsQuerier) GetBackendMetricsByCluster(clusterName string) []byte {
+	if clusterName != "" {
+		snapshot := mq.manager.Snapshot()
+		cluster := snapshot[clusterName]
+		if cluster == nil {
+			return nil
+		}
+		return cluster.metrics.GetBackendMetrics()
+	}
+	if cluster := mq.manager.PrimaryCluster(); cluster != nil {
+		return cluster.metrics.GetBackendMetrics()
+	}
+	return nil
+}
+
+func (mq *MetricsQuerier) snapshot() map[string]struct {
+	expr metricsreader.QueryExpr
+	rule metricsreader.QueryRule
+} {
+	mq.mu.RLock()
+	snapshot := make(map[string]struct {
+		expr metricsreader.QueryExpr
+		rule metricsreader.QueryRule
+	}, len(mq.exprs))
+	for key, expr := range mq.exprs {
+		snapshot[key] = struct {
+			expr metricsreader.QueryExpr
+			rule metricsreader.QueryRule
+		}{
+			expr: expr,
+			rule: mq.rules[key],
+		}
+	}
+	mq.mu.RUnlock()
+	return snapshot
+}
+
+func mergeQueryResults(results []metricsreader.QueryResult) metricsreader.QueryResult {
+	if len(results) == 0 {
+		return metricsreader.QueryResult{}
+	}
+	merged := metricsreader.QueryResult{}
+	for _, result := range results {
+		if merged.UpdateTime.Before(result.UpdateTime) {
+			merged.UpdateTime = result.UpdateTime
+		}
+		if result.Value == nil || reflect.ValueOf(result.Value).IsNil() {
+			continue
+		}
+		switch value := result.Value.(type) {
+		case model.Vector:
+			vector, _ := merged.Value.(model.Vector)
+			vector = append(vector, value...)
+			merged.Value = vector
+		case model.Matrix:
+			matrix, _ := merged.Value.(model.Matrix)
+			matrix = append(matrix, value...)
+			merged.Value = matrix
+		}
+	}
+	if merged.Value == nil {
+		return metricsreader.QueryResult{}
+	}
+	return merged
+}

--- a/pkg/manager/backendcluster/metrics_querier_test.go
+++ b/pkg/manager/backendcluster/metrics_querier_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package backendcluster
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiproxy/lib/config"
+	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestMetricsQuerierQueryRegistry(t *testing.T) {
+	mgr := NewManager(zap.NewNop(), nilClusterTLS)
+	mq := NewMetricsQuerier(mgr)
+
+	expr := metricsreader.QueryExpr{PromQL: "avg(up)"}
+	rule := metricsreader.QueryRule{
+		Names:      []string{"up"},
+		ResultType: model.ValVector,
+	}
+
+	mq.AddQueryExpr("up", expr, rule)
+
+	snapshot := mq.snapshot()
+	require.Len(t, snapshot, 1)
+	require.Equal(t, expr, snapshot["up"].expr)
+	require.Equal(t, rule.Names, snapshot["up"].rule.Names)
+	require.Equal(t, rule.ResultType, snapshot["up"].rule.ResultType)
+
+	mq.RemoveQueryExpr("up")
+	require.Empty(t, mq.snapshot())
+}
+
+func TestMergeQueryResults(t *testing.T) {
+	ts1 := time.Unix(10, 0)
+	ts2 := time.Unix(20, 0)
+	vector1 := model.Vector{
+		&model.Sample{
+			Metric:    model.Metric{model.LabelName("instance"): "tidb-1"},
+			Value:     model.SampleValue(1),
+			Timestamp: model.Time(1000),
+		},
+	}
+	vector2 := model.Vector{
+		&model.Sample{
+			Metric:    model.Metric{model.LabelName("instance"): "tidb-2"},
+			Value:     model.SampleValue(2),
+			Timestamp: model.Time(2000),
+		},
+	}
+
+	merged := mergeQueryResults([]metricsreader.QueryResult{
+		{UpdateTime: ts1, Value: vector1},
+		{UpdateTime: ts2, Value: vector2},
+	})
+	require.Equal(t, ts2, merged.UpdateTime)
+	require.Len(t, merged.Value.(model.Vector), 2)
+	require.ElementsMatch(t, []string{"tidb-1", "tidb-2"}, []string{
+		string(merged.Value.(model.Vector)[0].Metric[model.LabelName("instance")]),
+		string(merged.Value.(model.Vector)[1].Metric[model.LabelName("instance")]),
+	})
+}
+
+func TestMergeQueryResultsMatrix(t *testing.T) {
+	ts1 := time.Unix(10, 0)
+	ts2 := time.Unix(20, 0)
+	matrix1 := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{model.LabelName("instance"): "tidb-1"},
+			Values: []model.SamplePair{{Timestamp: model.Time(1000), Value: model.SampleValue(1)}},
+		},
+	}
+	matrix2 := model.Matrix{
+		&model.SampleStream{
+			Metric: model.Metric{model.LabelName("instance"): "tidb-2"},
+			Values: []model.SamplePair{{Timestamp: model.Time(2000), Value: model.SampleValue(2)}},
+		},
+	}
+
+	merged := mergeQueryResults([]metricsreader.QueryResult{
+		{UpdateTime: ts1, Value: matrix1},
+		{UpdateTime: ts2, Value: matrix2},
+	})
+	require.Equal(t, ts2, merged.UpdateTime)
+	require.Len(t, merged.Value.(model.Matrix), 2)
+	require.ElementsMatch(t, []string{"tidb-1", "tidb-2"}, []string{
+		string(merged.Value.(model.Matrix)[0].Metric[model.LabelName("instance")]),
+		string(merged.Value.(model.Matrix)[1].Metric[model.LabelName("instance")]),
+	})
+}
+
+func TestMetricsQuerierPropagatesQueriesToExistingAndNewClusters(t *testing.T) {
+	clusterA := newManagerTestEtcdCluster(t)
+	clusterB := newManagerTestEtcdCluster(t)
+	t.Cleanup(func() { clusterA.close(t) })
+	t.Cleanup(func() { clusterB.close(t) })
+
+	cfg := newManagerTestConfig()
+	cfg.Proxy.BackendClusters = []config.BackendCluster{
+		{Name: "cluster-a", PDAddrs: clusterA.addr},
+	}
+	cfgGetter := newManagerTestConfigGetter(cfg)
+	cfgCh := make(chan *config.Config, 1)
+
+	mgr := NewManager(zap.NewNop(), nilClusterTLS)
+	require.NoError(t, mgr.Start(context.Background(), cfgGetter, cfgCh))
+	t.Cleanup(func() {
+		require.NoError(t, mgr.Close())
+	})
+
+	expr := metricsreader.QueryExpr{PromQL: "sum(up)"}
+	rule := metricsreader.QueryRule{
+		Names:      []string{"up"},
+		ResultType: model.ValVector,
+	}
+	mgr.MetricsQuerier().AddQueryExpr("up", expr, rule)
+
+	require.Eventually(t, func() bool {
+		return clusterHasBackendQueryRule(mgr.Snapshot()["cluster-a"], "up")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	nextCfg := cfg.Clone()
+	nextCfg.Proxy.BackendClusters = []config.BackendCluster{
+		{Name: "cluster-a", PDAddrs: clusterA.addr},
+		{Name: "cluster-b", PDAddrs: clusterB.addr},
+	}
+	cfgGetter.setConfig(nextCfg)
+	cfgCh <- nextCfg.Clone()
+
+	require.Eventually(t, func() bool {
+		snapshot := mgr.Snapshot()
+		return clusterHasBackendQueryRule(snapshot["cluster-a"], "up") &&
+			clusterHasBackendQueryRule(snapshot["cluster-b"], "up")
+	}, 5*time.Second, 100*time.Millisecond)
+
+	mgr.MetricsQuerier().RemoveQueryExpr("up")
+	require.Eventually(t, func() bool {
+		snapshot := mgr.Snapshot()
+		return !clusterHasBackendQueryRule(snapshot["cluster-a"], "up") &&
+			!clusterHasBackendQueryRule(snapshot["cluster-b"], "up")
+	}, 5*time.Second, 100*time.Millisecond)
+}
+
+func clusterHasBackendQueryRule(cluster *Cluster, key string) bool {
+	if cluster == nil || cluster.metrics == nil {
+		return false
+	}
+	metricsValue := reflect.ValueOf(cluster.metrics).Elem()
+	backendReaderValue := metricsValue.FieldByName("backendReader")
+	if !backendReaderValue.IsValid() || backendReaderValue.IsNil() {
+		return false
+	}
+	queryRulesValue := backendReaderValue.Elem().FieldByName("queryRules")
+	if !queryRulesValue.IsValid() || queryRulesValue.Len() == 0 {
+		return false
+	}
+	return queryRulesValue.MapIndex(reflect.ValueOf(key)).IsValid()
+}

--- a/pkg/manager/namespace/manager.go
+++ b/pkg/manager/namespace/manager.go
@@ -26,7 +26,7 @@ import (
 type NamespaceManager interface {
 	Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher observer.TopologyFetcher,
 		promFetcher metricsreader.PromInfoFetcher, httpCli *http.Client, cfgMgr *mconfig.ConfigManager,
-		metricsReader metricsreader.MetricsReader) error
+		metricsReader metricsreader.MetricsQuerier) error
 	CommitNamespaces(nss []*config.Namespace, nssDelete []bool) error
 	GetNamespace(nm string) (*Namespace, bool)
 	GetNamespaceByUser(user string) (*Namespace, bool)
@@ -40,7 +40,7 @@ type namespaceManager struct {
 	nsm           map[string]*Namespace
 	tpFetcher     observer.TopologyFetcher
 	promFetcher   metricsreader.PromInfoFetcher
-	metricsReader metricsreader.MetricsReader
+	metricsReader metricsreader.MetricsQuerier
 	httpCli       *http.Client
 	logger        *zap.Logger
 	cfgMgr        *mconfig.ConfigManager
@@ -105,7 +105,7 @@ func (mgr *namespaceManager) CommitNamespaces(nss []*config.Namespace, nssDelete
 
 func (mgr *namespaceManager) Init(logger *zap.Logger, nscs []*config.Namespace, tpFetcher observer.TopologyFetcher,
 	promFetcher metricsreader.PromInfoFetcher, httpCli *http.Client, cfgMgr *mconfig.ConfigManager,
-	metricsReader metricsreader.MetricsReader) error {
+	metricsReader metricsreader.MetricsQuerier) error {
 	mgr.Lock()
 	mgr.tpFetcher = tpFetcher
 	mgr.promFetcher = promFetcher

--- a/pkg/proxy/net/packetio_test.go
+++ b/pkg/proxy/net/packetio_test.go
@@ -635,7 +635,9 @@ func TestForwardUntilError(t *testing.T) {
 	wg.Run(func() {
 		testTCPConn(t,
 			func(t *testing.T, cli *packetIO) {
-				require.NoError(t, cli.Close())
+				tcpConn, ok := cli.rawConn.(*net.TCPConn)
+				require.True(t, ok)
+				require.NoError(t, tcpConn.SetLinger(0))
 			},
 			func(t *testing.T, srv2 *packetIO) {
 				srv2.ApplyOpts(WithWrapError(peerErr))

--- a/pkg/server/api/backend.go
+++ b/pkg/server/api/backend.go
@@ -11,11 +11,11 @@ import (
 )
 
 type BackendReader interface {
-	GetBackendMetrics() []byte
+	GetBackendMetricsByCluster(cluster string) []byte
 }
 
 func (h *Server) BackendMetrics(c *gin.Context) {
-	metrics := h.mgr.BackendReader.GetBackendMetrics()
+	metrics := h.mgr.BackendReader.GetBackendMetricsByCluster(c.Query("cluster"))
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(http.StatusOK)
 	if _, err := c.Writer.Write(metrics); err != nil {

--- a/pkg/server/api/backend_test.go
+++ b/pkg/server/api/backend_test.go
@@ -35,19 +35,37 @@ func TestBackendMetrics(t *testing.T) {
 	mbr := server.mgr.BackendReader.(*mockBackendReader)
 	for _, tt := range tests {
 		mbr.data.Store(string(tt.data))
+		mbr.cluster.Store("")
 		doHTTP(t, http.MethodGet, "/api/backend/metrics", httpOpts{}, func(t *testing.T, r *http.Response) {
 			all, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, tt.expect, all)
 			require.Equal(t, http.StatusOK, r.StatusCode)
+			require.Empty(t, mbr.cluster.Load())
 		})
 	}
 }
 
-type mockBackendReader struct {
-	data atomic.String
+func TestBackendMetricsClusterQuery(t *testing.T) {
+	server, doHTTP := createServer(t)
+	mbr := server.mgr.BackendReader.(*mockBackendReader)
+	mbr.data.Store(`{"key":"value"}`)
+
+	doHTTP(t, http.MethodGet, "/api/backend/metrics?cluster=cluster-a", httpOpts{}, func(t *testing.T, r *http.Response) {
+		all, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, []byte(`{"key":"value"}`), all)
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		require.Equal(t, "cluster-a", mbr.cluster.Load())
+	})
 }
 
-func (mbr *mockBackendReader) GetBackendMetrics() []byte {
+type mockBackendReader struct {
+	data    atomic.String
+	cluster atomic.String
+}
+
+func (mbr *mockBackendReader) GetBackendMetricsByCluster(cluster string) []byte {
+	mbr.cluster.Store(cluster)
 	return []byte(mbr.data.Load())
 }

--- a/pkg/server/api/mock_test.go
+++ b/pkg/server/api/mock_test.go
@@ -30,7 +30,7 @@ func newMockNamespaceManager() *mockNamespaceManager {
 }
 
 func (m *mockNamespaceManager) Init(_ *zap.Logger, _ []*config.Namespace, _ observer.TopologyFetcher,
-	_ metricsreader.PromInfoFetcher, _ *http.Client, _ *mconfig.ConfigManager, _ metricsreader.MetricsReader) error {
+	_ metricsreader.PromInfoFetcher, _ *http.Client, _ *mconfig.ConfigManager, _ metricsreader.MetricsQuerier) error {
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
-	"github.com/pingcap/tiproxy/pkg/balance/metricsreader"
 	"github.com/pingcap/tiproxy/pkg/manager/backendcluster"
 	"github.com/pingcap/tiproxy/pkg/manager/cert"
 	mgrcfg "github.com/pingcap/tiproxy/pkg/manager/config"
@@ -44,12 +43,9 @@ type Server struct {
 	certManager      *cert.CertManager
 	clusterManager   *backendcluster.Manager
 	vipManager       vip.VIPManager
-	metricsReader    metricsreader.MetricsReader
 	replay           mgrrp.JobManager
 	meter            *meter.Meter
 	memManager       *memory.MemManager
-	// etcd client
-	etcdCli *clientv3.Client
 	// HTTP client
 	httpCli *http.Client
 	// HTTP server
@@ -111,24 +107,14 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 	if err = srv.clusterManager.Start(ctx, srv.configManager, srv.configManager.WatchConfig()); err != nil {
 		return
 	}
-	var promFetcher metricsreader.PromInfoFetcher
+	var vipEtcdCli *clientv3.Client
 	if cluster := srv.clusterManager.PrimaryCluster(); cluster != nil {
-		srv.etcdCli = cluster.EtcdClient()
-		promFetcher = cluster
+		vipEtcdCli = cluster.EtcdClient()
 	}
 
 	// general cluster HTTP client
 	{
 		srv.httpCli = http.NewHTTPClient(srv.certManager.ClusterTLS)
-	}
-
-	// setup metrics reader
-	{
-		healthCheckCfg := config.NewDefaultHealthCheckConfig()
-		srv.metricsReader = metricsreader.NewDefaultMetricsReader(lg.Named("mr"), promFetcher, srv.clusterManager, srv.httpCli, srv.etcdCli, healthCheckCfg, srv.configManager)
-		if err = srv.metricsReader.Start(ctx); err != nil {
-			return
-		}
 	}
 
 	// setup namespace manager
@@ -153,7 +139,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 			nscs = append(nscs, nsc)
 		}
 
-		err = srv.namespaceManager.Init(lg.Named("nsmgr"), nscs, srv.clusterManager, promFetcher, srv.httpCli, srv.configManager, srv.metricsReader)
+		err = srv.namespaceManager.Init(lg.Named("nsmgr"), nscs, srv.clusterManager, nil, srv.httpCli, srv.configManager, srv.clusterManager.MetricsQuerier())
 		if err != nil {
 			return
 		}
@@ -196,7 +182,7 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 		CfgMgr:        srv.configManager,
 		NsMgr:         srv.namespaceManager,
 		CertMgr:       srv.certManager,
-		BackendReader: srv.metricsReader,
+		BackendReader: srv.clusterManager.MetricsQuerier(),
 		ReplayJobMgr:  srv.replay,
 	}
 	if srv.apiServer, err = api.NewServer(cfg.API, lg.Named("api"), mgrs, handler, ready); err != nil {
@@ -210,8 +196,8 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 			return
 		}
 		if srv.vipManager != nil && !reflect.ValueOf(srv.vipManager).IsNil() {
-			if srv.etcdCli != nil {
-				if err = srv.vipManager.Start(ctx, srv.etcdCli); err != nil {
+			if vipEtcdCli != nil {
+				if err = srv.vipManager.Start(ctx, vipEtcdCli); err != nil {
 					return
 				}
 			} else {
@@ -247,9 +233,8 @@ func (s *Server) preClose() {
 	if s.apiServer != nil {
 		s.apiServer.PreClose()
 	}
-	// Resign the metric reader owner to make other members campaign ASAP.
-	if s.metricsReader != nil && !reflect.ValueOf(s.metricsReader).IsNil() {
-		s.metricsReader.PreClose()
+	if s.clusterManager != nil {
+		s.clusterManager.PreClose()
 	}
 	// Gracefully drain clients.
 	if s.proxy != nil {
@@ -276,9 +261,6 @@ func (s *Server) Close() error {
 	}
 	if s.namespaceManager != nil {
 		errs = append(errs, s.namespaceManager.Close())
-	}
-	if s.metricsReader != nil && !reflect.ValueOf(s.metricsReader).IsNil() {
-		s.metricsReader.Close()
 	}
 	if s.memManager != nil {
 		s.memManager.Close()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1099


- https://github.com/pingcap/tiproxy/pull/1102 
- https://github.com/pingcap/tiproxy/pull/1103
- https://github.com/pingcap/tiproxy/pull/1104
- https://github.com/pingcap/tiproxy/pull/1105 <-
- https://github.com/pingcap/tiproxy/pull/1106
- https://github.com/pingcap/tiproxy/pull/1107

What is changed and how it works:

Move backend metrics lifecycle to the cluster-scoped runtime introduced by the backend-cluster manager.

This PR changes metrics collection so that:
- each backend cluster owns its own metrics reader
- backend metrics election is cluster-scoped
- metrics queries are dispatched through the manager to the right cluster readers


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
