### PR TITLE
balance, proxy: support evicting backends by config (#1116)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ cmd_%:
 	go build $(BUILDFLAGS) -o $(OUTPUT) $(SOURCE)
 
 golangci-lint:
-	GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	GOBIN=$(GOBIN) GOTOOLCHAIN=go1.25.6 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 go-header:
 	GOBIN=$(GOBIN) go install github.com/denis-tingaikin/go-header/cmd/go-header@latest

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ cmd_%:
 	go build $(BUILDFLAGS) -o $(OUTPUT) $(SOURCE)
 
 golangci-lint:
-	GOBIN=$(GOBIN) GOTOOLCHAIN=go1.25.6 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	GOBIN=$(GOBIN) GOTOOLCHAIN=go1.25.6 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 
 go-header:
 	GOBIN=$(GOBIN) go install github.com/denis-tingaikin/go-header/cmd/go-header@latest

--- a/conf/proxy.toml
+++ b/conf/proxy.toml
@@ -23,6 +23,15 @@
 
 graceful-close-conn-timeout = 15
 
+# fail-backend-list marks backend pod names or backend addresses as failed. TiProxy will stop routing new
+# connections to them and migrate existing connections away. If the list would leave no routeable backend,
+# TiProxy ignores the list to avoid making routing unavailable.
+# fail-backend-list = ["db-2033841436272623616-0f6e346b-tidb-0", "10.0.0.10:4000"]
+
+# failover-timeout is measured in seconds. If a failed backend still has remaining connections after the timeout,
+# TiProxy will force close them.
+# failover-timeout = 60
+
 # possible values:
 #		"" => enable static routing.
 #		"pd-addr:pd-port" => automatically tidb discovery.

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -199,17 +199,24 @@ func (cfg *Config) Check() error {
 	if cfg.Proxy.ConnBufferSize > 0 && (cfg.Proxy.ConnBufferSize > 16*1024*1024 || cfg.Proxy.ConnBufferSize < 1024) {
 		return errors.Wrapf(ErrInvalidConfigValue, "conn-buffer-size must be between 1K and 16M")
 	}
+	if err := cfg.Proxy.Check(); err != nil {
+		return err
+	}
 
 	if err := cfg.Balance.Check(); err != nil {
 		return err
 	}
 
-	if cfg.Proxy.FailoverTimeout < 0 {
+	return nil
+}
+
+func (ps *ProxyServer) Check() error {
+	if ps.FailoverTimeout < 0 {
 		return errors.Wrapf(ErrInvalidConfigValue, "proxy.failover-timeout must be greater than or equal to 0")
 	}
-	failBackends := cfg.Proxy.FailBackendList[:0]
-	failBackendSet := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
-	for i, backendName := range cfg.Proxy.FailBackendList {
+	failBackends := ps.FailBackendList[:0]
+	failBackendSet := make(map[string]struct{}, len(ps.FailBackendList))
+	for i, backendName := range ps.FailBackendList {
 		backendName = strings.TrimSpace(backendName)
 		if backendName == "" {
 			return errors.Wrapf(ErrInvalidConfigValue, "proxy.fail-backend-list[%d] is empty", i)
@@ -220,8 +227,7 @@ func (cfg *Config) Check() error {
 		failBackendSet[backendName] = struct{}{}
 		failBackends = append(failBackends, backendName)
 	}
-	cfg.Proxy.FailBackendList = failBackends
-
+	ps.FailBackendList = failBackends
 	return nil
 }
 

--- a/lib/config/proxy.go
+++ b/lib/config/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -59,6 +60,12 @@ type ProxyServerOnline struct {
 	// In k8s, the pod terminationGracePeriodSeconds can be set to very long so that these configs can be updated online.
 	GracefulWaitBeforeShutdown int `yaml:"graceful-wait-before-shutdown,omitempty" toml:"graceful-wait-before-shutdown,omitempty" json:"graceful-wait-before-shutdown,omitempty" reloadable:"true"`
 	GracefulCloseConnTimeout   int `yaml:"graceful-close-conn-timeout,omitempty" toml:"graceful-close-conn-timeout,omitempty" json:"graceful-close-conn-timeout,omitempty" reloadable:"true"`
+	// FailBackendList contains backend pod names or backend addresses (IP:port) that should be drained immediately
+	// and excluded from new routing. If the configured list would leave no routeable backend,
+	// TiProxy ignores the list to keep routing available.
+	FailBackendList []string `yaml:"fail-backend-list,omitempty" toml:"fail-backend-list,omitempty" json:"fail-backend-list,omitempty" reloadable:"true"`
+	// FailoverTimeout is the grace period in seconds before force closing the remaining connections on failed backends.
+	FailoverTimeout int `yaml:"failover-timeout,omitempty" toml:"failover-timeout,omitempty" json:"failover-timeout,omitempty" reloadable:"true"`
 }
 
 type ProxyServer struct {
@@ -144,6 +151,7 @@ func NewConfig() *Config {
 	cfg.Proxy.FrontendKeepalive, cfg.Proxy.BackendHealthyKeepalive, cfg.Proxy.BackendUnhealthyKeepalive = DefaultKeepAlive()
 	cfg.Proxy.PDAddrs = "127.0.0.1:2379"
 	cfg.Proxy.GracefulCloseConnTimeout = 15
+	cfg.Proxy.FailoverTimeout = 60
 
 	cfg.API.Addr = "0.0.0.0:3080"
 
@@ -168,6 +176,7 @@ func NewConfig() *Config {
 func (cfg *Config) Clone() *Config {
 	newCfg := *cfg
 	newCfg.Labels = maps.Clone(cfg.Labels)
+	newCfg.Proxy.FailBackendList = slices.Clone(cfg.Proxy.FailBackendList)
 	return &newCfg
 }
 
@@ -194,6 +203,24 @@ func (cfg *Config) Check() error {
 	if err := cfg.Balance.Check(); err != nil {
 		return err
 	}
+
+	if cfg.Proxy.FailoverTimeout < 0 {
+		return errors.Wrapf(ErrInvalidConfigValue, "proxy.failover-timeout must be greater than or equal to 0")
+	}
+	failBackends := cfg.Proxy.FailBackendList[:0]
+	failBackendSet := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
+	for i, backendName := range cfg.Proxy.FailBackendList {
+		backendName = strings.TrimSpace(backendName)
+		if backendName == "" {
+			return errors.Wrapf(ErrInvalidConfigValue, "proxy.fail-backend-list[%d] is empty", i)
+		}
+		if _, ok := failBackendSet[backendName]; ok {
+			continue
+		}
+		failBackendSet[backendName] = struct{}{}
+		failBackends = append(failBackends, backendName)
+	}
+	cfg.Proxy.FailBackendList = failBackends
 
 	return nil
 }

--- a/lib/config/proxy_test.go
+++ b/lib/config/proxy_test.go
@@ -24,6 +24,8 @@ var testProxyConfig = Config{
 			FrontendKeepalive:          KeepAlive{Enabled: true},
 			ProxyProtocol:              "v2",
 			GracefulWaitBeforeShutdown: 10,
+			FailBackendList:            []string{"db-tidb-0", "db-tidb-1"},
+			FailoverTimeout:            60,
 			ConnBufferSize:             32 * 1024,
 		},
 	},
@@ -112,6 +114,18 @@ func TestProxyCheck(t *testing.T) {
 			},
 			err: ErrInvalidConfigValue,
 		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.FailBackendList = []string{"db-tidb-0", " "}
+			},
+			err: ErrInvalidConfigValue,
+		},
+		{
+			pre: func(t *testing.T, c *Config) {
+				c.Proxy.FailoverTimeout = -1
+			},
+			err: ErrInvalidConfigValue,
+		},
 	}
 	for _, tc := range testcases {
 		cfg := testProxyConfig
@@ -174,5 +188,7 @@ func TestCloneConfig(t *testing.T) {
 	clone := cfg.Clone()
 	require.Equal(t, cfg, *clone)
 	cfg.Labels["c"] = "d"
+	cfg.Proxy.FailBackendList[0] = "db-tidb-9"
 	require.NotContains(t, clone.Labels, "c")
+	require.Equal(t, []string{"db-tidb-0", "db-tidb-1"}, clone.Proxy.FailBackendList)
 }

--- a/pkg/balance/factor/factor_balance.go
+++ b/pkg/balance/factor/factor_balance.go
@@ -202,6 +202,23 @@ func (fbb *FactorBasedBalance) BackendToRoute(backends []policy.BackendCtx) poli
 	}
 }
 
+func (fbb *FactorBasedBalance) RouteableBackends(backends []policy.BackendCtx) []policy.BackendCtx {
+	if len(backends) == 0 {
+		return nil
+	}
+
+	fbb.Lock()
+	defer fbb.Unlock()
+	scoredBackends := fbb.updateScore(backends)
+	routeable := make([]policy.BackendCtx, 0, len(scoredBackends))
+	for _, backend := range scoredBackends {
+		if fbb.canBeRouted(backend.scoreBits) {
+			routeable = append(routeable, backend.BackendCtx)
+		}
+	}
+	return routeable
+}
+
 func (fbb *FactorBasedBalance) routeIdlest(scoredBackends []scoredBackend, fields *[]zap.Field) policy.BackendCtx {
 	// Evict the backends that are can't be routed to, and then choose the idlest one.
 	// It's like least-connection algorithm.

--- a/pkg/balance/policy/balance_policy.go
+++ b/pkg/balance/policy/balance_policy.go
@@ -12,6 +12,8 @@ import (
 type BalancePolicy interface {
 	Init(cfg *config.Config)
 	BackendToRoute(backends []BackendCtx) BackendCtx
+	// RouteableBackends returns the backends that are eligible for routing under the current policy.
+	RouteableBackends(backends []BackendCtx) []BackendCtx
 	// balanceCount is the count of connections to balance per second.
 	BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field)
 	SetConfig(cfg *config.Config)

--- a/pkg/balance/policy/simple_policy.go
+++ b/pkg/balance/policy/simple_policy.go
@@ -44,6 +44,16 @@ func (sbp *SimpleBalancePolicy) BackendToRoute(backends []BackendCtx) BackendCtx
 	return nil
 }
 
+func (sbp *SimpleBalancePolicy) RouteableBackends(backends []BackendCtx) []BackendCtx {
+	routeable := make([]BackendCtx, 0, len(backends))
+	for _, backend := range backends {
+		if backend.Healthy() {
+			routeable = append(routeable, backend)
+		}
+	}
+	return routeable
+}
+
 func (sbp *SimpleBalancePolicy) BackendsToBalance(backends []BackendCtx) (from, to BackendCtx, balanceCount float64, reason string, logFields []zap.Field) {
 	if len(backends) <= 1 {
 		return

--- a/pkg/balance/router/mock_test.go
+++ b/pkg/balance/router/mock_test.go
@@ -20,13 +20,14 @@ import (
 
 type mockRedirectableConn struct {
 	sync.Mutex
-	t        *testing.T
-	kv       map[any]any
-	connID   uint64
-	from     BackendInst
-	to       BackendInst
-	receiver ConnEventReceiver
-	closing  bool
+	t             *testing.T
+	kv            map[any]any
+	connID        uint64
+	from          BackendInst
+	to            BackendInst
+	receiver      ConnEventReceiver
+	closing       bool
+	blockRedirect bool
 }
 
 func newMockRedirectableConn(t *testing.T, id uint64) *mockRedirectableConn {
@@ -62,9 +63,22 @@ func (conn *mockRedirectableConn) Redirect(inst BackendInst) bool {
 	if conn.closing {
 		return false
 	}
+	if conn.blockRedirect {
+		return false
+	}
 	require.Nil(conn.t, conn.to)
 	require.True(conn.t, inst.Healthy())
 	conn.to = inst
+	return true
+}
+
+func (conn *mockRedirectableConn) ForceClose() bool {
+	conn.Lock()
+	defer conn.Unlock()
+	if conn.closing {
+		return false
+	}
+	conn.closing = true
 	return true
 }
 
@@ -202,6 +216,16 @@ func (m *mockBalancePolicy) BackendToRoute(backends []policy.BackendCtx) policy.
 		return m.backendToRoute(backends)
 	}
 	return nil
+}
+
+func (m *mockBalancePolicy) RouteableBackends(backends []policy.BackendCtx) []policy.BackendCtx {
+	routeable := make([]policy.BackendCtx, 0, len(backends))
+	for _, backend := range backends {
+		if backend.Healthy() {
+			routeable = append(routeable, backend)
+		}
+	}
+	return routeable
 }
 
 func (m *mockBalancePolicy) BackendsToBalance(backends []policy.BackendCtx) (from policy.BackendCtx, to policy.BackendCtx, balanceCount float64, reason string, logFields []zapcore.Field) {

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -4,6 +4,8 @@
 package router
 
 import (
+	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +18,15 @@ import (
 var (
 	ErrNoBackend = errors.New("no available backend")
 )
+
+type routeCheckBackend struct {
+	*backendWrapper
+	healthy bool
+}
+
+func (b routeCheckBackend) Healthy() bool {
+	return b.healthy
+}
 
 // ConnEventReceiver receives connection events.
 type ConnEventReceiver interface {
@@ -69,6 +80,8 @@ type RedirectableConn interface {
 	Value(key any) any
 	// Redirect returns false if the current conn is not redirectable.
 	Redirect(backend BackendInst) bool
+	// ForceClose closes the connection immediately and returns false if it's already closing.
+	ForceClose() bool
 	ConnectionID() uint64
 	ConnInfo() []zap.Field
 }
@@ -85,8 +98,10 @@ type backendWrapper struct {
 	mu struct {
 		sync.RWMutex
 		observer.BackendHealth
+		failoverSince time.Time
 	}
-	addr string
+	addr    string
+	podName string
 	// connScore is used for calculating backend scores and check if the backend can be removed from the list.
 	// connScore = connList.Len() + incoming connections - outgoing connections.
 	connScore int
@@ -98,6 +113,7 @@ type backendWrapper struct {
 func newBackendWrapper(addr string, health observer.BackendHealth) *backendWrapper {
 	wrapper := &backendWrapper{
 		addr:     addr,
+		podName:  backendPodNameFromAddr(addr),
 		connList: glist.New[*connWrapper](),
 	}
 	wrapper.setHealth(health)
@@ -127,9 +143,44 @@ func (b *backendWrapper) Addr() string {
 
 func (b *backendWrapper) Healthy() bool {
 	b.mu.RLock()
+	healthy := b.mu.Healthy && b.mu.failoverSince.IsZero()
+	b.mu.RUnlock()
+	return healthy
+}
+
+func (b *backendWrapper) ObservedHealthy() bool {
+	b.mu.RLock()
 	healthy := b.mu.Healthy
 	b.mu.RUnlock()
 	return healthy
+}
+
+func (b *backendWrapper) PodName() string {
+	return b.podName
+}
+
+func (b *backendWrapper) setFailover(since time.Time) (changed bool, failoverSince time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !since.IsZero() {
+		if !b.mu.failoverSince.IsZero() {
+			return false, b.mu.failoverSince
+		}
+		b.mu.failoverSince = since
+		return true, b.mu.failoverSince
+	}
+	if b.mu.failoverSince.IsZero() {
+		return false, time.Time{}
+	}
+	b.mu.failoverSince = time.Time{}
+	return true, time.Time{}
+}
+
+func (b *backendWrapper) FailoverSince() (since time.Time) {
+	b.mu.RLock()
+	since = b.mu.failoverSince
+	b.mu.RUnlock()
+	return
 }
 
 func (b *backendWrapper) ServerVersion() string {
@@ -180,4 +231,22 @@ type connWrapper struct {
 	lastRedirect time.Time
 	createTime   time.Time
 	phase        connPhase
+	forceClosing bool
+}
+
+func backendPodNameFromAddr(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if host == "" {
+		return ""
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return host
+	}
+	if idx := strings.IndexByte(host, '.'); idx >= 0 {
+		return host[:idx]
+	}
+	return host
 }

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -44,13 +44,18 @@ type ScoreBasedRouter struct {
 	serverVersion string
 	// To limit the speed of redirection.
 	lastRedirectTime time.Time
+	// failoverTargets contains backend pod names or addresses configured in fail-backend-list.
+	failoverTargets map[string]struct{}
+	failoverTimeout time.Duration
+	ignoreFailover  bool
 }
 
 // NewScoreBasedRouter creates a ScoreBasedRouter.
 func NewScoreBasedRouter(logger *zap.Logger) *ScoreBasedRouter {
 	return &ScoreBasedRouter{
-		logger:   logger,
-		backends: make(map[string]*backendWrapper),
+		logger:          logger,
+		backends:        make(map[string]*backendWrapper),
+		failoverTargets: make(map[string]struct{}),
 	}
 }
 
@@ -66,6 +71,11 @@ func (r *ScoreBasedRouter) Init(ctx context.Context, ob observer.BackendObserver
 	r.wg.RunWithRecover(func() {
 		r.rebalanceLoop(childCtx)
 	}, nil, r.logger)
+
+	r.Lock()
+	r.setFailoverConfigLocked(cfg)
+	r.updateFailoverLocked(time.Now())
+	r.Unlock()
 }
 
 // GetBackendSelector implements Router.GetBackendSelector interface.
@@ -149,6 +159,7 @@ func (router *ScoreBasedRouter) onCreateConn(backendInst BackendInst, conn Redir
 			RedirectableConn: conn,
 			createTime:       time.Now(),
 			phase:            phaseNotRedirected,
+			forceClosing:     false,
 		}
 		router.addConn(backend, connWrapper)
 		conn.SetEventReceiver(router)
@@ -312,6 +323,7 @@ func (router *ScoreBasedRouter) updateBackendHealth(healthResults observer.Healt
 			router.logger.Debug("unhealthy backend is not in router", zap.String("addr", addr), zap.Stringer("health", health))
 		}
 	}
+	router.updateFailoverLocked(time.Now())
 	if len(serverVersion) > 0 {
 		router.serverVersion = serverVersion
 	}
@@ -327,7 +339,13 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 		case healthResults := <-router.healthCh:
 			router.updateBackendHealth(healthResults)
 		case cfg := <-router.cfgCh:
-			router.policy.SetConfig(cfg)
+			router.Lock()
+			if cfg != nil {
+				router.policy.SetConfig(cfg)
+			}
+			router.setFailoverConfigLocked(cfg)
+			router.updateFailoverLocked(time.Now())
+			router.Unlock()
 		case <-ticker.C:
 			router.rebalance(ctx)
 		}
@@ -339,7 +357,11 @@ func (router *ScoreBasedRouter) rebalanceLoop(ctx context.Context) {
 // - The connections are migrated to different backends
 func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 	router.Lock()
-	defer router.Unlock()
+	now := time.Now()
+	defer func() {
+		router.closeTimedOutFailoverConnectionsLocked(now)
+		router.Unlock()
+	}()
 
 	if len(router.backends) <= 1 {
 		return
@@ -356,13 +378,13 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 	fromBackend, toBackend := busiestBackend.(*backendWrapper), idlestBackend.(*backendWrapper)
 
 	// Control the speed of migration.
-	curTime := time.Now()
+	curTime := now
 	migrationInterval := time.Duration(float64(time.Second) / balanceCount)
 	count := 0
 	if migrationInterval < rebalanceInterval*2 {
 		// If we need to migrate multiple connections in each round, calculate the connection count for each round.
 		count = int((rebalanceInterval-1)/migrationInterval) + 1
-	} else {
+	} else if curTime.Sub(router.lastRedirectTime) >= migrationInterval {
 		// If we need to wait for multiple rounds to migrate a connection, calculate the interval for each connection.
 		if curTime.Sub(router.lastRedirectTime) >= migrationInterval {
 			count = 1
@@ -374,6 +396,9 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 	i := 0
 	for ele := fromBackend.connList.Front(); ele != nil && ctx.Err() == nil && i < count; ele = ele.Next() {
 		conn := ele.Value
+		if conn.forceClosing {
+			continue
+		}
 		switch conn.phase {
 		case phaseRedirectNotify:
 			// A connection cannot be redirected again when it has not finished redirecting.
@@ -425,11 +450,150 @@ func (router *ScoreBasedRouter) redirectConn(conn *connWrapper, fromBackend *bac
 func (router *ScoreBasedRouter) removeBackendIfEmpty(backend *backendWrapper) bool {
 	// If connList.Len() == 0, there won't be any outgoing connections.
 	// And if also connScore == 0, there won't be any incoming connections.
-	if !backend.Healthy() && backend.connList.Len() == 0 && backend.connScore <= 0 {
+	if !backend.ObservedHealthy() && backend.connList.Len() == 0 && backend.connScore <= 0 {
 		delete(router.backends, backend.addr)
 		return true
 	}
 	return false
+}
+
+func (router *ScoreBasedRouter) setConfig(cfg *config.Config) {
+	router.Lock()
+	defer router.Unlock()
+	if cfg != nil {
+		router.policy.SetConfig(cfg)
+	}
+	router.setFailoverConfigLocked(cfg)
+	router.updateFailoverLocked(time.Now())
+}
+
+func (router *ScoreBasedRouter) setFailoverConfigLocked(cfg *config.Config) {
+	if cfg == nil {
+		router.failoverTargets = make(map[string]struct{})
+		router.failoverTimeout = 0
+		return
+	}
+	targets := make(map[string]struct{}, len(cfg.Proxy.FailBackendList))
+	for _, name := range cfg.Proxy.FailBackendList {
+		targets[name] = struct{}{}
+	}
+	router.failoverTargets = targets
+	router.failoverTimeout = time.Duration(cfg.Proxy.FailoverTimeout) * time.Second
+}
+
+func (router *ScoreBasedRouter) backendInFailoverListLocked(backend *backendWrapper) bool {
+	_, active := router.failoverTargets[backend.PodName()]
+	if !active {
+		_, active = router.failoverTargets[backend.Addr()]
+	}
+	return active
+}
+
+func (router *ScoreBasedRouter) routeableObservedBackendsLocked(failoverAddrs map[string]struct{}) []policy.BackendCtx {
+	backends := make([]policy.BackendCtx, 0, len(router.backends))
+	for _, backend := range router.backends {
+		if !backend.ObservedHealthy() {
+			continue
+		}
+		healthy := true
+		if failoverAddrs != nil {
+			_, inFail := failoverAddrs[backend.Addr()]
+			healthy = !inFail
+		}
+		backends = append(backends, routeCheckBackend{
+			backendWrapper: backend,
+			healthy:        healthy,
+		})
+	}
+	return router.policy.RouteableBackends(backends)
+}
+
+func (router *ScoreBasedRouter) updateFailoverLocked(now time.Time) {
+	if router.policy == nil {
+		return
+	}
+	failoverAddrs := make(map[string]struct{}, len(router.backends))
+	for _, backend := range router.backends {
+		if router.backendInFailoverListLocked(backend) {
+			failoverAddrs[backend.Addr()] = struct{}{}
+		}
+	}
+
+	routeable := router.routeableObservedBackendsLocked(nil)
+	if len(routeable) > 0 {
+		remaining := router.routeableObservedBackendsLocked(failoverAddrs)
+		if len(remaining) == 0 {
+			matched := 0
+			for _, b := range routeable {
+				if _, ok := failoverAddrs[b.Addr()]; ok {
+					matched++
+				}
+			}
+			if !router.ignoreFailover {
+				router.logger.Warn("fail-backend-list would leave no routeable backend, ignore the list",
+					zap.Int("routeable_backend_count", len(routeable)),
+					zap.Int("matched_routeable_backend_count", matched))
+			}
+			router.ignoreFailover = true
+			clear(failoverAddrs)
+		} else {
+			router.ignoreFailover = false
+		}
+	} else {
+		router.ignoreFailover = false
+	}
+
+	for _, backend := range router.backends {
+		_, active := failoverAddrs[backend.Addr()]
+		since := time.Time{}
+		if active {
+			since = now
+		}
+		changed, since := backend.setFailover(since)
+		if !changed {
+			continue
+		}
+		fields := []zap.Field{
+			zap.String("backend_addr", backend.Addr()),
+			zap.String("backend_pod", backend.PodName()),
+			zap.Duration("failover_timeout", router.failoverTimeout),
+		}
+		if active {
+			fields = append(fields, zap.Time("failover_since", since))
+			router.logger.Warn("backend enters failover", fields...)
+			continue
+		}
+		router.logger.Info("backend exits failover", fields...)
+	}
+}
+
+func (router *ScoreBasedRouter) closeTimedOutFailoverConnectionsLocked(now time.Time) {
+	for _, backend := range router.backends {
+		since := backend.FailoverSince()
+		if since.IsZero() {
+			continue
+		}
+		if router.failoverTimeout > 0 && since.Add(router.failoverTimeout).After(now) {
+			continue
+		}
+		for ele := backend.connList.Front(); ele != nil; ele = ele.Next() {
+			conn := ele.Value
+			if conn.phase == phaseClosed || conn.forceClosing {
+				continue
+			}
+			fields := []zap.Field{
+				zap.Uint64("connID", conn.ConnectionID()),
+				zap.String("backend_addr", backend.addr),
+				zap.String("backend_pod", backend.PodName()),
+				zap.Duration("failover_timeout", router.failoverTimeout),
+				zap.Duration("failover_elapsed", now.Sub(since)),
+			}
+			if conn.ForceClose() {
+				conn.forceClosing = true
+				router.logger.Info("force close connection on failover backend", fields...)
+			}
+		}
+	}
 }
 
 func (router *ScoreBasedRouter) ConnCount() int {

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -384,7 +384,7 @@ func (router *ScoreBasedRouter) rebalance(ctx context.Context) {
 	if migrationInterval < rebalanceInterval*2 {
 		// If we need to migrate multiple connections in each round, calculate the connection count for each round.
 		count = int((rebalanceInterval-1)/migrationInterval) + 1
-	} else if curTime.Sub(router.lastRedirectTime) >= migrationInterval {
+	} else {
 		// If we need to wait for multiple rounds to migrate a connection, calculate the interval for each connection.
 		if curTime.Sub(router.lastRedirectTime) >= migrationInterval {
 			count = 1

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -707,6 +707,174 @@ func TestSetBackendStatus(t *testing.T) {
 	}
 }
 
+func TestBackendPodNameFromAddr(t *testing.T) {
+	require.Equal(t, "db-2033841436272623616-0f6e346b-tidb-0", backendPodNameFromAddr("db-2033841436272623616-0f6e346b-tidb-0.peer.ns.svc:4000"))
+	require.Equal(t, "127.0.0.1", backendPodNameFromAddr("127.0.0.1:4000"))
+	require.Equal(t, "backend-host", backendPodNameFromAddr("backend-host"))
+}
+
+func TestFailoverBackendByAddr(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.Addr()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	selector := tester.router.GetBackendSelector()
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Equal(t, toBackend.Addr(), backend.Addr())
+}
+
+func TestIgnoreFailoverListWhenItMatchesAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.addBackends(2)
+	require.True(t, tester.getBackendByIndex(0).Healthy())
+	require.True(t, tester.getBackendByIndex(1).Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+	selector := tester.router.GetBackendSelector()
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+}
+
+func TestIgnoreFailoverListAfterExpandingToAllHealthyBackends(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	tester.addConnections(20)
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	tester.rebalance(1)
+	tester.redirectFinish(10, true)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+	require.False(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName(), toBackend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	require.True(t, fromBackend.Healthy())
+	require.True(t, toBackend.Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+	tester.rebalance(1)
+	for _, conn := range tester.conns {
+		require.False(t, conn.closing)
+	}
+}
+
+func TestFailoverTimeoutForceClose(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(1)
+	tester.addConnections(3)
+	for _, conn := range tester.conns {
+		conn.blockRedirect = true
+	}
+	tester.addBackends(1)
+	backend := tester.getBackendByIndex(0)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{backend.PodName()},
+				FailoverTimeout: 0,
+			},
+		},
+	})
+	tester.rebalance(1)
+	for _, conn := range tester.conns {
+		require.True(t, conn.closing)
+	}
+	tester.closeConnections(3, false)
+	tester.checkBackendConnMetrics()
+}
+
+func TestFailoverListReevaluatedWithBackendHealth(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(3)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{"1", "2"},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	require.False(t, tester.getBackendByIndex(0).Healthy())
+	require.False(t, tester.getBackendByIndex(1).Healthy())
+	require.True(t, tester.getBackendByIndex(2).Healthy())
+	require.Equal(t, 1, tester.router.HealthyBackendCount())
+	tester.updateBackendStatusByAddr("3", false)
+	require.True(t, tester.getBackendByIndex(0).Healthy())
+	require.True(t, tester.getBackendByIndex(1).Healthy())
+	require.Equal(t, 2, tester.router.HealthyBackendCount())
+	tester.updateBackendStatusByAddr("3", true)
+	require.False(t, tester.getBackendByIndex(0).Healthy())
+	require.False(t, tester.getBackendByIndex(1).Healthy())
+	require.True(t, tester.getBackendByIndex(2).Healthy())
+	require.Equal(t, 1, tester.router.HealthyBackendCount())
+}
+
+func TestFailoverBackend(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	tester.addConnections(20)
+	fromBackend := tester.getBackendByIndex(0)
+	toBackend := tester.getBackendByIndex(1)
+	tester.router.setConfig(&config.Config{
+		Proxy: config.ProxyServer{
+			ProxyServerOnline: config.ProxyServerOnline{
+				FailBackendList: []string{fromBackend.PodName()},
+				FailoverTimeout: 60,
+			},
+		},
+	})
+	require.False(t, fromBackend.Healthy())
+	selector := tester.router.GetBackendSelector()
+	backend, err := selector.Next()
+	require.NoError(t, err)
+	selector.Finish(nil, false)
+	require.NotNil(t, backend)
+	require.Equal(t, toBackend.Addr(), backend.Addr())
+	tester.rebalance(1)
+	require.Equal(t, 10, fromBackend.ConnCount())
+	tester.checkRedirectingNum(10)
+	tester.redirectFinish(10, true)
+	require.Equal(t, 0, fromBackend.ConnCount())
+	require.Equal(t, 20, toBackend.ConnCount())
+	tester.checkBackendConnMetrics()
+}
+
 func TestGetServerVersion(t *testing.T) {
 	lg, _ := logger.CreateLoggerForTest(t)
 	rt := NewScoreBasedRouter(lg)

--- a/pkg/manager/config/config_test.go
+++ b/pkg/manager/config/config_test.go
@@ -100,6 +100,26 @@ func TestConfigReload(t *testing.T) {
 				return c.Proxy.Addr == "gg"
 			},
 		},
+		{
+			name: "failover override",
+			precfg: `
+proxy.fail-backend-list = ["db-tidb-0", "db-tidb-1"]
+proxy.failover-timeout = 90
+`,
+			precheck: func(c *config.Config) bool {
+				return c.Proxy.FailoverTimeout == 90 &&
+					len(c.Proxy.FailBackendList) == 2 &&
+					c.Proxy.FailBackendList[0] == "db-tidb-0" &&
+					c.Proxy.FailBackendList[1] == "db-tidb-1"
+			},
+			postcfg: `
+proxy.fail-backend-list = []
+proxy.failover-timeout = 0
+`,
+			postcheck: func(c *config.Config) bool {
+				return c.Proxy.FailoverTimeout == 0 && len(c.Proxy.FailBackendList) == 0
+			},
+		},
 	}
 
 	for i, tc := range cases {

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -208,7 +208,8 @@ func TestMultiVIP(t *testing.T) {
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return strings.Count(text.String(), "adding VIP success") >= 2 ||
-			strings.Count(text.String(), "ip: command not found") >= 2
+			strings.Count(text.String(), "ip: command not found") >= 2 ||
+			strings.Count(text.String(), "executable file not found") >= 2
 	}, 3*time.Second, 10*time.Millisecond)
 	vm1.PreClose()
 	vm2.PreClose()

--- a/pkg/manager/vip/network_test.go
+++ b/pkg/manager/vip/network_test.go
@@ -45,7 +45,9 @@ func TestAddDelIP(t *testing.T) {
 	}
 
 	isOtherErr := func(err error) bool {
-		return strings.Contains(err.Error(), "command not found") || strings.Contains(err.Error(), "not in the sudoers file")
+		return strings.Contains(err.Error(), "command not found") ||
+			strings.Contains(err.Error(), "not in the sudoers file") ||
+			strings.Contains(err.Error(), "executable file not found")
 	}
 
 	for i, test := range tests {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -630,6 +630,28 @@ func (mgr *BackendConnManager) Redirect(backendInst router.BackendInst) bool {
 	return true
 }
 
+// ForceClose forces closing the connection when the failover times out.
+func (mgr *BackendConnManager) ForceClose() bool {
+	for {
+		status := mgr.closeStatus.Load()
+		if status >= statusClosing {
+			return false
+		}
+		if mgr.closeStatus.CompareAndSwap(status, statusClosing) {
+			break
+		}
+	}
+	mgr.quitSource = SrcProxyQuit
+	if mgr.clientIO != nil {
+		// Interrupt in-flight I/O and let the normal connection teardown release buffers.
+		// Closing the PacketIO here may race with ExecuteCmd() flushing to the client.
+		if err := mgr.clientIO.GracefulClose(); err != nil && !pnet.IsDisconnectError(err) {
+			mgr.logger.Warn("force close client IO error", zap.Error(err))
+		}
+	}
+	return true
+}
+
 func (mgr *BackendConnManager) notifyRedirectResult(ctx context.Context, rs *redirectResult) {
 	if rs == nil {
 		return

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -786,6 +786,69 @@ func TestGracefulCloseWhenActive(t *testing.T) {
 	ts.runTests(runners)
 }
 
+type countingPacketIO struct {
+	pnet.PacketIO
+	gracefulCloseCnt atomic.Int32
+	closeCnt         atomic.Int32
+}
+
+func (cp *countingPacketIO) GracefulClose() error {
+	cp.gracefulCloseCnt.Add(1)
+	return nil
+}
+
+func (cp *countingPacketIO) Close() error {
+	cp.closeCnt.Add(1)
+	return nil
+}
+
+func TestForceClose(t *testing.T) {
+	ts := newBackendMgrTester(t)
+	runners := []runner{
+		// 1st handshake
+		{
+			client:  ts.mc.authenticate,
+			proxy:   ts.firstHandshake4Proxy,
+			backend: ts.handshake4Backend,
+		},
+		// force close
+		{
+			proxy: func(_, _ pnet.PacketIO) error {
+				require.True(t, ts.mp.ForceClose())
+				return nil
+			},
+		},
+		// really closed
+		{
+			proxy: ts.checkConnClosed4Proxy,
+		},
+		{
+			proxy: func(clientIO, backendIO pnet.PacketIO) error {
+				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				require.False(t, ts.mp.ForceClose())
+				return nil
+			},
+		},
+	}
+	ts.runTests(runners)
+}
+
+func TestForceCloseUsesGracefulClose(t *testing.T) {
+	mgr := NewBackendConnManager(zap.NewNop(), &DefaultHandshakeHandler{}, nil, 1, &BCConfig{})
+	clientIO := &countingPacketIO{}
+	mgr.clientIO = clientIO
+
+	require.True(t, mgr.ForceClose())
+	require.Equal(t, SrcProxyQuit, mgr.QuitSource())
+	require.Equal(t, int32(statusClosing), mgr.closeStatus.Load())
+	require.EqualValues(t, 1, clientIO.gracefulCloseCnt.Load())
+	require.Zero(t, clientIO.closeCnt.Load())
+
+	require.False(t, mgr.ForceClose())
+	require.EqualValues(t, 1, clientIO.gracefulCloseCnt.Load())
+	require.Zero(t, clientIO.closeCnt.Load())
+}
+
 func TestGracefulCloseBeforeHandshake(t *testing.T) {
 	ts := newBackendMgrTester(t)
 	runners := []runner{


### PR DESCRIPTION
This is a manual cherry-pick of #1116

<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1115

Problem Summary:
When a backend is confirmed to fail, we need a way to evict it manually.

What is changed and how it works:
- add `proxy.fail-backend-list` and `proxy.failover-timeout` config
- stop routing new connections to failed backends and migrate existing ones away
- force close remaining connections after the failover timeout
- if no more available backends, ignore the list to be HA
- allow `fail-backend-list` to match by pod name or backend address

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

<img width="2178" height="480" alt="image" src="https://github.com/user-attachments/assets/1697b97a-992d-452d-8ce5-dfa8d77239da" />

Notable changes

- [x] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Support evict failed backends by config
```
