### PR TITLE
balance, proxy: support evicting backends by config

### DIFF
--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -24,7 +24,8 @@
 graceful-close-conn-timeout = 15
 
 # fail-backend-list marks backend pod names or backend addresses as failed. TiProxy will stop routing new
-# connections to them and migrate existing connections away.
+# connections to them and migrate existing connections away. If the list would match all healthy backends,
+# TiProxy ignores the whole list to avoid making the cluster unavailable.
 # fail-backend-list = ["db-2033841436272623616-0f6e346b-tidb-0", "10.0.0.10:4000"]
 
 # failover-timeout is measured in seconds. If a failed backend still has remaining connections after the timeout,

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -24,8 +24,8 @@
 graceful-close-conn-timeout = 15
 
 # fail-backend-list marks backend pod names or backend addresses as failed. TiProxy will stop routing new
-# connections to them and migrate existing connections away. If the list would match all healthy backends,
-# TiProxy ignores the whole list to avoid making the cluster unavailable.
+# connections to them and migrate existing connections away. If the list would leave no routeable backend in
+# a routing group, TiProxy ignores the list for that group to avoid making routing unavailable.
 # fail-backend-list = ["db-2033841436272623616-0f6e346b-tidb-0", "10.0.0.10:4000"]
 
 # failover-timeout is measured in seconds. If a failed backend still has remaining connections after the timeout,

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -23,6 +23,14 @@
 
 graceful-close-conn-timeout = 15
 
+# fail-backend-list marks backend pod names or backend addresses as failed. TiProxy will stop routing new
+# connections to them and migrate existing connections away.
+# fail-backend-list = ["db-2033841436272623616-0f6e346b-tidb-0", "10.0.0.10:4000"]
+
+# failover-timeout is measured in seconds. If a failed backend still has remaining connections after the timeout,
+# TiProxy will force close them.
+# failover-timeout = 60
+
 # possible values:
 #		"" => enable static routing.
 #		"pd-addr:pd-port" => automatically tidb discovery.

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -70,6 +70,11 @@ type ProxyServerOnline struct {
 	// BackendClusters represents multiple backend clusters that the proxy can route to. It can be reloaded
 	// online.
 	BackendClusters []BackendCluster `yaml:"backend-clusters,omitempty" toml:"backend-clusters,omitempty" json:"backend-clusters,omitempty" reloadable:"true"`
+	// FailBackendList contains backend pod names or backend addresses (IP:port) that should be drained immediately
+	// and excluded from new routing.
+	FailBackendList []string `yaml:"fail-backend-list,omitempty" toml:"fail-backend-list,omitempty" json:"fail-backend-list,omitempty" reloadable:"true"`
+	// FailoverTimeout is the grace period in seconds before force closing the remaining connections on failed backends.
+	FailoverTimeout int `yaml:"failover-timeout,omitempty" toml:"failover-timeout,omitempty" json:"failover-timeout,omitempty" reloadable:"true"`
 }
 
 type ProxyServer struct {
@@ -136,6 +141,7 @@ func NewConfig() *Config {
 	cfg.Proxy.FrontendKeepalive, cfg.Proxy.BackendHealthyKeepalive, cfg.Proxy.BackendUnhealthyKeepalive = DefaultKeepAlive()
 	cfg.Proxy.PDAddrs = "127.0.0.1:2379"
 	cfg.Proxy.GracefulCloseConnTimeout = 15
+	cfg.Proxy.FailoverTimeout = 60
 
 	cfg.API.Addr = "0.0.0.0:3080"
 
@@ -162,6 +168,7 @@ func (cfg *Config) Clone() *Config {
 	newCfg.Labels = maps.Clone(cfg.Labels)
 	newCfg.Proxy.PublicEndpoints = slices.Clone(cfg.Proxy.PublicEndpoints)
 	newCfg.Proxy.BackendClusters = slices.Clone(cfg.Proxy.BackendClusters)
+	newCfg.Proxy.FailBackendList = slices.Clone(cfg.Proxy.FailBackendList)
 	for i := range newCfg.Proxy.BackendClusters {
 		newCfg.Proxy.BackendClusters[i].NSServers = slices.Clone(newCfg.Proxy.BackendClusters[i].NSServers)
 	}
@@ -281,6 +288,23 @@ func (ps *ProxyServer) Check() error {
 			return errors.Wrapf(ErrInvalidConfigValue, "invalid proxy.backend-clusters.ns-servers: %s", err.Error())
 		}
 	}
+	if ps.FailoverTimeout < 0 {
+		return errors.Wrapf(ErrInvalidConfigValue, "proxy.failover-timeout must be greater than or equal to 0")
+	}
+	failBackends := ps.FailBackendList[:0]
+	failBackendSet := make(map[string]struct{}, len(ps.FailBackendList))
+	for i, backendName := range ps.FailBackendList {
+		backendName = strings.TrimSpace(backendName)
+		if backendName == "" {
+			return errors.Wrapf(ErrInvalidConfigValue, "proxy.fail-backend-list[%d] is empty", i)
+		}
+		if _, ok := failBackendSet[backendName]; ok {
+			return errors.Wrapf(ErrInvalidConfigValue, "duplicate proxy.fail-backend-list entry %s", backendName)
+		}
+		failBackendSet[backendName] = struct{}{}
+		failBackends = append(failBackends, backendName)
+	}
+	ps.FailBackendList = failBackends
 	return nil
 }
 

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -71,8 +71,8 @@ type ProxyServerOnline struct {
 	// online.
 	BackendClusters []BackendCluster `yaml:"backend-clusters,omitempty" toml:"backend-clusters,omitempty" json:"backend-clusters,omitempty" reloadable:"true"`
 	// FailBackendList contains backend pod names or backend addresses (IP:port) that should be drained immediately
-	// and excluded from new routing. If the configured list would leave no healthy backend, TiProxy ignores the
-	// whole list to keep the cluster available.
+	// and excluded from new routing. If the configured list would leave no routeable backend in a routing group,
+	// TiProxy ignores the list for that group to keep routing available.
 	FailBackendList []string `yaml:"fail-backend-list,omitempty" toml:"fail-backend-list,omitempty" json:"fail-backend-list,omitempty" reloadable:"true"`
 	// FailoverTimeout is the grace period in seconds before force closing the remaining connections on failed backends.
 	FailoverTimeout int `yaml:"failover-timeout,omitempty" toml:"failover-timeout,omitempty" json:"failover-timeout,omitempty" reloadable:"true"`

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -267,10 +267,6 @@ func (ps *ProxyServer) Check() error {
 	if _, err := ps.GetSQLAddrs(); err != nil {
 		return errors.Wrapf(ErrInvalidConfigValue, "invalid proxy.addr or proxy.port-range: %s", err.Error())
 	}
-	if len(ps.BackendClusters) == 0 {
-		return nil
-	}
-
 	clusterNames := make(map[string]struct{}, len(ps.BackendClusters))
 	for i, cluster := range ps.BackendClusters {
 		name := strings.TrimSpace(cluster.Name)
@@ -288,6 +284,7 @@ func (ps *ProxyServer) Check() error {
 			return errors.Wrapf(ErrInvalidConfigValue, "invalid proxy.backend-clusters.ns-servers: %s", err.Error())
 		}
 	}
+
 	if ps.FailoverTimeout < 0 {
 		return errors.Wrapf(ErrInvalidConfigValue, "proxy.failover-timeout must be greater than or equal to 0")
 	}
@@ -299,7 +296,7 @@ func (ps *ProxyServer) Check() error {
 			return errors.Wrapf(ErrInvalidConfigValue, "proxy.fail-backend-list[%d] is empty", i)
 		}
 		if _, ok := failBackendSet[backendName]; ok {
-			return errors.Wrapf(ErrInvalidConfigValue, "duplicate proxy.fail-backend-list entry %s", backendName)
+			continue
 		}
 		failBackendSet[backendName] = struct{}{}
 		failBackends = append(failBackends, backendName)

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -71,7 +71,8 @@ type ProxyServerOnline struct {
 	// online.
 	BackendClusters []BackendCluster `yaml:"backend-clusters,omitempty" toml:"backend-clusters,omitempty" json:"backend-clusters,omitempty" reloadable:"true"`
 	// FailBackendList contains backend pod names or backend addresses (IP:port) that should be drained immediately
-	// and excluded from new routing.
+	// and excluded from new routing. If the configured list would leave no healthy backend, TiProxy ignores the
+	// whole list to keep the cluster available.
 	FailBackendList []string `yaml:"fail-backend-list,omitempty" toml:"fail-backend-list,omitempty" json:"fail-backend-list,omitempty" reloadable:"true"`
 	// FailoverTimeout is the grace period in seconds before force closing the remaining connections on failed backends.
 	FailoverTimeout int `yaml:"failover-timeout,omitempty" toml:"failover-timeout,omitempty" json:"failover-timeout,omitempty" reloadable:"true"`

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -198,12 +198,6 @@ func TestProxyCheck(t *testing.T) {
 		},
 		{
 			pre: func(t *testing.T, c *Config) {
-				c.Proxy.FailBackendList = []string{"db-tidb-0", "db-tidb-0"}
-			},
-			err: ErrInvalidConfigValue,
-		},
-		{
-			pre: func(t *testing.T, c *Config) {
 				c.Proxy.FailoverTimeout = -1
 			},
 			err: ErrInvalidConfigValue,

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -26,6 +26,8 @@ var testProxyConfig = Config{
 			FrontendKeepalive:          KeepAlive{Enabled: true},
 			ProxyProtocol:              "v2",
 			GracefulWaitBeforeShutdown: 10,
+			FailBackendList:            []string{"db-tidb-0", "db-tidb-1"},
+			FailoverTimeout:            60,
 			ConnBufferSize:             32 * 1024,
 			BackendClusters: []BackendCluster{
 				{
@@ -188,6 +190,24 @@ func TestProxyCheck(t *testing.T) {
 			},
 			err: ErrInvalidConfigValue,
 		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.FailBackendList = []string{"db-tidb-0", " "}
+			},
+			err: ErrInvalidConfigValue,
+		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.FailBackendList = []string{"db-tidb-0", "db-tidb-0"}
+			},
+			err: ErrInvalidConfigValue,
+		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.FailoverTimeout = -1
+			},
+			err: ErrInvalidConfigValue,
+		},
 	}
 	for _, tc := range testcases {
 		cfg := testProxyConfig
@@ -311,10 +331,12 @@ func TestCloneConfig(t *testing.T) {
 	require.Equal(t, cfg, *clone)
 	cfg.Labels["c"] = "d"
 	cfg.Proxy.PublicEndpoints[0] = "2.2.2.0/24"
+	cfg.Proxy.FailBackendList[0] = "db-tidb-9"
 	cfg.Proxy.BackendClusters[0].Name = "cluster-updated"
 	cfg.Proxy.BackendClusters[0].NSServers[0] = "10.0.0.9"
 	require.NotContains(t, clone.Labels, "c")
 	require.Equal(t, []string{"1.1.1.0/24"}, clone.Proxy.PublicEndpoints)
+	require.Equal(t, []string{"db-tidb-0", "db-tidb-1"}, clone.Proxy.FailBackendList)
 	require.Equal(t, "cluster-a", clone.Proxy.BackendClusters[0].Name)
 	require.Equal(t, []string{"10.0.0.2", "10.0.0.3"}, clone.Proxy.BackendClusters[0].NSServers)
 }

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -202,6 +202,23 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 	}
 }
 
+func (fbb *FactorBasedBalance) RouteableBackends(backends []policy.BackendCtx) []policy.BackendCtx {
+	if len(backends) == 0 {
+		return nil
+	}
+
+	fbb.Lock()
+	defer fbb.Unlock()
+	scoredBackends := fbb.updateScore(backends)
+	routeable := make([]policy.BackendCtx, 0, len(scoredBackends))
+	for _, backend := range scoredBackends {
+		if fbb.canBeRouted(backend.scoreBits) {
+			routeable = append(routeable, backend.BackendCtx)
+		}
+	}
+	return routeable
+}
+
 func (fbb *FactorBasedBalance) routeIdlest(scoredBackends []scoredBackend, fields *[]zap.Field) policy.BackendCtx {
 	// Evict the backends that are can't be routed to, and then choose the idlest one.
 	// It's like least-connection algorithm.

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -12,6 +12,8 @@ import (
 type BalancePolicy interface {
 	Init(cfg *config.Config)
 	BackendToRoute(backends []BackendCtx) BackendCtx
+	// RouteableBackends returns the backends that are eligible for routing under the current policy.
+	RouteableBackends(backends []BackendCtx) []BackendCtx
 	// balanceCount is the count of connections to balance per second.
 	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field)
 	SetConfig(cfg *config.Config)

--- a/pkg/balance/policy/simple_policy.go
+++ b/pkg/balance/policy/simple_policy.go
@@ -44,6 +44,16 @@ func (sbp *SimpleBalancePolicy) BackendToRoute(backends []BackendCtx) BackendCtx
 	return nil
 }
 
+func (sbp *SimpleBalancePolicy) RouteableBackends(backends []BackendCtx) []BackendCtx {
+	routeable := make([]BackendCtx, 0, len(backends))
+	for _, backend := range backends {
+		if backend.Healthy() {
+			routeable = append(routeable, backend)
+		}
+	}
+	return routeable
+}
+
 func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -256,6 +256,9 @@ func (g *Group) Balance(ctx context.Context) {
 	i := 0
 	for ele := fromBackend.connList.Front(); ele != nil && ctx.Err() == nil && i < count; ele = ele.Next() {
 		conn := ele.Value
+		if conn.forceClosing {
+			continue
+		}
 		switch conn.phase {
 		case phaseRedirectNotify:
 			// A connection cannot be redirected again when it has not finished redirecting.
@@ -282,11 +285,43 @@ func (g *Group) onCreateConn(backendInst BackendInst, conn RedirectableConn, suc
 			RedirectableConn: conn,
 			createTime:       time.Now(),
 			phase:            phaseNotRedirected,
+			forceClosing:     false,
 		}
 		g.addConn(backend, connWrapper)
 		conn.SetEventReceiver(g)
 	} else {
 		backend.connScore--
+	}
+}
+
+func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Duration) {
+	g.Lock()
+	defer g.Unlock()
+	for _, backend := range g.backends {
+		active, since := backend.Failover()
+		if !active {
+			continue
+		}
+		if timeout > 0 && since.Add(timeout).After(now) {
+			continue
+		}
+		for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
+			conn := ele.Value
+			if conn.phase == phaseClosed || conn.forceClosing {
+				continue
+			}
+			fields := []zap.Field{
+				zap.Uint64("connID", conn.ConnectionID()),
+				zap.String("backend_addr", backend.addr),
+				zap.String("backend_pod", backend.PodName()),
+				zap.Duration("failover_timeout", timeout),
+				zap.Duration("failover_elapsed", now.Sub(since)),
+			}
+			if conn.ForceClose() {
+				conn.forceClosing = true
+				g.lg.Warn("force close connection on failover backend", fields...)
+			}
+		}
 	}
 }
 

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -37,6 +37,15 @@ const (
 
 var _ ConnEventReceiver = (*Group)(nil)
 
+type routeCheckBackend struct {
+	*backendWrapper
+	healthy bool
+}
+
+func (b routeCheckBackend) Healthy() bool {
+	return b.healthy
+}
+
 // Group is used for one backend group that can be matched by CIDR, username, database, or resource group list.
 type Group struct {
 	sync.Mutex
@@ -48,6 +57,10 @@ type Group struct {
 	// parsed CIDR list for faster match
 	cidrList []*net.IPNet
 	backends map[string]*backendWrapper
+	// failoverTargets contains backend pod names or addresses configured in fail-backend-list.
+	failoverTargets map[string]struct{}
+	failoverTimeout time.Duration
+	ignoreFailover  bool
 	// To limit the speed of redirection.
 	lastRedirectTime time.Time
 }
@@ -59,11 +72,12 @@ func NewGroup(values []string, bpCreator func(lg *zap.Logger) policy.BalancePoli
 	lg.Info("new group created")
 
 	group := &Group{
-		matchType: matchType,
-		lg:        lg,
-		values:    values,
-		backends:  make(map[string]*backendWrapper),
-		policy:    bpCreator(lg.Named("policy")),
+		matchType:       matchType,
+		lg:              lg,
+		values:          values,
+		backends:        make(map[string]*backendWrapper),
+		failoverTargets: make(map[string]struct{}),
+		policy:          bpCreator(lg.Named("policy")),
 	}
 	err := group.parseValues()
 	if err != nil {
@@ -188,6 +202,104 @@ func setConnWrapper(conn RedirectableConn, ce *glist.Element[*connWrapper]) {
 	conn.SetValue(_routerKey, ce)
 }
 
+func (g *Group) routeableObservedBackendsLocked(failoverBackendIDs map[string]struct{}) []policy.BackendCtx {
+	backends := make([]policy.BackendCtx, 0, len(g.backends))
+	for _, backend := range g.backends {
+		if !backend.ObservedHealthy() {
+			continue
+		}
+		healthy := true
+		if failoverBackendIDs != nil {
+			_, healthy = failoverBackendIDs[backend.ID()]
+			healthy = !healthy
+		}
+		backends = append(backends, routeCheckBackend{
+			backendWrapper: backend,
+			healthy:        healthy,
+		})
+	}
+	return g.policy.RouteableBackends(backends)
+}
+
+func (g *Group) backendInFailoverListLocked(backend *backendWrapper) bool {
+	_, active := g.failoverTargets[backend.PodName()]
+	if !active {
+		_, active = g.failoverTargets[backend.Addr()]
+	}
+	return active
+}
+
+func (g *Group) setFailoverConfigLocked(cfg *config.Config) {
+	targets := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
+	for _, backend := range cfg.Proxy.FailBackendList {
+		targets[backend] = struct{}{}
+	}
+	g.failoverTargets = targets
+	g.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
+}
+
+func (g *Group) updateFailoverLocked(now time.Time) {
+	failoverBackendIDs := make(map[string]struct{}, len(g.backends))
+	for _, backend := range g.backends {
+		if g.backendInFailoverListLocked(backend) {
+			failoverBackendIDs[backend.ID()] = struct{}{}
+		}
+	}
+
+	routeable := g.routeableObservedBackendsLocked(nil)
+	if len(routeable) > 0 {
+		remaining := g.routeableObservedBackendsLocked(failoverBackendIDs)
+		if len(remaining) == 0 {
+			matched := 0
+			for _, backend := range routeable {
+				if _, ok := failoverBackendIDs[backend.ID()]; ok {
+					matched++
+				}
+			}
+			if !g.ignoreFailover {
+				g.lg.Warn("fail-backend-list would leave no routeable backend in group, ignore the list for this group",
+					zap.Int("routeable_backend_count", len(routeable)),
+					zap.Int("matched_routeable_backend_count", matched))
+			}
+			g.ignoreFailover = true
+			clear(failoverBackendIDs)
+		} else {
+			g.ignoreFailover = false
+		}
+	} else {
+		g.ignoreFailover = false
+	}
+
+	for _, backend := range g.backends {
+		_, active := failoverBackendIDs[backend.ID()]
+		since := time.Time{}
+		if active {
+			since = now
+		}
+		changed, since := backend.setFailover(since)
+		if !changed {
+			continue
+		}
+		fields := []zap.Field{
+			zap.String("backend_addr", backend.Addr()),
+			zap.String("backend_pod", backend.PodName()),
+			zap.Duration("failover_timeout", g.failoverTimeout),
+		}
+		if active {
+			fields = append(fields, zap.Time("failover_since", since))
+			g.lg.Warn("backend enters failover", fields...)
+			continue
+		}
+		g.lg.Info("backend exits failover", fields...)
+	}
+}
+
+func (g *Group) UpdateFailover(now time.Time) {
+	g.Lock()
+	defer g.Unlock()
+	g.updateFailoverLocked(now)
+}
+
 func (g *Group) Route(excluded []BackendInst) (policy.BackendCtx, error) {
 	g.Lock()
 	defer g.Unlock()
@@ -294,7 +406,7 @@ func (g *Group) onCreateConn(backendInst BackendInst, conn RedirectableConn, suc
 	}
 }
 
-func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Duration) {
+func (g *Group) CloseTimedOutFailoverConnections(now time.Time) {
 	g.Lock()
 	defer g.Unlock()
 	for _, backend := range g.backends {
@@ -302,7 +414,7 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Dur
 		if since.IsZero() {
 			continue
 		}
-		if timeout > 0 && since.Add(timeout).After(now) {
+		if g.failoverTimeout > 0 && since.Add(g.failoverTimeout).After(now) {
 			continue
 		}
 		for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
@@ -314,7 +426,7 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Dur
 				zap.Uint64("connID", conn.ConnectionID()),
 				zap.String("backend_addr", backend.addr),
 				zap.String("backend_pod", backend.PodName()),
-				zap.Duration("failover_timeout", timeout),
+				zap.Duration("failover_timeout", g.failoverTimeout),
 				zap.Duration("failover_elapsed", now.Sub(since)),
 			}
 			if conn.ForceClose() {
@@ -477,5 +589,9 @@ func (g *Group) ConnCount() int {
 }
 
 func (g *Group) SetConfig(cfg *config.Config) {
+	g.Lock()
+	defer g.Unlock()
 	g.policy.SetConfig(cfg)
+	g.setFailoverConfigLocked(cfg)
+	g.updateFailoverLocked(time.Now())
 }

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -298,8 +298,8 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Dur
 	g.Lock()
 	defer g.Unlock()
 	for _, backend := range g.backends {
-		active, since := backend.Failover()
-		if !active {
+		since := backend.FailoverSince()
+		if since.IsZero() {
 			continue
 		}
 		if timeout > 0 && since.Add(timeout).After(now) {
@@ -319,7 +319,7 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time, timeout time.Dur
 			}
 			if conn.ForceClose() {
 				conn.forceClosing = true
-				g.lg.Warn("force close connection on failover backend", fields...)
+				g.lg.Info("force close connection on failover backend", fields...)
 			}
 		}
 	}

--- a/pkg/balance/router/group_test.go
+++ b/pkg/balance/router/group_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
@@ -171,4 +172,118 @@ func TestRefreshCidr(t *testing.T) {
 		require.True(t, g1.EqualValues(test.final))
 		require.Equal(t, len(g1.values), len(g1.cidrList))
 	}
+}
+
+func TestFailoverBackendByAddr(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.Addr()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Equal(t, toBackend.Addr(), backend.Addr())
+}
+
+func TestIgnoreFailoverListWhenItMatchesAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.addBackends(2)
+
+	require.True(t, tester.getBackendByIndex(0).Healthy())
+	require.True(t, tester.getBackendByIndex(1).Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+}
+
+func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	tester.addConnections(20)
+
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.rebalance(1)
+	tester.redirectFinish(10, true)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName(), toBackend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	require.True(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+
+	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now())
+	for _, conn := range tester.conns {
+		require.False(t, conn.closing)
+	}
+}
+
+func TestFailoverTimeoutForceClose(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(1)
+	tester.addConnections(3)
+	tester.addBackends(1)
+
+	backend := tester.getBackendByIndex(0)
+	tester.updateBackendRedirectSupportByAddr(backend.Addr(), false)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{backend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+
+	tester.rebalance(1)
+	for _, conn := range tester.conns {
+		require.True(t, conn.closing)
+	}
+	tester.closeConnections(3, false)
+	tester.checkBackendConnMetrics()
 }

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -69,6 +69,16 @@ func (conn *mockRedirectableConn) Redirect(inst BackendInst) bool {
 	return true
 }
 
+func (conn *mockRedirectableConn) ForceClose() bool {
+	conn.Lock()
+	defer conn.Unlock()
+	if conn.closing {
+		return false
+	}
+	conn.closing = true
+	return true
+}
+
 func (conn *mockRedirectableConn) GetRedirectingBackendID() string {
 	conn.Lock()
 	defer conn.Unlock()

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -229,6 +229,16 @@ func (m *mockBalancePolicy) BackendToRoute(backends []policy.BackendCtx) policy.
 	return nil
 }
 
+func (m *mockBalancePolicy) RouteableBackends(backends []policy.BackendCtx) []policy.BackendCtx {
+	routeable := make([]policy.BackendCtx, 0, len(backends))
+	for _, backend := range backends {
+		if backend.Healthy() {
+			routeable = append(routeable, backend)
+		}
+	}
+	return routeable
+}
+
 func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount float64, reason string, logFields []zapcore.Field) {
 	if m.backendsToBalance != nil {
 		return m.backendsToBalance(backends)

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -257,15 +257,19 @@ func (m *mockBalancePolicy) getConfig() *config.Config {
 var _ config.ConfigGetter = (*mockConfigGetter)(nil)
 
 type mockConfigGetter struct {
-	cfg *config.Config
+	cfg atomic.Pointer[config.Config]
 }
 
 func newMockConfigGetter(cfg *config.Config) *mockConfigGetter {
-	return &mockConfigGetter{
-		cfg: cfg,
-	}
+	cfgGetter := &mockConfigGetter{}
+	cfgGetter.setConfig(cfg)
+	return cfgGetter
 }
 
 func (cfgGetter *mockConfigGetter) GetConfig() *config.Config {
-	return cfgGetter.cfg
+	return cfgGetter.cfg.Load()
+}
+
+func (cfgGetter *mockConfigGetter) setConfig(cfg *config.Config) {
+	cfgGetter.cfg.Store(cfg)
 }

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -91,8 +91,7 @@ type backendWrapper struct {
 	mu struct {
 		sync.RWMutex
 		observer.BackendHealth
-		failoverActive bool
-		failoverSince  time.Time
+		failoverSince time.Time
 	}
 	id      string
 	addr    string
@@ -145,7 +144,7 @@ func (b *backendWrapper) Addr() string {
 
 func (b *backendWrapper) Healthy() bool {
 	b.mu.RLock()
-	healthy := b.mu.Healthy && !b.mu.failoverActive
+	healthy := b.mu.Healthy && b.mu.failoverSince.IsZero()
 	b.mu.RUnlock()
 	return healthy
 }
@@ -165,24 +164,21 @@ func (b *backendWrapper) setFailover(active bool, since time.Time) (changed bool
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if active {
-		if b.mu.failoverActive {
+		if !b.mu.failoverSince.IsZero() {
 			return false, b.mu.failoverSince
 		}
-		b.mu.failoverActive = true
 		b.mu.failoverSince = since
 		return true, b.mu.failoverSince
 	}
-	if !b.mu.failoverActive {
+	if b.mu.failoverSince.IsZero() {
 		return false, time.Time{}
 	}
-	b.mu.failoverActive = false
 	b.mu.failoverSince = time.Time{}
 	return true, time.Time{}
 }
 
-func (b *backendWrapper) Failover() (active bool, since time.Time) {
+func (b *backendWrapper) FailoverSince() (since time.Time) {
 	b.mu.RLock()
-	active = b.mu.failoverActive
 	since = b.mu.failoverSince
 	b.mu.RUnlock()
 	return

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -4,6 +4,7 @@
 package router
 
 import (
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -69,6 +70,8 @@ type RedirectableConn interface {
 	Value(key any) any
 	// Redirect returns false if the current conn is not redirectable.
 	Redirect(backend BackendInst) bool
+	// ForceClose closes the connection immediately and returns false if it's already closing.
+	ForceClose() bool
 	ConnectionID() uint64
 	ConnInfo() []zap.Field
 }
@@ -88,9 +91,12 @@ type backendWrapper struct {
 	mu struct {
 		sync.RWMutex
 		observer.BackendHealth
+		failoverActive bool
+		failoverSince  time.Time
 	}
-	id   string
-	addr string
+	id      string
+	addr    string
+	podName string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
 	// connScore = connList.Len() + incoming connections - outgoing connections.
 	connScore int
@@ -105,6 +111,7 @@ func newBackendWrapper(id string, health observer.BackendHealth) *backendWrapper
 	wrapper := &backendWrapper{
 		id:       id,
 		addr:     health.Addr,
+		podName:  backendPodNameFromAddr(health.Addr),
 		connList: glist.New[*connWrapper](),
 	}
 	wrapper.setHealth(health)
@@ -138,9 +145,47 @@ func (b *backendWrapper) Addr() string {
 
 func (b *backendWrapper) Healthy() bool {
 	b.mu.RLock()
+	healthy := b.mu.Healthy && !b.mu.failoverActive
+	b.mu.RUnlock()
+	return healthy
+}
+
+func (b *backendWrapper) ObservedHealthy() bool {
+	b.mu.RLock()
 	healthy := b.mu.Healthy
 	b.mu.RUnlock()
 	return healthy
+}
+
+func (b *backendWrapper) PodName() string {
+	return b.podName
+}
+
+func (b *backendWrapper) setFailover(active bool, since time.Time) (changed bool, failoverSince time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if active {
+		if b.mu.failoverActive {
+			return false, b.mu.failoverSince
+		}
+		b.mu.failoverActive = true
+		b.mu.failoverSince = since
+		return true, b.mu.failoverSince
+	}
+	if !b.mu.failoverActive {
+		return false, time.Time{}
+	}
+	b.mu.failoverActive = false
+	b.mu.failoverSince = time.Time{}
+	return true, time.Time{}
+}
+
+func (b *backendWrapper) Failover() (active bool, since time.Time) {
+	b.mu.RLock()
+	active = b.mu.failoverActive
+	since = b.mu.failoverSince
+	b.mu.RUnlock()
+	return
 }
 
 func (b *backendWrapper) ServerVersion() string {
@@ -236,4 +281,22 @@ type connWrapper struct {
 	lastRedirect time.Time
 	createTime   time.Time
 	phase        connPhase
+	forceClosing bool
+}
+
+func backendPodNameFromAddr(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if host == "" {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return host
+	}
+	if idx := strings.IndexByte(host, '.'); idx >= 0 {
+		return host[:idx]
+	}
+	return host
 }

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -160,10 +160,10 @@ func (b *backendWrapper) PodName() string {
 	return b.podName
 }
 
-func (b *backendWrapper) setFailover(active bool, since time.Time) (changed bool, failoverSince time.Time) {
+func (b *backendWrapper) setFailover(since time.Time) (changed bool, failoverSince time.Time) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if active {
+	if !since.IsZero() {
 		if !b.mu.failoverSince.IsZero() {
 			return false, b.mu.failoverSince
 		}

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -228,7 +228,6 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 				zap.String("backend_id", backendID), zap.String("addr", health.Addr), zap.Stringer("health", health))
 			backend = newBackendWrapper(backendID, *health)
 			router.backends[backendID] = backend
-			router.setBackendFailoverLocked(backend, now)
 			serverVersion = health.ServerVersion
 		} else if ok {
 			if !health.Equals(backend.getHealth()) {
@@ -236,7 +235,6 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 					zap.String("backend_id", backendID), zap.String("addr", health.Addr), zap.Stringer("health", health))
 			}
 			backend.setHealth(*health)
-			router.setBackendFailoverLocked(backend, now)
 			if health.Healthy {
 				serverVersion = health.ServerVersion
 			}
@@ -247,6 +245,7 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 		supportRedirection = health.SupportRedirection && supportRedirection
 	}
 
+	router.updateBackendFailoverLocked(now)
 	router.updateGroups()
 	if len(serverVersion) > 0 {
 		router.serverVersion = serverVersion
@@ -432,32 +431,36 @@ func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
 	}
 	router.failoverBackends = failoverBackends
 	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
-	now := time.Now()
-	for _, backend := range router.backends {
-		router.setBackendFailoverLocked(backend, now)
-	}
+	router.updateBackendFailoverLocked(time.Now())
 }
 
-func (router *ScoreBasedRouter) setBackendFailoverLocked(backend *backendWrapper, now time.Time) {
-	_, active := router.failoverBackends[backend.PodName()]
-	if !active {
-		_, active = router.failoverBackends[backend.Addr()]
+func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
+	for _, backend := range router.backends {
+		_, active := router.failoverBackends[backend.PodName()]
+		if !active {
+			// Also support IP:port.
+			_, active = router.failoverBackends[backend.Addr()]
+		}
+		since := time.Time{}
+		if active {
+			since = now
+		}
+		changed, since := backend.setFailover(since)
+		if !changed {
+			return
+		}
+		fields := []zap.Field{
+			zap.String("backend_addr", backend.Addr()),
+			zap.String("backend_pod", backend.PodName()),
+			zap.Duration("failover_timeout", router.failoverTimeout),
+		}
+		if active {
+			fields = append(fields, zap.Time("failover_since", since))
+			router.logger.Warn("backend enters failover", fields...)
+			return
+		}
+		router.logger.Info("backend exits failover", fields...)
 	}
-	changed, since := backend.setFailover(active, now)
-	if !changed {
-		return
-	}
-	fields := []zap.Field{
-		zap.String("backend_addr", backend.Addr()),
-		zap.String("backend_pod", backend.PodName()),
-		zap.Duration("failover_timeout", router.failoverTimeout),
-	}
-	if active {
-		fields = append(fields, zap.Time("failover_since", since))
-		router.logger.Warn("backend enters failover", fields...)
-		return
-	}
-	router.logger.Info("backend exits failover", fields...)
 }
 
 func (router *ScoreBasedRouter) ConnCount() int {

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -51,14 +51,17 @@ type ScoreBasedRouter struct {
 	serverVersion string
 	// The backend supports redirection only when they have signing certs.
 	supportRedirection bool
+	failoverBackends   map[string]struct{}
+	failoverTimeout    time.Duration
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
 func NewScoreBasedRouter(logger *zap.Logger) *ScoreBasedRouter {
 	return &ScoreBasedRouter{
-		logger:   logger,
-		backends: make(map[string]*backendWrapper),
-		groups:   make([]*Group, 0),
+		logger:           logger,
+		backends:         make(map[string]*backendWrapper),
+		groups:           make([]*Group, 0),
+		failoverBackends: make(map[string]struct{}),
 	}
 }
 
@@ -83,6 +86,9 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 	default:
 		r.logger.Error("unsupported routing rule, use the default rule", zap.String("rule", cfg.Balance.RoutingRule))
 	}
+	r.Lock()
+	r.setFailoverConfigLocked(cfg)
+	r.Unlock()
 
 	childCtx, cancelFunc := context.WithCancel(ctx)
 	r.cancelFunc = cancelFunc
@@ -214,12 +220,15 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 	}
 	var serverVersion string
 	supportRedirection := true
+	now := time.Now()
 	for backendID, health := range backends {
 		backend, ok := router.backends[backendID]
 		if !ok && health.Healthy {
 			router.logger.Debug("add new backend to router",
 				zap.String("backend_id", backendID), zap.String("addr", health.Addr), zap.Stringer("health", health))
-			router.backends[backendID] = newBackendWrapper(backendID, *health)
+			backend = newBackendWrapper(backendID, *health)
+			router.backends[backendID] = backend
+			router.setBackendFailoverLocked(backend, now)
 			serverVersion = health.ServerVersion
 		} else if ok {
 			if !health.Equals(backend.getHealth()) {
@@ -227,6 +236,7 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 					zap.String("backend_id", backendID), zap.String("addr", health.Addr), zap.Stringer("health", health))
 			}
 			backend.setHealth(*health)
+			router.setBackendFailoverLocked(backend, now)
 			if health.Healthy {
 				serverVersion = health.ServerVersion
 			}
@@ -292,7 +302,7 @@ func (router *ScoreBasedRouter) updateGroups() {
 	for _, backend := range router.backends {
 		// If connList.Len() == 0, there won't be any outgoing connections.
 		// And if also connScore == 0, there won't be any incoming connections.
-		if !backend.Healthy() && backend.connList.Len() == 0 && backend.connScore <= 0 {
+		if !backend.ObservedHealthy() && backend.connList.Len() == 0 && backend.connScore <= 0 {
 			delete(router.backends, backend.id)
 			if backend.group != nil {
 				backend.group.RemoveBackend(backend.id)
@@ -392,6 +402,7 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 func (router *ScoreBasedRouter) setConfig(cfg *config.Config) {
 	router.Lock()
 	defer router.Unlock()
+	router.setFailoverConfigLocked(cfg)
 	for _, group := range router.groups {
 		group.SetConfig(cfg)
 	}
@@ -404,12 +415,49 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 	router.Lock()
 	defer router.Unlock()
 
-	if !router.supportRedirection {
-		return
+	if router.supportRedirection {
+		for _, group := range router.groups {
+			group.Balance(ctx)
+		}
 	}
 	for _, group := range router.groups {
-		group.Balance(ctx)
+		group.CloseTimedOutFailoverConnections(time.Now(), router.failoverTimeout)
 	}
+}
+
+func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
+	failoverBackends := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
+	for _, backend := range cfg.Proxy.FailBackendList {
+		failoverBackends[backend] = struct{}{}
+	}
+	router.failoverBackends = failoverBackends
+	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
+	now := time.Now()
+	for _, backend := range router.backends {
+		router.setBackendFailoverLocked(backend, now)
+	}
+}
+
+func (router *ScoreBasedRouter) setBackendFailoverLocked(backend *backendWrapper, now time.Time) {
+	_, active := router.failoverBackends[backend.PodName()]
+	if !active {
+		_, active = router.failoverBackends[backend.Addr()]
+	}
+	changed, since := backend.setFailover(active, now)
+	if !changed {
+		return
+	}
+	fields := []zap.Field{
+		zap.String("backend_addr", backend.Addr()),
+		zap.String("backend_pod", backend.PodName()),
+		zap.Duration("failover_timeout", router.failoverTimeout),
+	}
+	if active {
+		fields = append(fields, zap.Time("failover_since", since))
+		router.logger.Warn("backend enters failover", fields...)
+		return
+	}
+	router.logger.Info("backend exits failover", fields...)
 }
 
 func (router *ScoreBasedRouter) ConnCount() int {

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -45,8 +45,10 @@ type ScoreBasedRouter struct {
 	// portConflictDetector dispatches listener ports to cluster-scoped backend groups.
 	portConflictDetector *portConflictDetector
 	// The routing rule for categorizing backends to groups.
-	matchType    MatchType
-	observeError error
+	matchType           MatchType
+	observeError        error
+	routeLabelName      string
+	routeSelfLabelValue string
 	// Only store the version of a random backend, so the client may see a wrong version when backends are upgrading.
 	serverVersion string
 	// The backend supports redirection only when they have signing certs.
@@ -88,6 +90,7 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 		r.logger.Error("unsupported routing rule, use the default rule", zap.String("rule", cfg.Balance.RoutingRule))
 	}
 	r.Lock()
+	r.setRouteConstraintsConfigLocked(cfg)
 	r.setFailoverConfigLocked(cfg)
 	r.Unlock()
 
@@ -246,8 +249,8 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 		supportRedirection = health.SupportRedirection && supportRedirection
 	}
 
-	router.updateBackendFailoverLocked(now)
 	router.updateGroups()
+	router.updateBackendFailoverLocked(now)
 	if len(serverVersion) > 0 {
 		router.serverVersion = serverVersion
 	}
@@ -402,6 +405,7 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 func (router *ScoreBasedRouter) setConfig(cfg *config.Config) {
 	router.Lock()
 	defer router.Unlock()
+	router.setRouteConstraintsConfigLocked(cfg)
 	router.setFailoverConfigLocked(cfg)
 	for _, group := range router.groups {
 		group.SetConfig(cfg)
@@ -432,10 +436,6 @@ func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
 	}
 	router.failoverTargets = failoverTargets
 	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
-	router.logger.Info("apply failover config",
-		zap.Strings("failover_targets", router.failoverTargetListLocked()),
-		zap.Duration("failover_timeout", router.failoverTimeout),
-		zap.Int("backend_count", len(router.backends)))
 	router.updateBackendFailoverLocked(time.Now())
 }
 
@@ -448,70 +448,92 @@ func (router *ScoreBasedRouter) backendInFailoverListLocked(backend *backendWrap
 	return active
 }
 
-func (router *ScoreBasedRouter) failoverTargetListLocked() []string {
-	targets := make([]string, 0, len(router.failoverTargets))
-	for target := range router.failoverTargets {
-		targets = append(targets, target)
+func (router *ScoreBasedRouter) setRouteConstraintsConfigLocked(cfg *config.Config) {
+	router.routeLabelName = cfg.Balance.LabelName
+	router.routeSelfLabelValue = ""
+	if router.routeLabelName != "" && cfg.Labels != nil {
+		router.routeSelfLabelValue = cfg.Labels[router.routeLabelName]
 	}
-	slices.Sort(targets)
-	return targets
 }
 
-func formatFailoverSince(since time.Time) string {
-	if since.IsZero() {
-		return "zero"
+func (router *ScoreBasedRouter) backendRouteableByLabelLocked(backend *backendWrapper) bool {
+	if router.routeLabelName == "" || router.routeSelfLabelValue == "" {
+		return true
 	}
-	return since.Format(time.RFC3339Nano)
+	labels := backend.GetBackendInfo().Labels
+	return labels != nil && labels[router.routeLabelName] == router.routeSelfLabelValue
 }
 
-func formatBackendFailoverState(backend *backendWrapper, matched, observedHealthy bool) string {
-	return fmt.Sprintf("id=%s addr=%s pod=%s matched=%t observed_healthy=%t healthy=%t failover_since=%s",
-		backend.ID(), backend.Addr(), backend.PodName(), matched, observedHealthy, backend.Healthy(), formatFailoverSince(backend.FailoverSince()))
+func (router *ScoreBasedRouter) shouldIgnoreFailoverListLocked(failoverBackendIDs map[string]struct{}) (ignore bool, healthyBackends int, matchedHealthyBackends int, groupValues []string) {
+	type groupStats struct {
+		healthy int
+		matched int
+	}
+
+	globalHealthyBackends := 0
+	globalMatchedHealthyBackends := 0
+	statsByGroup := make(map[*Group]*groupStats, len(router.groups))
+	for _, backend := range router.backends {
+		if !backend.ObservedHealthy() {
+			continue
+		}
+		if !router.backendRouteableByLabelLocked(backend) {
+			continue
+		}
+		globalHealthyBackends++
+		_, matched := failoverBackendIDs[backend.ID()]
+		if matched {
+			globalMatchedHealthyBackends++
+		}
+		if backend.group == nil {
+			continue
+		}
+		stats := statsByGroup[backend.group]
+		if stats == nil {
+			stats = &groupStats{}
+			statsByGroup[backend.group] = stats
+		}
+		stats.healthy++
+		if matched {
+			stats.matched++
+		}
+	}
+
+	if len(statsByGroup) == 0 {
+		return globalHealthyBackends > 0 && globalMatchedHealthyBackends == globalHealthyBackends, globalHealthyBackends, globalMatchedHealthyBackends, nil
+	}
+
+	for group, stats := range statsByGroup {
+		if stats.healthy > 0 && stats.matched == stats.healthy {
+			return true, stats.healthy, stats.matched, group.values
+		}
+	}
+	return false, globalHealthyBackends, globalMatchedHealthyBackends, nil
 }
 
 func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
-	prevIgnoreFailoverList := router.ignoreFailoverList
 	failoverBackendIDs := make(map[string]struct{}, len(router.backends))
-	healthyBackends := 0
-	matchedHealthyBackends := 0
-	backendStates := make([]string, 0, len(router.backends))
 	for _, backend := range router.backends {
-		matched := router.backendInFailoverListLocked(backend)
-		if matched {
+		if router.backendInFailoverListLocked(backend) {
 			failoverBackendIDs[backend.ID()] = struct{}{}
 		}
-		observedHealthy := backend.ObservedHealthy()
-		if len(router.failoverTargets) > 0 {
-			backendStates = append(backendStates, formatBackendFailoverState(backend, matched, observedHealthy))
-		}
-		if !observedHealthy {
-			continue
-		}
-		healthyBackends++
-		if matched {
-			matchedHealthyBackends++
-		}
 	}
-	if healthyBackends > 0 && matchedHealthyBackends == healthyBackends {
+	ignoreFailoverList, healthyBackends, matchedHealthyBackends, groupValues := router.shouldIgnoreFailoverListLocked(failoverBackendIDs)
+	if ignoreFailoverList {
 		if !router.ignoreFailoverList {
-			router.logger.Warn("fail-backend-list would leave no healthy backend, ignore the whole list",
+			fields := []zap.Field{
 				zap.Int("healthy_backend_count", healthyBackends),
-				zap.Int("matched_healthy_backend_count", matchedHealthyBackends))
+				zap.Int("matched_healthy_backend_count", matchedHealthyBackends),
+			}
+			if len(groupValues) > 0 {
+				fields = append(fields, zap.Strings("group_values", groupValues))
+			}
+			router.logger.Warn("fail-backend-list would leave no healthy backend, ignore the whole list", fields...)
 		}
 		router.ignoreFailoverList = true
 		clear(failoverBackendIDs)
 	} else {
 		router.ignoreFailoverList = false
-	}
-	if len(router.failoverTargets) > 0 {
-		router.logger.Info("evaluate failover list",
-			zap.Strings("failover_targets", router.failoverTargetListLocked()),
-			zap.Int("backend_count", len(router.backends)),
-			zap.Int("healthy_backend_count", healthyBackends),
-			zap.Int("matched_healthy_backend_count", matchedHealthyBackends),
-			zap.Bool("ignore_failover_list_before", prevIgnoreFailoverList),
-			zap.Bool("ignore_failover_list_after", router.ignoreFailoverList),
-			zap.Strings("backend_states", backendStates))
 	}
 	for _, backend := range router.backends {
 		_, active := failoverBackendIDs[backend.ID()]

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -432,6 +432,10 @@ func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
 	}
 	router.failoverTargets = failoverTargets
 	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
+	router.logger.Info("apply failover config",
+		zap.Strings("failover_targets", router.failoverTargetListLocked()),
+		zap.Duration("failover_timeout", router.failoverTimeout),
+		zap.Int("backend_count", len(router.backends)))
 	router.updateBackendFailoverLocked(time.Now())
 }
 
@@ -444,16 +448,43 @@ func (router *ScoreBasedRouter) backendInFailoverListLocked(backend *backendWrap
 	return active
 }
 
+func (router *ScoreBasedRouter) failoverTargetListLocked() []string {
+	targets := make([]string, 0, len(router.failoverTargets))
+	for target := range router.failoverTargets {
+		targets = append(targets, target)
+	}
+	slices.Sort(targets)
+	return targets
+}
+
+func formatFailoverSince(since time.Time) string {
+	if since.IsZero() {
+		return "zero"
+	}
+	return since.Format(time.RFC3339Nano)
+}
+
+func formatBackendFailoverState(backend *backendWrapper, matched, observedHealthy bool) string {
+	return fmt.Sprintf("id=%s addr=%s pod=%s matched=%t observed_healthy=%t healthy=%t failover_since=%s",
+		backend.ID(), backend.Addr(), backend.PodName(), matched, observedHealthy, backend.Healthy(), formatFailoverSince(backend.FailoverSince()))
+}
+
 func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
+	prevIgnoreFailoverList := router.ignoreFailoverList
 	failoverBackendIDs := make(map[string]struct{}, len(router.backends))
 	healthyBackends := 0
 	matchedHealthyBackends := 0
+	backendStates := make([]string, 0, len(router.backends))
 	for _, backend := range router.backends {
 		matched := router.backendInFailoverListLocked(backend)
 		if matched {
 			failoverBackendIDs[backend.ID()] = struct{}{}
 		}
-		if !backend.ObservedHealthy() {
+		observedHealthy := backend.ObservedHealthy()
+		if len(router.failoverTargets) > 0 {
+			backendStates = append(backendStates, formatBackendFailoverState(backend, matched, observedHealthy))
+		}
+		if !observedHealthy {
 			continue
 		}
 		healthyBackends++
@@ -471,6 +502,16 @@ func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
 		clear(failoverBackendIDs)
 	} else {
 		router.ignoreFailoverList = false
+	}
+	if len(router.failoverTargets) > 0 {
+		router.logger.Info("evaluate failover list",
+			zap.Strings("failover_targets", router.failoverTargetListLocked()),
+			zap.Int("backend_count", len(router.backends)),
+			zap.Int("healthy_backend_count", healthyBackends),
+			zap.Int("matched_healthy_backend_count", matchedHealthyBackends),
+			zap.Bool("ignore_failover_list_before", prevIgnoreFailoverList),
+			zap.Bool("ignore_failover_list_after", router.ignoreFailoverList),
+			zap.Strings("backend_states", backendStates))
 	}
 	for _, backend := range router.backends {
 		_, active := failoverBackendIDs[backend.ID()]

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -51,17 +51,18 @@ type ScoreBasedRouter struct {
 	serverVersion string
 	// The backend supports redirection only when they have signing certs.
 	supportRedirection bool
-	failoverBackends   map[string]struct{}
+	failoverTargets    map[string]struct{}
 	failoverTimeout    time.Duration
+	ignoreFailoverList bool
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
 func NewScoreBasedRouter(logger *zap.Logger) *ScoreBasedRouter {
 	return &ScoreBasedRouter{
-		logger:           logger,
-		backends:         make(map[string]*backendWrapper),
-		groups:           make([]*Group, 0),
-		failoverBackends: make(map[string]struct{}),
+		logger:          logger,
+		backends:        make(map[string]*backendWrapper),
+		groups:          make([]*Group, 0),
+		failoverTargets: make(map[string]struct{}),
 	}
 }
 
@@ -425,29 +426,61 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 }
 
 func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
-	failoverBackends := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
+	failoverTargets := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
 	for _, backend := range cfg.Proxy.FailBackendList {
-		failoverBackends[backend] = struct{}{}
+		failoverTargets[backend] = struct{}{}
 	}
-	router.failoverBackends = failoverBackends
+	router.failoverTargets = failoverTargets
 	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
 	router.updateBackendFailoverLocked(time.Now())
 }
 
+func (router *ScoreBasedRouter) backendInFailoverListLocked(backend *backendWrapper) bool {
+	_, active := router.failoverTargets[backend.PodName()]
+	if !active {
+		// Also support IP:port.
+		_, active = router.failoverTargets[backend.Addr()]
+	}
+	return active
+}
+
 func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
+	failoverBackendIDs := make(map[string]struct{}, len(router.backends))
+	healthyBackends := 0
+	matchedHealthyBackends := 0
 	for _, backend := range router.backends {
-		_, active := router.failoverBackends[backend.PodName()]
-		if !active {
-			// Also support IP:port.
-			_, active = router.failoverBackends[backend.Addr()]
+		matched := router.backendInFailoverListLocked(backend)
+		if matched {
+			failoverBackendIDs[backend.ID()] = struct{}{}
 		}
+		if !backend.ObservedHealthy() {
+			continue
+		}
+		healthyBackends++
+		if matched {
+			matchedHealthyBackends++
+		}
+	}
+	if healthyBackends > 0 && matchedHealthyBackends == healthyBackends {
+		if !router.ignoreFailoverList {
+			router.logger.Warn("fail-backend-list would leave no healthy backend, ignore the whole list",
+				zap.Int("healthy_backend_count", healthyBackends),
+				zap.Int("matched_healthy_backend_count", matchedHealthyBackends))
+		}
+		router.ignoreFailoverList = true
+		clear(failoverBackendIDs)
+	} else {
+		router.ignoreFailoverList = false
+	}
+	for _, backend := range router.backends {
+		_, active := failoverBackendIDs[backend.ID()]
 		since := time.Time{}
 		if active {
 			since = now
 		}
 		changed, since := backend.setFailover(since)
 		if !changed {
-			return
+			continue
 		}
 		fields := []zap.Field{
 			zap.String("backend_addr", backend.Addr()),
@@ -457,7 +490,7 @@ func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
 		if active {
 			fields = append(fields, zap.Time("failover_since", since))
 			router.logger.Warn("backend enters failover", fields...)
-			return
+			continue
 		}
 		router.logger.Info("backend exits failover", fields...)
 	}

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -47,7 +47,6 @@ type ScoreBasedRouter struct {
 	// The routing rule for categorizing backends to groups.
 	matchType    MatchType
 	observeError error
-	currentCfg   *config.Config
 	// Only store the version of a random backend, so the client may see a wrong version when backends are upgrading.
 	serverVersion string
 	// The backend supports redirection only when they have signing certs.
@@ -84,9 +83,6 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 	default:
 		r.logger.Error("unsupported routing rule, use the default rule", zap.String("rule", cfg.Balance.RoutingRule))
 	}
-	r.Lock()
-	r.currentCfg = cfg
-	r.Unlock()
 
 	childCtx, cancelFunc := context.WithCancel(ctx)
 	r.cancelFunc = cancelFunc
@@ -355,8 +351,10 @@ func (router *ScoreBasedRouter) updateGroups() {
 				g, err := NewGroup(values, router.bpCreator, router.matchType, router.logger)
 				if err == nil {
 					group = g
-					if router.currentCfg != nil {
-						group.SetConfig(router.currentCfg)
+					if router.cfgGetter != nil {
+						if cfg := router.cfgGetter.GetConfig(); cfg != nil {
+							group.SetConfig(cfg)
+						}
 					}
 					router.groups = append(router.groups, group)
 				}
@@ -404,7 +402,6 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 func (router *ScoreBasedRouter) setConfig(cfg *config.Config) {
 	router.Lock()
 	defer router.Unlock()
-	router.currentCfg = cfg
 	for _, group := range router.groups {
 		group.SetConfig(cfg)
 	}

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -45,26 +45,21 @@ type ScoreBasedRouter struct {
 	// portConflictDetector dispatches listener ports to cluster-scoped backend groups.
 	portConflictDetector *portConflictDetector
 	// The routing rule for categorizing backends to groups.
-	matchType           MatchType
-	observeError        error
-	routeLabelName      string
-	routeSelfLabelValue string
+	matchType    MatchType
+	observeError error
+	currentCfg   *config.Config
 	// Only store the version of a random backend, so the client may see a wrong version when backends are upgrading.
 	serverVersion string
 	// The backend supports redirection only when they have signing certs.
 	supportRedirection bool
-	failoverTargets    map[string]struct{}
-	failoverTimeout    time.Duration
-	ignoreFailoverList bool
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
 func NewScoreBasedRouter(logger *zap.Logger) *ScoreBasedRouter {
 	return &ScoreBasedRouter{
-		logger:          logger,
-		backends:        make(map[string]*backendWrapper),
-		groups:          make([]*Group, 0),
-		failoverTargets: make(map[string]struct{}),
+		logger:   logger,
+		backends: make(map[string]*backendWrapper),
+		groups:   make([]*Group, 0),
 	}
 }
 
@@ -90,8 +85,7 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 		r.logger.Error("unsupported routing rule, use the default rule", zap.String("rule", cfg.Balance.RoutingRule))
 	}
 	r.Lock()
-	r.setRouteConstraintsConfigLocked(cfg)
-	r.setFailoverConfigLocked(cfg)
+	r.currentCfg = cfg
 	r.Unlock()
 
 	childCtx, cancelFunc := context.WithCancel(ctx)
@@ -250,7 +244,9 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 	}
 
 	router.updateGroups()
-	router.updateBackendFailoverLocked(now)
+	for _, group := range router.groups {
+		group.UpdateFailover(now)
+	}
 	if len(serverVersion) > 0 {
 		router.serverVersion = serverVersion
 	}
@@ -359,6 +355,9 @@ func (router *ScoreBasedRouter) updateGroups() {
 				g, err := NewGroup(values, router.bpCreator, router.matchType, router.logger)
 				if err == nil {
 					group = g
+					if router.currentCfg != nil {
+						group.SetConfig(router.currentCfg)
+					}
 					router.groups = append(router.groups, group)
 				}
 				// maybe too many logs, ignore the error now
@@ -405,8 +404,7 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 func (router *ScoreBasedRouter) setConfig(cfg *config.Config) {
 	router.Lock()
 	defer router.Unlock()
-	router.setRouteConstraintsConfigLocked(cfg)
-	router.setFailoverConfigLocked(cfg)
+	router.currentCfg = cfg
 	for _, group := range router.groups {
 		group.SetConfig(cfg)
 	}
@@ -425,137 +423,7 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 		}
 	}
 	for _, group := range router.groups {
-		group.CloseTimedOutFailoverConnections(time.Now(), router.failoverTimeout)
-	}
-}
-
-func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
-	failoverTargets := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
-	for _, backend := range cfg.Proxy.FailBackendList {
-		failoverTargets[backend] = struct{}{}
-	}
-	router.failoverTargets = failoverTargets
-	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
-	router.updateBackendFailoverLocked(time.Now())
-}
-
-func (router *ScoreBasedRouter) backendInFailoverListLocked(backend *backendWrapper) bool {
-	_, active := router.failoverTargets[backend.PodName()]
-	if !active {
-		// Also support IP:port.
-		_, active = router.failoverTargets[backend.Addr()]
-	}
-	return active
-}
-
-func (router *ScoreBasedRouter) setRouteConstraintsConfigLocked(cfg *config.Config) {
-	router.routeLabelName = cfg.Balance.LabelName
-	router.routeSelfLabelValue = ""
-	if router.routeLabelName != "" && cfg.Labels != nil {
-		router.routeSelfLabelValue = cfg.Labels[router.routeLabelName]
-	}
-}
-
-func (router *ScoreBasedRouter) backendRouteableByLabelLocked(backend *backendWrapper) bool {
-	if router.routeLabelName == "" || router.routeSelfLabelValue == "" {
-		return true
-	}
-	labels := backend.GetBackendInfo().Labels
-	return labels != nil && labels[router.routeLabelName] == router.routeSelfLabelValue
-}
-
-func (router *ScoreBasedRouter) shouldIgnoreFailoverListLocked(failoverBackendIDs map[string]struct{}) (ignore bool, healthyBackends int, matchedHealthyBackends int, groupValues []string) {
-	type groupStats struct {
-		healthy int
-		matched int
-	}
-
-	globalHealthyBackends := 0
-	globalMatchedHealthyBackends := 0
-	statsByGroup := make(map[*Group]*groupStats, len(router.groups))
-	for _, backend := range router.backends {
-		if !backend.ObservedHealthy() {
-			continue
-		}
-		if !router.backendRouteableByLabelLocked(backend) {
-			continue
-		}
-		globalHealthyBackends++
-		_, matched := failoverBackendIDs[backend.ID()]
-		if matched {
-			globalMatchedHealthyBackends++
-		}
-		if backend.group == nil {
-			continue
-		}
-		stats := statsByGroup[backend.group]
-		if stats == nil {
-			stats = &groupStats{}
-			statsByGroup[backend.group] = stats
-		}
-		stats.healthy++
-		if matched {
-			stats.matched++
-		}
-	}
-
-	if len(statsByGroup) == 0 {
-		return globalHealthyBackends > 0 && globalMatchedHealthyBackends == globalHealthyBackends, globalHealthyBackends, globalMatchedHealthyBackends, nil
-	}
-
-	for group, stats := range statsByGroup {
-		if stats.healthy > 0 && stats.matched == stats.healthy {
-			return true, stats.healthy, stats.matched, group.values
-		}
-	}
-	return false, globalHealthyBackends, globalMatchedHealthyBackends, nil
-}
-
-func (router *ScoreBasedRouter) updateBackendFailoverLocked(now time.Time) {
-	failoverBackendIDs := make(map[string]struct{}, len(router.backends))
-	for _, backend := range router.backends {
-		if router.backendInFailoverListLocked(backend) {
-			failoverBackendIDs[backend.ID()] = struct{}{}
-		}
-	}
-	ignoreFailoverList, healthyBackends, matchedHealthyBackends, groupValues := router.shouldIgnoreFailoverListLocked(failoverBackendIDs)
-	if ignoreFailoverList {
-		if !router.ignoreFailoverList {
-			fields := []zap.Field{
-				zap.Int("healthy_backend_count", healthyBackends),
-				zap.Int("matched_healthy_backend_count", matchedHealthyBackends),
-			}
-			if len(groupValues) > 0 {
-				fields = append(fields, zap.Strings("group_values", groupValues))
-			}
-			router.logger.Warn("fail-backend-list would leave no healthy backend, ignore the whole list", fields...)
-		}
-		router.ignoreFailoverList = true
-		clear(failoverBackendIDs)
-	} else {
-		router.ignoreFailoverList = false
-	}
-	for _, backend := range router.backends {
-		_, active := failoverBackendIDs[backend.ID()]
-		since := time.Time{}
-		if active {
-			since = now
-		}
-		changed, since := backend.setFailover(since)
-		if !changed {
-			continue
-		}
-		fields := []zap.Field{
-			zap.String("backend_addr", backend.Addr()),
-			zap.String("backend_pod", backend.PodName()),
-			zap.Duration("failover_timeout", router.failoverTimeout),
-		}
-		if active {
-			fields = append(fields, zap.Time("failover_since", since))
-			router.logger.Warn("backend enters failover", fields...)
-			continue
-		}
-		router.logger.Info("backend exits failover", fields...)
+		group.CloseTimedOutFailoverConnections(time.Now())
 	}
 }
 

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -782,95 +782,6 @@ func TestFailoverBackend(t *testing.T) {
 	tester.checkBackendConnMetrics()
 }
 
-func TestFailoverBackendByAddr(t *testing.T) {
-	tester := newRouterTester(t, nil)
-	tester.addBackends(2)
-
-	fromBackend := tester.getBackendByIndex(0)
-	toBackend := tester.getBackendByIndex(1)
-	tester.router.setConfig(&config.Config{
-		Proxy: config.ProxyServer{
-			ProxyServerOnline: config.ProxyServerOnline{
-				FailBackendList: []string{fromBackend.Addr()},
-				FailoverTimeout: 60,
-			},
-		},
-	})
-
-	require.False(t, fromBackend.Healthy())
-	require.True(t, toBackend.Healthy())
-	selector := tester.router.GetBackendSelector(ClientInfo{})
-	backend, err := selector.Next()
-	require.NoError(t, err)
-	selector.Finish(nil, false)
-	require.NotNil(t, backend)
-	require.Equal(t, toBackend.Addr(), backend.Addr())
-}
-
-func TestIgnoreFailoverListWhenItMatchesAllHealthyBackends(t *testing.T) {
-	tester := newRouterTester(t, nil)
-	tester.router.setConfig(&config.Config{
-		Proxy: config.ProxyServer{
-			ProxyServerOnline: config.ProxyServerOnline{
-				FailBackendList: []string{"1", "2"},
-				FailoverTimeout: 60,
-			},
-		},
-	})
-	tester.addBackends(2)
-
-	require.True(t, tester.getBackendByIndex(0).Healthy())
-	require.True(t, tester.getBackendByIndex(1).Healthy())
-	require.Equal(t, 2, tester.router.HealthyBackendCount())
-
-	selector := tester.router.GetBackendSelector(ClientInfo{})
-	backend, err := selector.Next()
-	require.NoError(t, err)
-	selector.Finish(nil, false)
-	require.NotNil(t, backend)
-}
-
-func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
-	tester := newRouterTester(t, nil)
-	tester.addBackends(2)
-	tester.addConnections(20)
-
-	fromBackend := tester.getBackendByIndex(0)
-	toBackend := tester.getBackendByIndex(1)
-
-	tester.router.setConfig(&config.Config{
-		Proxy: config.ProxyServer{
-			ProxyServerOnline: config.ProxyServerOnline{
-				FailBackendList: []string{fromBackend.PodName()},
-				FailoverTimeout: 60,
-			},
-		},
-	})
-	tester.rebalance(1)
-	tester.redirectFinish(10, true)
-	require.Equal(t, 0, fromBackend.ConnCount())
-	require.Equal(t, 20, toBackend.ConnCount())
-	require.False(t, fromBackend.Healthy())
-	require.True(t, toBackend.Healthy())
-
-	tester.router.setConfig(&config.Config{
-		Proxy: config.ProxyServer{
-			ProxyServerOnline: config.ProxyServerOnline{
-				FailBackendList: []string{fromBackend.PodName(), toBackend.PodName()},
-				FailoverTimeout: 0,
-			},
-		},
-	})
-	require.True(t, fromBackend.Healthy())
-	require.True(t, toBackend.Healthy())
-	require.Equal(t, 2, tester.router.HealthyBackendCount())
-
-	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now())
-	for _, conn := range tester.conns {
-		require.False(t, conn.closing)
-	}
-}
-
 func TestIgnoreFailoverListWhenItMatchesAllHealthyBackendsInRouteGroup(t *testing.T) {
 	tester := newRouterTester(t, nil)
 	tester.router.matchType = MatchPort
@@ -1112,31 +1023,6 @@ func TestFailoverListReevaluatedWithBackendHealth(t *testing.T) {
 	require.False(t, tester.getBackendByIndex(1).Healthy())
 	require.True(t, tester.getBackendByIndex(2).Healthy())
 	require.Equal(t, 1, tester.router.HealthyBackendCount())
-}
-
-func TestFailoverTimeoutForceClose(t *testing.T) {
-	tester := newRouterTester(t, nil)
-	tester.addBackends(1)
-	tester.addConnections(3)
-	tester.addBackends(1)
-
-	backend := tester.getBackendByIndex(0)
-	tester.updateBackendRedirectSupportByAddr(backend.Addr(), false)
-	tester.router.setConfig(&config.Config{
-		Proxy: config.ProxyServer{
-			ProxyServerOnline: config.ProxyServerOnline{
-				FailBackendList: []string{backend.PodName()},
-				FailoverTimeout: 0,
-			},
-		},
-	})
-
-	tester.rebalance(1)
-	for _, conn := range tester.conns {
-		require.True(t, conn.closing)
-	}
-	tester.closeConnections(3, false)
-	tester.checkBackendConnMetrics()
 }
 
 func TestGetServerVersion(t *testing.T) {

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -1376,6 +1376,57 @@ func TestWatchFailoverConfig(t *testing.T) {
 	}, 3*time.Second, 10*time.Millisecond)
 }
 
+func TestNewGroupUsesLatestConfigGetter(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	router := NewScoreBasedRouter(lg)
+	cfgCh := make(chan *config.Config)
+	cfgGetter := newMockConfigGetter(&config.Config{
+		Balance: config.Balance{
+			RoutingRule: config.MatchPortStr,
+		},
+	})
+	bo := newMockBackendObserver()
+	router.Init(context.Background(), bo, simpleBpCreator, cfgGetter, cfgCh)
+	t.Cleanup(bo.Close)
+	t.Cleanup(router.Close)
+
+	addr1 := "db-2033841436272623616-0f6e346b-tidb-0.peer.ns.svc:4000"
+	addr2 := "db-2033841436272623616-0f6e346b-tidb-1.peer.ns.svc:4000"
+	addr3 := "db-2033841436272623616-0f6e346b-tidb-2.peer.ns.svc:4000"
+	bo.addBackend(addr1, map[string]string{config.TiProxyPortLabelName: "10080"})
+	bo.notify(nil)
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr1]
+		return backend != nil && backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+
+	nextCfg := &config.Config{
+		Balance: config.Balance{
+			RoutingRule: config.MatchPortStr,
+		},
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{addr2},
+				FailoverTimeout: 60,
+			},
+		},
+	}
+	cfgGetter.setConfig(nextCfg)
+	cfgCh <- nextCfg
+
+	bo.addBackend(addr2, map[string]string{config.TiProxyPortLabelName: "10081"})
+	bo.addBackend(addr3, map[string]string{config.TiProxyPortLabelName: "10081"})
+	bo.notify(nil)
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr2]
+		return backend != nil && !backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr3]
+		return backend != nil && backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
 func TestControlSpeed(t *testing.T) {
 	tests := []struct {
 		balanceCount     float64

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -829,6 +829,47 @@ func TestIgnoreFailoverListWhenItMatchesAllHealthyBackends(t *testing.T) {
 	require.NotNil(t, backend)
 }
 
+func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	tester.addConnections(20)
+
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.rebalance(1)
+	tester.redirectFinish(10, true)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName(), toBackend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	require.True(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+
+	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now(), 0)
+	for _, conn := range tester.conns {
+		require.False(t, conn.closing)
+	}
+}
+
 func TestFailoverListReevaluatedWithBackendHealth(t *testing.T) {
 	tester := newRouterTester(t, nil)
 	tester.addBackends(3)

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -136,6 +136,13 @@ func (tester *routerTester) updateBackendLocalityByAddr(addr string, local bool)
 	tester.notifyHealth()
 }
 
+func (tester *routerTester) updateBackendRedirectSupportByAddr(addr string, support bool) {
+	health, ok := tester.backends[addr]
+	require.True(tester.t, ok)
+	health.SupportRedirection = support
+	tester.notifyHealth()
+}
+
 func (tester *routerTester) getBackendByIndex(index int) *backendWrapper {
 	addr := strconv.Itoa(index + 1)
 	backend := tester.router.backends[addr]
@@ -735,6 +742,94 @@ func TestSetBackendStatus(t *testing.T) {
 	}
 }
 
+func TestBackendPodNameFromAddr(t *testing.T) {
+	require.Equal(t, "db-2033841436272623616-0f6e346b-tidb-0", backendPodNameFromAddr("db-2033841436272623616-0f6e346b-tidb-0.peer.ns.svc:4000"))
+	require.Equal(t, "127.0.0.1", backendPodNameFromAddr("127.0.0.1:4000"))
+	require.Equal(t, "backend-host", backendPodNameFromAddr("backend-host"))
+}
+
+func TestFailoverBackend(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	tester.addConnections(20)
+
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+
+	require.False(t, fromBackend.Healthy())
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Equal(t, toBackend.Addr(), backend.Addr())
+
+	tester.rebalance(1)
+	require.Equal(t, 10, fromBackend.ConnCount())
+	tester.checkRedirectingNum(10)
+	tester.redirectFinish(10, true)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+	tester.checkBackendConnMetrics()
+}
+
+func TestFailoverBackendByAddr(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.Addr()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Equal(t, toBackend.Addr(), backend.Addr())
+}
+
+func TestFailoverTimeoutForceClose(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(1)
+	tester.addConnections(3)
+
+	backend := tester.getBackendByIndex(0)
+	tester.updateBackendRedirectSupportByAddr(backend.Addr(), false)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{backend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+
+	tester.rebalance(1)
+	for _, conn := range tester.conns {
+		require.True(t, conn.closing)
+	}
+	tester.closeConnections(3, false)
+	tester.checkBackendConnMetrics()
+}
+
 func TestGetServerVersion(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)
@@ -905,6 +1000,69 @@ func TestChannelClosed(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 		})
 	}
+}
+
+func TestWatchFailoverConfig(t *testing.T) {
+	lg, _ := logger.CreateLoggerForTest(t)
+	router := NewScoreBasedRouter(lg)
+	cfgCh := make(chan *config.Config)
+	addr := "db-2033841436272623616-0f6e346b-tidb-0.peer.ns.svc:4000"
+	cfgGetter := newMockConfigGetter(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	bo := newMockBackendObserver()
+	router.Init(context.Background(), bo, simpleBpCreator, cfgGetter, cfgCh)
+	t.Cleanup(bo.Close)
+	t.Cleanup(router.Close)
+
+	bo.addBackend(addr, nil)
+	bo.notify(nil)
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr]
+		return backend != nil && backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+
+	cfgCh <- &config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"db-2033841436272623616-0f6e346b-tidb-0"},
+				FailoverTimeout: 60,
+			},
+		},
+	}
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr]
+		return backend != nil && !backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+
+	cfgCh <- &config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{addr},
+				FailoverTimeout: 60,
+			},
+		},
+	}
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr]
+		return backend != nil && !backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
+
+	cfgCh <- &config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailoverTimeout: 60,
+			},
+		},
+	}
+	require.Eventually(t, func() bool {
+		backend := router.backends[addr]
+		return backend != nil && backend.Healthy()
+	}, 3*time.Second, 10*time.Millisecond)
 }
 
 func TestControlSpeed(t *testing.T) {

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/waitgroup"
+	"github.com/pingcap/tiproxy/pkg/balance/factor"
 	"github.com/pingcap/tiproxy/pkg/balance/observer"
 	"github.com/pingcap/tiproxy/pkg/balance/policy"
 	"github.com/pingcap/tiproxy/pkg/metrics"
@@ -865,6 +866,220 @@ func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
 	require.Equal(t, 2, tester.router.HealthyBackendCount())
 
 	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now(), 0)
+	for _, conn := range tester.conns {
+		require.False(t, conn.closing)
+	}
+}
+
+func TestIgnoreFailoverListWhenItMatchesAllHealthyBackendsInRouteGroup(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.router.matchType = MatchPort
+	for _, backend := range []struct {
+		addr string
+		port string
+	}{
+		{addr: "1", port: "10080"},
+		{addr: "2", port: "10080"},
+		{addr: "3", port: "10081"},
+		{addr: "4", port: "10081"},
+		{addr: "5", port: "10081"},
+		{addr: "6", port: "10081"},
+		{addr: "7", port: "10081"},
+	} {
+		tester.backends[backend.addr] = &observer.BackendHealth{
+			Healthy:            true,
+			SupportRedirection: true,
+			BackendInfo: observer.BackendInfo{
+				Addr: backend.addr,
+				Labels: map[string]string{
+					config.TiProxyPortLabelName: backend.port,
+				},
+			},
+		}
+	}
+	tester.notifyHealth()
+
+	for range 20 {
+		conn := tester.createConn()
+		backend := tester.route(conn, ClientInfo{ListenerPort: "10080"})
+		require.NotNil(t, backend)
+		conn.from = backend
+		tester.conns[conn.connID] = conn
+	}
+
+	fromBackend := tester.router.backends["1"]
+	toBackend := tester.router.backends["2"]
+	require.NotNil(t, fromBackend)
+	require.NotNil(t, toBackend)
+	require.Equal(t, 10, fromBackend.ConnCount())
+	require.Equal(t, 10, toBackend.ConnCount())
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.Addr()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+
+	tester.rebalance(1)
+	tester.checkRedirectingNum(10)
+	group := findGroupByValues(t, tester.router, []string{"10080"})
+	redirected := 0
+	for _, conn := range tester.conns {
+		if len(conn.GetRedirectingBackendID()) == 0 {
+			continue
+		}
+		require.NoError(t, group.OnRedirectSucceed(conn.from.ID(), conn.to.ID(), conn))
+		conn.redirectSucceed()
+		redirected++
+		if redirected >= 10 {
+			break
+		}
+	}
+	require.Equal(t, 10, redirected)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.Addr(), toBackend.Addr()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	require.True(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+
+	selector := tester.router.GetBackendSelector(ClientInfo{ListenerPort: "10080"})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Contains(t, []string{fromBackend.ID(), toBackend.ID()}, backend.ID())
+
+	group.CloseTimedOutFailoverConnections(time.Now(), 0)
+	for _, conn := range tester.conns {
+		require.False(t, conn.closing)
+	}
+}
+
+func TestIgnoreFailoverListWhenItMatchesAllLabelRoutableBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.router.bpCreator = func(lg *zap.Logger) policy.BalancePolicy {
+		return factor.NewFactorBasedBalance(lg, nil)
+	}
+	for _, backend := range []struct {
+		addr  string
+		group string
+	}{
+		{addr: "1", group: "a"},
+		{addr: "2", group: "a"},
+		{addr: "3", group: "b"},
+		{addr: "4", group: "b"},
+		{addr: "5", group: "b"},
+		{addr: "6", group: "b"},
+		{addr: "7", group: "b"},
+	} {
+		tester.backends[backend.addr] = &observer.BackendHealth{
+			Healthy:            true,
+			SupportRedirection: true,
+			BackendInfo: observer.BackendInfo{
+				Addr: backend.addr,
+				Labels: map[string]string{
+					"group": backend.group,
+				},
+			},
+		}
+	}
+	tester.notifyHealth()
+	tester.router.setConfig(&config.Config{
+		Labels: map[string]string{
+			"group": "a",
+		},
+		Balance: config.Balance{
+			LabelName: "group",
+			Policy:    config.BalancePolicyConnection,
+			Status: config.Factor{
+				MigrationsPerSecond: 1000,
+			},
+		},
+	})
+
+	for range 10 {
+		selector := tester.router.GetBackendSelector(ClientInfo{})
+		backend, err := selector.Next()
+		require.NoError(t, err)
+		selector.Finish(nil, false)
+		require.NotNil(t, backend)
+		require.Contains(t, []string{"1", "2"}, backend.ID())
+	}
+
+	group := tester.router.groups[0]
+	toBackend := tester.router.backends["2"]
+	require.NotNil(t, toBackend)
+	for range 10 {
+		conn := tester.createConn()
+		conn.from = toBackend
+		tester.conns[conn.connID] = conn
+		group.onCreateConn(toBackend, conn, true)
+	}
+	require.Equal(t, 10, toBackend.ConnCount())
+
+	tester.router.setConfig(&config.Config{
+		Labels: map[string]string{
+			"group": "a",
+		},
+		Balance: config.Balance{
+			LabelName: "group",
+			Policy:    config.BalancePolicyConnection,
+			Status: config.Factor{
+				MigrationsPerSecond: 1000,
+			},
+		},
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	require.False(t, tester.router.backends["1"].Healthy())
+	require.True(t, toBackend.Healthy())
+
+	tester.router.setConfig(&config.Config{
+		Labels: map[string]string{
+			"group": "a",
+		},
+		Balance: config.Balance{
+			LabelName: "group",
+			Policy:    config.BalancePolicyConnection,
+			Status: config.Factor{
+				MigrationsPerSecond: 1000,
+			},
+		},
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	require.True(t, tester.router.backends["1"].Healthy())
+	require.True(t, toBackend.Healthy())
+
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Contains(t, []string{"1", "2"}, backend.ID())
+
+	group.CloseTimedOutFailoverConnections(time.Now(), 0)
 	for _, conn := range tester.conns {
 		require.False(t, conn.closing)
 	}

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -865,7 +865,7 @@ func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
 	require.True(t, toBackend.Healthy())
 	require.Equal(t, 2, tester.router.HealthyBackendCount())
 
-	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now(), 0)
+	tester.router.groups[0].CloseTimedOutFailoverConnections(time.Now())
 	for _, conn := range tester.conns {
 		require.False(t, conn.closing)
 	}
@@ -962,7 +962,7 @@ func TestIgnoreFailoverListWhenItMatchesAllHealthyBackendsInRouteGroup(t *testin
 	require.NotNil(t, backend)
 	require.Contains(t, []string{fromBackend.ID(), toBackend.ID()}, backend.ID())
 
-	group.CloseTimedOutFailoverConnections(time.Now(), 0)
+	group.CloseTimedOutFailoverConnections(time.Now())
 	for _, conn := range tester.conns {
 		require.False(t, conn.closing)
 	}
@@ -1079,7 +1079,7 @@ func TestIgnoreFailoverListWhenItMatchesAllLabelRoutableBackends(t *testing.T) {
 	require.NotNil(t, backend)
 	require.Contains(t, []string{"1", "2"}, backend.ID())
 
-	group.CloseTimedOutFailoverConnections(time.Now(), 0)
+	group.CloseTimedOutFailoverConnections(time.Now())
 	for _, conn := range tester.conns {
 		require.False(t, conn.closing)
 	}

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -806,10 +806,63 @@ func TestFailoverBackendByAddr(t *testing.T) {
 	require.Equal(t, toBackend.Addr(), backend.Addr())
 }
 
+func TestIgnoreFailoverListWhenItMatchesAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.addBackends(2)
+
+	require.True(t, tester.getBackendByIndex(0).Healthy())
+	require.True(t, tester.getBackendByIndex(1).Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+
+	selector := tester.router.GetBackendSelector(ClientInfo{})
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+}
+
+func TestFailoverListReevaluatedWithBackendHealth(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(3)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+
+	require.False(t, tester.getBackendByIndex(0).Healthy())
+	require.False(t, tester.getBackendByIndex(1).Healthy())
+	require.True(t, tester.getBackendByIndex(2).Healthy())
+	require.Equal(t, 1, tester.router.HealthyBackendCount())
+
+	tester.updateBackendStatusByAddr("3", false)
+	require.True(t, tester.getBackendByIndex(0).Healthy())
+	require.True(t, tester.getBackendByIndex(1).Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+
+	tester.updateBackendStatusByAddr("3", true)
+	require.False(t, tester.getBackendByIndex(0).Healthy())
+	require.False(t, tester.getBackendByIndex(1).Healthy())
+	require.True(t, tester.getBackendByIndex(2).Healthy())
+	require.Equal(t, 1, tester.router.HealthyBackendCount())
+}
+
 func TestFailoverTimeoutForceClose(t *testing.T) {
 	tester := newRouterTester(t, nil)
 	tester.addBackends(1)
 	tester.addConnections(3)
+	tester.addBackends(1)
 
 	backend := tester.getBackendByIndex(0)
 	tester.updateBackendRedirectSupportByAddr(backend.Addr(), false)
@@ -1007,6 +1060,7 @@ func TestWatchFailoverConfig(t *testing.T) {
 	router := NewScoreBasedRouter(lg)
 	cfgCh := make(chan *config.Config)
 	addr := "db-2033841436272623616-0f6e346b-tidb-0.peer.ns.svc:4000"
+	addr2 := "db-2033841436272623616-0f6e346b-tidb-1.peer.ns.svc:4000"
 	cfgGetter := newMockConfigGetter(&config.Config{
 		Proxy: config.ProxyServer{
 			ProxyServerOnline: config.ProxyServerOnline{
@@ -1020,6 +1074,7 @@ func TestWatchFailoverConfig(t *testing.T) {
 	t.Cleanup(router.Close)
 
 	bo.addBackend(addr, nil)
+	bo.addBackend(addr2, nil)
 	bo.notify(nil)
 	require.Eventually(t, func() bool {
 		backend := router.backends[addr]

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -89,6 +89,26 @@ func TestConfigReload(t *testing.T) {
 			},
 		},
 		{
+			name: "failover override",
+			precfg: `
+proxy.fail-backend-list = ["db-tidb-0", "db-tidb-1"]
+proxy.failover-timeout = 90
+`,
+			precheck: func(c *config.Config) bool {
+				return c.Proxy.FailoverTimeout == 90 &&
+					len(c.Proxy.FailBackendList) == 2 &&
+					c.Proxy.FailBackendList[0] == "db-tidb-0" &&
+					c.Proxy.FailBackendList[1] == "db-tidb-1"
+			},
+			postcfg: `
+proxy.fail-backend-list = []
+proxy.failover-timeout = 0
+`,
+			postcheck: func(c *config.Config) bool {
+				return c.Proxy.FailoverTimeout == 0 && len(c.Proxy.FailBackendList) == 0
+			},
+		},
+		{
 			name:   "non empty fields should not be override by empty fields",
 			precfg: `proxy.addr = "gg"`,
 			precheck: func(c *config.Config) bool {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -710,6 +710,7 @@ func (mgr *BackendConnManager) Redirect(backendInst router.BackendInst) bool {
 	return true
 }
 
+// ForceClose forces closing the connection when the failover times out.
 func (mgr *BackendConnManager) ForceClose() bool {
 	for {
 		status := mgr.closeStatus.Load()

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -723,7 +723,9 @@ func (mgr *BackendConnManager) ForceClose() bool {
 	}
 	mgr.quitSource = SrcProxyQuit
 	if mgr.clientIO != nil {
-		if err := mgr.clientIO.Close(); err != nil && !pnet.IsDisconnectError(err) {
+		// Interrupt in-flight I/O and let the normal connection teardown release buffers.
+		// Closing the PacketIO here may race with ExecuteCmd() flushing to the client.
+		if err := mgr.clientIO.GracefulClose(); err != nil && !pnet.IsDisconnectError(err) {
 			mgr.logger.Warn("force close client IO error", zap.Error(err))
 		}
 	}

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -710,6 +710,25 @@ func (mgr *BackendConnManager) Redirect(backendInst router.BackendInst) bool {
 	return true
 }
 
+func (mgr *BackendConnManager) ForceClose() bool {
+	for {
+		status := mgr.closeStatus.Load()
+		if status >= statusClosing {
+			return false
+		}
+		if mgr.closeStatus.CompareAndSwap(status, statusClosing) {
+			break
+		}
+	}
+	mgr.quitSource = SrcProxyQuit
+	if mgr.clientIO != nil {
+		if err := mgr.clientIO.Close(); err != nil && !pnet.IsDisconnectError(err) {
+			mgr.logger.Warn("force close client IO error", zap.Error(err))
+		}
+	}
+	return true
+}
+
 func (mgr *BackendConnManager) notifyRedirectResult(ctx context.Context, rs *redirectResult) {
 	_ = ctx
 	if rs == nil {

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -904,6 +904,37 @@ func TestGracefulCloseBeforeHandshake(t *testing.T) {
 	ts.runTests(runners)
 }
 
+func TestForceClose(t *testing.T) {
+	ts := newBackendMgrTester(t)
+	runners := []runner{
+		// 1st handshake
+		{
+			client:  ts.mc.authenticate,
+			proxy:   ts.firstHandshake4Proxy,
+			backend: ts.handshake4Backend,
+		},
+		// force close
+		{
+			proxy: func(_, _ pnet.PacketIO) error {
+				require.True(t, ts.mp.ForceClose())
+				return nil
+			},
+		},
+		// really closed
+		{
+			proxy: ts.checkConnClosed4Proxy,
+		},
+		{
+			proxy: func(clientIO, backendIO pnet.PacketIO) error {
+				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				require.False(t, ts.mp.ForceClose())
+				return nil
+			},
+		},
+	}
+	ts.runTests(runners)
+}
+
 func TestHandlerReturnError(t *testing.T) {
 	tests := []struct {
 		cfg        cfgOverrider

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -85,6 +85,22 @@ type mockBackendInst struct {
 	local    atomic.Bool
 }
 
+type countingPacketIO struct {
+	pnet.PacketIO
+	gracefulCloseCnt atomic.Int32
+	closeCnt         atomic.Int32
+}
+
+func (cp *countingPacketIO) GracefulClose() error {
+	cp.gracefulCloseCnt.Add(1)
+	return nil
+}
+
+func (cp *countingPacketIO) Close() error {
+	cp.closeCnt.Add(1)
+	return nil
+}
+
 func newMockBackendInst(ts *backendMgrTester) *mockBackendInst {
 	mbi := &mockBackendInst{
 		addr: ts.tc.backendListener.Addr().String(),
@@ -933,6 +949,22 @@ func TestForceClose(t *testing.T) {
 		},
 	}
 	ts.runTests(runners)
+}
+
+func TestForceCloseUsesGracefulClose(t *testing.T) {
+	mgr := NewBackendConnManager(zap.NewNop(), &DefaultHandshakeHandler{}, nil, 1, &BCConfig{}, nil)
+	clientIO := &countingPacketIO{}
+	mgr.clientIO = clientIO
+
+	require.True(t, mgr.ForceClose())
+	require.Equal(t, SrcProxyQuit, mgr.QuitSource())
+	require.Equal(t, int32(statusClosing), mgr.closeStatus.Load())
+	require.EqualValues(t, 1, clientIO.gracefulCloseCnt.Load())
+	require.Zero(t, clientIO.closeCnt.Load())
+
+	require.False(t, mgr.ForceClose())
+	require.EqualValues(t, 1, clientIO.gracefulCloseCnt.Load())
+	require.Zero(t, clientIO.closeCnt.Load())
 }
 
 func TestHandlerReturnError(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1115

Problem Summary:
When a backend is confirmed to fail, we need a way to evict it manually.

What is changed and how it works:
- add `proxy.fail-backend-list` and `proxy.failover-timeout` config
- stop routing new connections to failed backends and migrate existing ones away
- force close remaining connections after the failover timeout
- if no more available backends, ignore the list to be HA
- allow `fail-backend-list` to match by pod name or backend address

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

<img width="2178" height="480" alt="image" src="https://github.com/user-attachments/assets/1697b97a-992d-452d-8ce5-dfa8d77239da" />

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support evict failed backends by config
```
