### PR TITLE
cert: add fsnotify to watch and reload cert files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bahlo/generic-list-go v0.2.0
 	github.com/cenkalti/backoff/v4 v4.2.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/gin-contrib/pprof v1.4.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-mysql-org/go-mysql v1.12.0
@@ -39,6 +40,7 @@ require (
 	go.uber.org/ratelimit v0.2.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/net v0.48.0
+	golang.org/x/sync v0.19.0
 	google.golang.org/grpc v1.63.2
 )
 
@@ -274,7 +276,6 @@ require (
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1166,6 +1166,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	// If fsnotify not working, fast certificate reloads can serve as a fallback safeguard.
 	defaultRetryInterval     = 5 * time.Minute
 	watchEventDebounceWindow = 100 * time.Millisecond
 )

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -6,9 +6,11 @@ package cert
 import (
 	"context"
 	"crypto/tls"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/lib/util/security"
@@ -18,7 +20,7 @@ import (
 )
 
 const (
-	defaultRetryInterval = 1 * time.Hour
+	defaultRetryInterval = 5 * time.Minute
 )
 
 // CertManager reloads certs and offers interfaces for fetching TLS configs.
@@ -38,6 +40,7 @@ type CertManager struct {
 	wg            waitgroup.WaitGroup
 	retryInterval atomic.Int64
 	logger        *zap.Logger
+	watcher       *fsnotify.Watcher
 }
 
 // NewCertManager creates a new CertManager.
@@ -47,7 +50,7 @@ func NewCertManager() *CertManager {
 	return cm
 }
 
-// Init creates a CertManager and reloads certificates periodically.
+// Init creates a CertManager, reloads certificates periodically and watches cert files via fsnotify.
 // cfgch can be set to nil for the serverless tier because it has no config manager.
 func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger, cfgch <-chan *config.Config) error {
 	cm.logger = logger
@@ -57,6 +60,15 @@ func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger, cfgch <-chan
 	cm.sqlTLS = security.NewCert(false)
 	cm.setConfig(cfg)
 	if err := cm.reload(); err != nil {
+		return err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	cm.watcher = watcher
+	if err = cm.resetCertFileWatches(collectCertWatchFiles(cfg)); err != nil {
 		return err
 	}
 
@@ -95,7 +107,7 @@ func (cm *CertManager) SQLTLS() *tls.Config {
 
 // The proxy is supposed to be always online, so it should reload certs automatically,
 // rather than reloading it by restarting the proxy.
-// The proxy periodically reloads certs. If it fails, we will retry in the next round.
+// The proxy reloads certs on configuration changes, cert file changes, and periodic retries.
 // If configuration changes, it only affects new connections by returning new *tls.Config.
 func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Config) {
 	// Failing to reload certs may cause even more serious problems than TiProxy reboot, so we don't recover panics.
@@ -112,12 +124,75 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 					break
 				}
 				cm.setConfig(cfg)
+				if err := cm.resetCertFileWatches(collectCertWatchFiles(cfg)); err != nil {
+					cm.logger.Warn("failed to update cert file watcher", zap.Error(err))
+				}
 				_ = cm.reload()
+			case event, ok := <-cm.watcher.Events:
+				if !ok {
+					cm.logger.Warn("cert file watcher is closed, stop watching")
+					break
+				}
+				cm.logger.Info("cert files changed, reload certs",
+					zap.String("path", event.Name),
+					zap.String("op", event.Op.String()))
+				if event.Op.Has(fsnotify.Chmod) || event.Op.Has(fsnotify.Remove) {
+					cm.logger.Info("cert file should re-add to watcher, because it may mount by Pod Secret", zap.String("path", event.Name))
+					if err := cm.watcher.Add(event.Name); err != nil {
+						cm.logger.Error("failed to re-add cert file", zap.String("path", event.Name), zap.Error(err))
+					}
+				}
+				_ = cm.reload()
+			case err := <-cm.watcher.Errors:
+				if err != nil {
+					cm.logger.Warn("cert file watcher error, but still reload certs", zap.Error(err))
+					_ = cm.reload()
+				}
 			case <-time.After(time.Duration(cm.retryInterval.Load())):
 				_ = cm.reload()
 			}
 		}
 	}, cm.logger)
+}
+
+func collectCertWatchFiles(cfg *config.Config) []string {
+	files := make(map[string]struct{})
+	addCertWatchFiles(files, cfg.Security.ServerSQLTLS)
+	addCertWatchFiles(files, cfg.Security.ServerHTTPTLS)
+	addCertWatchFiles(files, cfg.Security.ClusterTLS)
+	addCertWatchFiles(files, cfg.Security.SQLTLS)
+	watchFiles := make([]string, 0, len(files))
+	for file := range files {
+		watchFiles = append(watchFiles, file)
+	}
+	return watchFiles
+}
+
+func addCertWatchFiles(files map[string]struct{}, tlsCfg config.TLSConfig) {
+	if tlsCfg.Cert != "" {
+		files[filepath.Clean(tlsCfg.Cert)] = struct{}{}
+	}
+	if tlsCfg.Key != "" {
+		files[filepath.Clean(tlsCfg.Key)] = struct{}{}
+	}
+	if tlsCfg.CA != "" {
+		files[filepath.Clean(tlsCfg.CA)] = struct{}{}
+	}
+}
+
+func (cm *CertManager) resetCertFileWatches(watchFiles []string) error {
+	errs := make([]error, 0)
+	for _, file := range cm.watcher.WatchList() {
+		if err := cm.watcher.Remove(file); err != nil {
+			errs = append(errs, errors.Wrapf(err, "unwatch cert file %s", file))
+		}
+	}
+	for _, file := range watchFiles {
+		if err := cm.watcher.Add(file); err != nil {
+			errs = append(errs, errors.Wrapf(err, "watch cert file %s", file))
+		}
+	}
+	return errors.Collect(errors.New("update cert file watcher"), errs...)
 }
 
 // If any error happens, we still continue and use the old cert.
@@ -157,4 +232,7 @@ func (cm *CertManager) Close() {
 		cm.cancel()
 	}
 	cm.wg.Wait()
+	if cm.watcher != nil {
+		_ = cm.watcher.Close()
+	}
 }

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -24,6 +24,8 @@ const (
 	watchEventDebounceWindow = 100 * time.Millisecond
 )
 
+var newWatcher = fsnotify.NewWatcher
+
 // CertManager reloads certs and offers interfaces for fetching TLS configs.
 // Currently, all the namespaces share the same certs but there might be per-namespace
 // certs in the future.
@@ -41,7 +43,10 @@ type CertManager struct {
 	wg            waitgroup.WaitGroup
 	retryInterval atomic.Int64
 	logger        *zap.Logger
+
 	watcher       *fsnotify.Watcher
+	watcherEvents <-chan fsnotify.Event
+	watcherErrors <-chan error
 }
 
 // NewCertManager creates a new CertManager.
@@ -51,7 +56,7 @@ func NewCertManager() *CertManager {
 	return cm
 }
 
-// Init creates a CertManager, reloads certificates periodically and watches cert files via fsnotify.
+// Init creates a CertManager, reloads certificates periodically and watches cert files via fsnotify when available.
 // cfgch can be set to nil for the serverless tier because it has no config manager.
 func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger, cfgch <-chan *config.Config) error {
 	cm.logger = logger
@@ -64,13 +69,16 @@ func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger, cfgch <-chan
 		return err
 	}
 
-	watcher, err := fsnotify.NewWatcher()
+	watcher, err := newWatcher()
 	if err != nil {
-		return err
-	}
-	cm.watcher = watcher
-	if err = cm.resetCertFileWatches(collectCertWatchFiles(cfg)); err != nil {
-		return err
+		cm.logger.Warn("cert file watcher is unavailable, fallback to periodic cert reload", zap.Error(err))
+	} else {
+		cm.watcher = watcher
+		cm.watcherEvents = watcher.Events
+		cm.watcherErrors = watcher.Errors
+		if err = cm.resetCertFileWatches(collectCertWatchFiles(cfg)); err != nil {
+			return err
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -129,9 +137,10 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 					cm.logger.Warn("failed to update cert file watcher", zap.Error(err))
 				}
 				_ = cm.reload()
-			case event, ok := <-cm.watcher.Events:
+			case event, ok := <-cm.watcherEvents:
 				if !ok {
 					cm.logger.Warn("cert file watcher is closed, stop watching")
+					cm.watcherEvents = nil
 					break
 				}
 				if events := cm.debounceEvents(event); len(events) > 0 {
@@ -139,11 +148,13 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 					cm.reAddWatchForKubeletSecret(events)
 					_ = cm.reload()
 				}
-			case err := <-cm.watcher.Errors:
-				if err != nil {
-					cm.logger.Warn("cert file watcher error, but still reload certs", zap.Error(err))
-					_ = cm.reload()
+			case err, ok := <-cm.watcherErrors:
+				if !ok {
+					cm.watcherErrors = nil
+					break
 				}
+				cm.logger.Warn("cert file watcher error, but still reload certs", zap.Error(err))
+				_ = cm.reload()
 			case <-time.After(time.Duration(cm.retryInterval.Load())):
 				_ = cm.reload()
 			}
@@ -157,7 +168,7 @@ func (cm *CertManager) debounceEvents(first fsnotify.Event) []fsnotify.Event {
 	defer timer.Stop()
 	for {
 		select {
-		case event, ok := <-cm.watcher.Events:
+		case event, ok := <-cm.watcherEvents:
 			if !ok {
 				return nil
 			}
@@ -211,6 +222,10 @@ func addCertWatchFiles(files map[string]struct{}, tlsCfg config.TLSConfig) {
 }
 
 func (cm *CertManager) resetCertFileWatches(watchFiles []string) error {
+	if cm.watcher == nil {
+		return nil
+	}
+
 	errs := make([]error, 0)
 	for _, file := range cm.watcher.WatchList() {
 		if err := cm.watcher.Remove(file); err != nil {

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// When the LB DNS name changes, the certificates are also updated and TiProxy needs to reload them fast. 
+	// When the LB DNS name changes, the certificates are also updated and TiProxy needs to reload them fast.
 	// If fsnotify does not work, fast certificate reloads can serve as a fallback safeguard.
 	defaultRetryInterval     = 5 * time.Minute
 	watchEventDebounceWindow = 100 * time.Millisecond
@@ -79,7 +79,7 @@ func (cm *CertManager) Init(cfg *config.Config, logger *zap.Logger, cfgch <-chan
 		cm.watcherEvents = watcher.Events
 		cm.watcherErrors = watcher.Errors
 		if err = cm.resetCertFileWatches(collectCertWatchFiles(cfg)); err != nil {
-			return err
+			cm.logger.Warn("failed to add cert file watcher", zap.Error(err))
 		}
 	}
 
@@ -145,7 +145,7 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 					cm.watcherEvents = nil
 					break
 				}
-				if events := cm.debounceEvents(event); len(events) > 0 {
+				if events := cm.debounceEvents(ctx, event); len(events) > 0 {
 					cm.logger.Info("cert file changed, reload cert", zap.Stringers("events", events))
 					cm.reAddWatchForKubeletSecret(events)
 					_ = cm.reload()
@@ -164,12 +164,15 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 	}, cm.logger)
 }
 
-func (cm *CertManager) debounceEvents(first fsnotify.Event) []fsnotify.Event {
+// debounceEvents aggregates consecutive fsnotify events within a debounce window.
+func (cm *CertManager) debounceEvents(ctx context.Context, first fsnotify.Event) []fsnotify.Event {
 	events := []fsnotify.Event{first}
 	timer := time.NewTimer(watchEventDebounceWindow)
 	defer timer.Stop()
 	for {
 		select {
+		case <-ctx.Done():
+			return nil
 		case event, ok := <-cm.watcherEvents:
 			if !ok {
 				return nil

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	defaultRetryInterval = 5 * time.Minute
+	defaultRetryInterval     = 5 * time.Minute
+	watchEventDebounceWindow = 100 * time.Millisecond
 )
 
 // CertManager reloads certs and offers interfaces for fetching TLS configs.
@@ -133,16 +134,11 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 					cm.logger.Warn("cert file watcher is closed, stop watching")
 					break
 				}
-				cm.logger.Info("cert files changed, reload certs",
-					zap.String("path", event.Name),
-					zap.String("op", event.Op.String()))
-				if event.Op.Has(fsnotify.Chmod) || event.Op.Has(fsnotify.Remove) {
-					cm.logger.Info("cert file should re-add to watcher, because it may mount by Pod Secret", zap.String("path", event.Name))
-					if err := cm.watcher.Add(event.Name); err != nil {
-						cm.logger.Error("failed to re-add cert file", zap.String("path", event.Name), zap.Error(err))
-					}
+				if events := cm.debounceEvents(event); len(events) > 0 {
+					cm.logger.Info("cert file changed, reload cert", zap.Stringers("events", events))
+					cm.reAddWatchForKubeletSecret(events)
+					_ = cm.reload()
 				}
-				_ = cm.reload()
 			case err := <-cm.watcher.Errors:
 				if err != nil {
 					cm.logger.Warn("cert file watcher error, but still reload certs", zap.Error(err))
@@ -153,6 +149,40 @@ func (cm *CertManager) reloadLoop(ctx context.Context, cfgch <-chan *config.Conf
 			}
 		}
 	}, cm.logger)
+}
+
+func (cm *CertManager) debounceEvents(first fsnotify.Event) []fsnotify.Event {
+	events := []fsnotify.Event{first}
+	timer := time.NewTimer(watchEventDebounceWindow)
+	defer timer.Stop()
+	for {
+		select {
+		case event, ok := <-cm.watcher.Events:
+			if !ok {
+				return nil
+			}
+			events = append(events, event)
+			timer.Reset(watchEventDebounceWindow)
+		case <-timer.C:
+			return events
+		}
+	}
+}
+
+func (cm *CertManager) reAddWatchForKubeletSecret(events []fsnotify.Event) {
+	added := make(map[string]bool, len(events))
+	for _, event := range events {
+		if event.Op.Has(fsnotify.Chmod) || event.Op.Has(fsnotify.Remove) {
+			if added[event.Name] {
+				continue
+			}
+			cm.logger.Info("cert file should re-add to watcher, because it may mount by Pod Secret", zap.String("path", event.Name))
+			if err := cm.watcher.Add(event.Name); err != nil {
+				cm.logger.Error("failed to re-add cert file", zap.String("path", event.Name), zap.Error(err))
+			}
+			added[event.Name] = true
+		}
+	}
 }
 
 func collectCertWatchFiles(cfg *config.Config) []string {

--- a/pkg/manager/cert/manager.go
+++ b/pkg/manager/cert/manager.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	// If fsnotify not working, fast certificate reloads can serve as a fallback safeguard.
+	// When the LB DNS name changes, the certificates are also updated and TiProxy needs to reload them fast. 
+	// If fsnotify does not work, fast certificate reloads can serve as a fallback safeguard.
 	defaultRetryInterval     = 5 * time.Minute
 	watchEventDebounceWindow = 100 * time.Millisecond
 )

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/lib/util/security"
@@ -492,6 +493,66 @@ func TestReloadByFsnotify(t *testing.T) {
 		},
 	}, lg, nil))
 	t.Cleanup(certMgr.Close)
+
+	stls := certMgr.ServerSQLTLS()
+	ctls := certMgr.SQLTLS()
+	clientErr, serverErr := connectWithTLS(ctls, stls)
+	require.ErrorContains(t, clientErr, "certificate signed by unknown authority")
+	require.ErrorContains(t, serverErr, "bad certificate")
+
+	copyFile(t, caPath2, caPath) // caPath2 is correct
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(ctls, stls)
+		return clientErr == nil && serverErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestReloadWithoutFsnotify(t *testing.T) {
+	oldNewWatcher := newWatcher
+	newWatcher = func() (*fsnotify.Watcher, error) {
+		return nil, fmt.Errorf("fsnotify unsupported")
+	}
+	t.Cleanup(func() {
+		newWatcher = oldNewWatcher
+	})
+
+	tmpdir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	caPath := filepath.Join(tmpdir, "ca")
+	keyPath := filepath.Join(tmpdir, "key")
+	certPath := filepath.Join(tmpdir, "cert")
+	caPath1 := filepath.Join(tmpdir, "c1", "ca")
+	keyPath1 := filepath.Join(tmpdir, "c1", "key")
+	certPath1 := filepath.Join(tmpdir, "c1", "cert")
+	caPath2 := filepath.Join(tmpdir, "c2", "ca")
+	keyPath2 := filepath.Join(tmpdir, "c2", "key")
+	certPath2 := filepath.Join(tmpdir, "c2", "cert")
+
+	createFile(t, caPath)
+	createFile(t, keyPath)
+	createFile(t, certPath)
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, ""))
+	copyFile(t, caPath1, caPath) // caPath1 is incorrect
+	copyFile(t, keyPath2, keyPath)
+	copyFile(t, certPath2, certPath)
+
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(50 * time.Millisecond)
+	require.NoError(t, certMgr.Init(&config.Config{
+		Workdir: tmpdir,
+		Security: config.Security{
+			ServerSQLTLS: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+			},
+			SQLTLS: config.TLSConfig{
+				CA: caPath,
+			},
+		},
+	}, lg, nil))
+	t.Cleanup(certMgr.Close)
+	require.Nil(t, certMgr.watcher)
 
 	stls := certMgr.ServerSQLTLS()
 	ctls := certMgr.SQLTLS()

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -426,3 +426,110 @@ func TestWatchConfig(t *testing.T) {
 		}, time.Second, 10*time.Millisecond)
 	}
 }
+
+func TestReloadByFsnotify(t *testing.T) {
+	tmpdir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	caPath := filepath.Join(tmpdir, "ca")
+	keyPath := filepath.Join(tmpdir, "key")
+	certPath := filepath.Join(tmpdir, "cert")
+	caPath1 := filepath.Join(tmpdir, "c1", "ca")
+	keyPath1 := filepath.Join(tmpdir, "c1", "key")
+	certPath1 := filepath.Join(tmpdir, "c1", "cert")
+	caPath2 := filepath.Join(tmpdir, "c2", "ca")
+	keyPath2 := filepath.Join(tmpdir, "c2", "key")
+	certPath2 := filepath.Join(tmpdir, "c2", "cert")
+
+	createFile(t, caPath)
+	createFile(t, keyPath)
+	createFile(t, certPath)
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, ""))
+	copyFile(t, caPath1, caPath) // caPath1 is incorrect
+	copyFile(t, keyPath2, keyPath)
+	copyFile(t, certPath2, certPath)
+
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(time.Hour)
+	require.NoError(t, certMgr.Init(&config.Config{
+		Workdir: tmpdir,
+		Security: config.Security{
+			ServerSQLTLS: config.TLSConfig{
+				Cert: certPath,
+				Key:  keyPath,
+			},
+			SQLTLS: config.TLSConfig{
+				CA: caPath,
+			},
+		},
+	}, lg, nil))
+	t.Cleanup(certMgr.Close)
+
+	stls := certMgr.ServerSQLTLS()
+	ctls := certMgr.SQLTLS()
+	clientErr, serverErr := connectWithTLS(ctls, stls)
+	require.ErrorContains(t, clientErr, "certificate signed by unknown authority")
+	require.ErrorContains(t, serverErr, "bad certificate")
+
+	copyFile(t, caPath2, caPath) // caPath2 is correct
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(ctls, stls)
+		return clientErr == nil && serverErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestReloadByFsnotifyAfterChangeCertFile(t *testing.T) {
+	tmpdir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	caPath1 := filepath.Join(tmpdir, "c1", "ca")
+	keyPath1 := filepath.Join(tmpdir, "c1", "key")
+	certPath1 := filepath.Join(tmpdir, "c1", "cert")
+	caPath2 := filepath.Join(tmpdir, "c2", "ca")
+	keyPath2 := filepath.Join(tmpdir, "c2", "key")
+	certPath2 := filepath.Join(tmpdir, "c2", "cert")
+	caPath3 := filepath.Join(tmpdir, "c3", "ca")
+
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, ""))
+	createFile(t, caPath3)
+	copyFile(t, caPath1, caPath3) // caPath3 is incorrect and will be added to the watcher after config update.
+
+	cfg := config.Config{
+		Workdir: tmpdir,
+		Security: config.Security{
+			ServerSQLTLS: config.TLSConfig{
+				Cert: certPath2,
+				Key:  keyPath2,
+			},
+			SQLTLS: config.TLSConfig{
+				CA: caPath2,
+			},
+		},
+	}
+	cfgCh := make(chan *config.Config, 1)
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(time.Hour)
+	require.NoError(t, certMgr.Init(&cfg, lg, cfgCh))
+	t.Cleanup(certMgr.Close)
+
+	stls := certMgr.ServerSQLTLS()
+	ctls := certMgr.SQLTLS()
+	clientErr, serverErr := connectWithTLS(ctls, stls)
+	require.NoError(t, clientErr)
+	require.NoError(t, serverErr)
+
+	cfg.Security.SQLTLS.CA = caPath3
+	cfgCh <- &cfg
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(ctls, stls)
+		return clientErr != nil && serverErr != nil &&
+			strings.Contains(clientErr.Error(), "certificate signed by unknown authority") &&
+			strings.Contains(serverErr.Error(), "bad certificate")
+	}, 5*time.Second, 50*time.Millisecond)
+
+	copyFile(t, caPath2, caPath3) // caPath3 becomes correct; success depends on the new watch entry taking effect.
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(ctls, stls)
+		return clientErr == nil && serverErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+}

--- a/pkg/manager/cert/manager_test.go
+++ b/pkg/manager/cert/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,33 @@ func copyFile(t *testing.T, src, dst string) {
 	require.NoError(t, err)
 	require.NoError(t, f1.Close())
 	require.NoError(t, f2.Close())
+}
+
+// kubelet projects Secret files through a stable user-visible symlink that points
+// to ..data/<file>, and updates the content by atomically switching ..data to a
+// new timestamped directory.
+func initKubeletSecret(t *testing.T, volumeDir, version string, files map[string]string) {
+	require.NoError(t, os.MkdirAll(volumeDir, 0755))
+	writeKubeletSecretVersion(t, volumeDir, version, files)
+	require.NoError(t, os.Symlink(version, filepath.Join(volumeDir, "..data")))
+	for name := range files {
+		require.NoError(t, os.Symlink(filepath.Join("..data", name), filepath.Join(volumeDir, name)))
+	}
+}
+
+func updateKubeletSecret(t *testing.T, volumeDir, oldVersion, newVersion string, files map[string]string) {
+	writeKubeletSecretVersion(t, volumeDir, newVersion, files)
+	require.NoError(t, os.Symlink(newVersion, filepath.Join(volumeDir, "..data_tmp")))
+	require.NoError(t, os.Rename(filepath.Join(volumeDir, "..data_tmp"), filepath.Join(volumeDir, "..data")))
+	require.NoError(t, os.RemoveAll(filepath.Join(volumeDir, oldVersion)))
+}
+
+func writeKubeletSecretVersion(t *testing.T, volumeDir, version string, files map[string]string) {
+	versionDir := filepath.Join(volumeDir, version)
+	require.NoError(t, os.MkdirAll(versionDir, 0755))
+	for name, src := range files {
+		copyFile(t, src, filepath.Join(versionDir, name))
+	}
 }
 
 func connectWithTLS(ctls, stls *tls.Config) (clientErr, serverErr error) {
@@ -475,6 +503,64 @@ func TestReloadByFsnotify(t *testing.T) {
 	require.Eventually(t, func() bool {
 		clientErr, serverErr = connectWithTLS(ctls, stls)
 		return clientErr == nil && serverErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestReloadByFsnotifyForKubeletSecret(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("kubelet Secret projection watcher behavior is only verified on linux, got %s", runtime.GOOS)
+	}
+
+	tmpdir := t.TempDir()
+	lg, _ := logger.CreateLoggerForTest(t)
+	caPath1 := filepath.Join(tmpdir, "c1", "ca")
+	keyPath1 := filepath.Join(tmpdir, "c1", "key")
+	certPath1 := filepath.Join(tmpdir, "c1", "cert")
+	caPath2 := filepath.Join(tmpdir, "c2", "ca")
+	keyPath2 := filepath.Join(tmpdir, "c2", "key")
+	certPath2 := filepath.Join(tmpdir, "c2", "cert")
+	secretDir := filepath.Join(tmpdir, "secret")
+	mountedCAPath := filepath.Join(secretDir, "ca")
+
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath1, keyPath1, caPath1, 0, security.DefaultCertExpiration, ""))
+	require.NoError(t, security.CreateTLSCertificates(lg, certPath2, keyPath2, caPath2, 0, security.DefaultCertExpiration, ""))
+	version1 := "..2026_04_15_12_34_01.11111111"
+	version2 := "..2026_04_15_12_34_02.22222222"
+	version3 := "..2026_04_15_12_34_03.33333333"
+	initKubeletSecret(t, secretDir, version1, map[string]string{"ca": caPath1})
+
+	certMgr := NewCertManager()
+	certMgr.SetRetryInterval(time.Hour)
+	require.NoError(t, certMgr.Init(&config.Config{
+		Workdir: tmpdir,
+		Security: config.Security{
+			ServerSQLTLS: config.TLSConfig{
+				Cert: certPath2,
+				Key:  keyPath2,
+			},
+			SQLTLS: config.TLSConfig{
+				CA: mountedCAPath,
+			},
+		},
+	}, lg, nil))
+	t.Cleanup(certMgr.Close)
+
+	clientErr, serverErr := connectWithTLS(certMgr.SQLTLS(), certMgr.ServerSQLTLS())
+	require.ErrorContains(t, clientErr, "certificate signed by unknown authority")
+	require.ErrorContains(t, serverErr, "bad certificate")
+
+	updateKubeletSecret(t, secretDir, version1, version2, map[string]string{"ca": caPath2})
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(certMgr.SQLTLS(), certMgr.ServerSQLTLS())
+		return clientErr == nil && serverErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+
+	updateKubeletSecret(t, secretDir, version2, version3, map[string]string{"ca": caPath1})
+	require.Eventually(t, func() bool {
+		clientErr, serverErr = connectWithTLS(certMgr.SQLTLS(), certMgr.ServerSQLTLS())
+		return clientErr != nil && serverErr != nil &&
+			strings.Contains(clientErr.Error(), "certificate signed by unknown authority") &&
+			strings.Contains(serverErr.Error(), "bad certificate")
 	}, 5*time.Second, 50*time.Millisecond)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1128 

Problem Summary:
This PR adds the capability to watch and reload certificate files using `fsnotify` when they change.

What is changed and how it works:
- Added `fsnotify` to monitor changes in the certificate files.
- When a change is detected, the new certificate files are reloaded to ensure the latest certificates are being used.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Added support for watching and reloading certificate files using `fsnotify`.
```
