### PR TITLE
api: add `PUT/DELETE /health` endpoint to mark the instance as unhealthy

### DIFF
--- a/lib/config/health.go
+++ b/lib/config/health.go
@@ -6,7 +6,8 @@ package config
 import "time"
 
 type HealthInfo struct {
-	ConfigChecksum uint32 `json:"config_checksum"`
+	ConfigChecksum  uint32 `json:"config_checksum"`
+	UnhealthyReason string `json:"unhealthy_reason,omitempty"`
 }
 
 const (

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -13,12 +13,25 @@ import (
 
 func (h *Server) DebugHealth(c *gin.Context) {
 	status := http.StatusOK
-	if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
+	health := config.HealthInfo{
+		ConfigChecksum: h.mgr.CfgMgr.GetConfigChecksum(),
+	}
+	if h.unhealthyMark.Load() {
+		status = http.StatusBadGateway
+	} else if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
 		status = http.StatusBadGateway
 	}
-	c.JSON(status, config.HealthInfo{
-		ConfigChecksum: h.mgr.CfgMgr.GetConfigChecksum(),
-	})
+	c.JSON(status, health)
+}
+
+func (h *Server) DebugSetHealthUnhealthy(c *gin.Context) {
+	h.unhealthyMark.Store(true)
+	c.JSON(http.StatusOK, "")
+}
+
+func (h *Server) DebugUnsetHealthUnhealthy(c *gin.Context) {
+	h.unhealthyMark.Store(false)
+	c.JSON(http.StatusOK, "")
 }
 
 func (h *Server) DebugRedirect(c *gin.Context) {
@@ -39,5 +52,7 @@ func (h *Server) DebugRedirect(c *gin.Context) {
 func (h *Server) registerDebug(group *gin.RouterGroup) {
 	group.POST("/redirect", h.DebugRedirect)
 	group.GET("/health", h.DebugHealth)
+	group.POST("/health/unhealthy", h.DebugSetHealthUnhealthy)
+	group.DELETE("/health/unhealthy", h.DebugUnsetHealthUnhealthy)
 	pprof.RouteRegister(group, "/pprof")
 }

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -5,11 +5,19 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/tiproxy/lib/config"
 )
+
+const manualHealthStatusUnhealthy = "unhealthy"
+
+type manualHealthOverride struct {
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
 
 func (h *Server) DebugHealth(c *gin.Context) {
 	status := http.StatusOK
@@ -18,6 +26,7 @@ func (h *Server) DebugHealth(c *gin.Context) {
 	}
 	if h.unhealthyMark.Load() {
 		status = http.StatusBadGateway
+		health.UnhealthyReason = h.unhealthyReason.Load()
 	} else if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
 		status = http.StatusBadGateway
 	}
@@ -25,12 +34,28 @@ func (h *Server) DebugHealth(c *gin.Context) {
 }
 
 func (h *Server) DebugSetHealthUnhealthy(c *gin.Context) {
+	var req manualHealthOverride
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, "bad health override json")
+		return
+	}
+	if req.Status != manualHealthStatusUnhealthy {
+		c.JSON(http.StatusBadRequest, "bad health override status")
+		return
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		c.JSON(http.StatusBadRequest, "health override reason is required")
+		return
+	}
+	h.unhealthyReason.Store(reason)
 	h.unhealthyMark.Store(true)
 	c.JSON(http.StatusOK, "")
 }
 
 func (h *Server) DebugUnsetHealthUnhealthy(c *gin.Context) {
 	h.unhealthyMark.Store(false)
+	h.unhealthyReason.Store("")
 	c.JSON(http.StatusOK, "")
 }
 
@@ -52,7 +77,7 @@ func (h *Server) DebugRedirect(c *gin.Context) {
 func (h *Server) registerDebug(group *gin.RouterGroup) {
 	group.POST("/redirect", h.DebugRedirect)
 	group.GET("/health", h.DebugHealth)
-	group.POST("/health/unhealthy", h.DebugSetHealthUnhealthy)
-	group.DELETE("/health/unhealthy", h.DebugUnsetHealthUnhealthy)
+	group.PUT("/health", h.DebugSetHealthUnhealthy)
+	group.DELETE("/health", h.DebugUnsetHealthUnhealthy)
 	pprof.RouteRegister(group, "/pprof")
 }

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -27,8 +27,12 @@ func (h *Server) DebugHealth(c *gin.Context) {
 			status = http.StatusBadGateway
 			health.UnhealthyReason = healthOverride.Reason
 		}
-	} else if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
+	} else if h.isClosing.Load() {
 		status = http.StatusBadGateway
+		health.UnhealthyReason = "server is closing"
+	} else if !h.mgr.NsMgr.Ready() {
+		status = http.StatusBadGateway
+		health.UnhealthyReason = "namespace manager is not ready"
 	}
 	c.JSON(status, health)
 }
@@ -40,10 +44,6 @@ func (h *Server) DebugSetManualHealthOverride(c *gin.Context) {
 		return
 	}
 	reason := strings.TrimSpace(req.Reason)
-	if !req.Healthy && reason == "" {
-		c.JSON(http.StatusBadRequest, "health override reason is required")
-		return
-	}
 	override := &manualHealthOverride{
 		Healthy: req.Healthy,
 		Reason:  reason,

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -12,11 +12,9 @@ import (
 	"github.com/pingcap/tiproxy/lib/config"
 )
 
-const manualHealthStatusUnhealthy = "unhealthy"
-
 type manualHealthOverride struct {
-	Status string `json:"status"`
-	Reason string `json:"reason"`
+	Healthy bool   `json:"healthy"`
+	Reason  string `json:"reason"`
 }
 
 func (h *Server) DebugHealth(c *gin.Context) {
@@ -24,38 +22,38 @@ func (h *Server) DebugHealth(c *gin.Context) {
 	health := config.HealthInfo{
 		ConfigChecksum: h.mgr.CfgMgr.GetConfigChecksum(),
 	}
-	if h.unhealthyMark.Load() {
-		status = http.StatusBadGateway
-		health.UnhealthyReason = h.unhealthyReason.Load()
+	if healthOverride := h.manualHealthOverride.Load(); healthOverride != nil {
+		if !healthOverride.Healthy {
+			status = http.StatusBadGateway
+			health.UnhealthyReason = healthOverride.Reason
+		}
 	} else if h.isClosing.Load() || !h.mgr.NsMgr.Ready() {
 		status = http.StatusBadGateway
 	}
 	c.JSON(status, health)
 }
 
-func (h *Server) DebugSetHealthUnhealthy(c *gin.Context) {
+func (h *Server) DebugSetManualHealthOverride(c *gin.Context) {
 	var req manualHealthOverride
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, "bad health override json")
 		return
 	}
-	if req.Status != manualHealthStatusUnhealthy {
-		c.JSON(http.StatusBadRequest, "bad health override status")
-		return
-	}
 	reason := strings.TrimSpace(req.Reason)
-	if reason == "" {
+	if !req.Healthy && reason == "" {
 		c.JSON(http.StatusBadRequest, "health override reason is required")
 		return
 	}
-	h.unhealthyReason.Store(reason)
-	h.unhealthyMark.Store(true)
+	override := &manualHealthOverride{
+		Healthy: req.Healthy,
+		Reason:  reason,
+	}
+	h.manualHealthOverride.Store(override)
 	c.JSON(http.StatusOK, "")
 }
 
-func (h *Server) DebugUnsetHealthUnhealthy(c *gin.Context) {
-	h.unhealthyMark.Store(false)
-	h.unhealthyReason.Store("")
+func (h *Server) DebugClearManualHealthOverride(c *gin.Context) {
+	h.manualHealthOverride.Store(nil)
 	c.JSON(http.StatusOK, "")
 }
 
@@ -77,7 +75,7 @@ func (h *Server) DebugRedirect(c *gin.Context) {
 func (h *Server) registerDebug(group *gin.RouterGroup) {
 	group.POST("/redirect", h.DebugRedirect)
 	group.GET("/health", h.DebugHealth)
-	group.PUT("/health", h.DebugSetHealthUnhealthy)
-	group.DELETE("/health", h.DebugUnsetHealthUnhealthy)
+	group.PUT("/health", h.DebugSetManualHealthOverride)
+	group.DELETE("/health", h.DebugClearManualHealthOverride)
 	pprof.RouteRegister(group, "/pprof")
 }

--- a/pkg/server/api/debug.go
+++ b/pkg/server/api/debug.go
@@ -32,7 +32,7 @@ func (h *Server) DebugHealth(c *gin.Context) {
 		health.UnhealthyReason = "server is closing"
 	} else if !h.mgr.NsMgr.Ready() {
 		status = http.StatusBadGateway
-		health.UnhealthyReason = "namespace manager is not ready"
+		health.UnhealthyReason = "server is not ready"
 	}
 	c.JSON(status, health)
 }

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -37,5 +38,39 @@ func TestDebug(t *testing.T) {
 	server.PreClose()
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+	})
+}
+
+func TestDebugHealthManualUnhealthy(t *testing.T) {
+	_, doHTTP := createServer(t)
+
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		_, ok := health["unhealthy_reason"]
+		require.False(t, ok)
+	})
+
+	doHTTP(t, http.MethodPost, "/api/debug/health/unhealthy", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		_, ok := health["unhealthy_reason"]
+		require.False(t, ok)
+	})
+
+	doHTTP(t, http.MethodDelete, "/api/debug/health/unhealthy", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		_, ok := health["unhealthy_reason"]
+		require.False(t, ok)
 	})
 }

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -29,6 +29,9 @@ func TestDebug(t *testing.T) {
 	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(false)
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		require.Equal(t, "namespace manager is not ready", health["unhealthy_reason"])
 	})
 
 	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(true)
@@ -39,69 +42,54 @@ func TestDebug(t *testing.T) {
 	server.PreClose()
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		require.Equal(t, "server is closing", health["unhealthy_reason"])
 	})
 }
 
-func TestDebugHealthManualUnhealthy(t *testing.T) {
-	_, doHTTP := createServer(t)
+func TestDebugHealthManualOverride(t *testing.T) {
+	server, doHTTP := createServer(t)
+	assertHealth := func(statusCode int, unhealthyReason string) {
+		doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+			require.Equal(t, statusCode, r.StatusCode)
+			var health map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+			if unhealthyReason == "" {
+				_, ok := health["unhealthy_reason"]
+				require.False(t, ok)
+			} else {
+				require.Equal(t, unhealthyReason, health["unhealthy_reason"])
+			}
+		})
+	}
 
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusOK, r.StatusCode)
-		var health map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		_, ok := health["unhealthy_reason"]
-		require.False(t, ok)
-	})
+	assertHealth(http.StatusOK, "")
 
 	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
-		reader: bytes.NewBufferString(`{"healthy":false,"reason":"graceful-shutdown"}`),
+		reader: bytes.NewBufferString(`{"healthy":false}`),
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusBadGateway, r.StatusCode)
-		var health map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		require.Equal(t, "graceful-shutdown", health["unhealthy_reason"])
-	})
+	assertHealth(http.StatusBadGateway, "")
 
 	doHTTP(t, http.MethodDelete, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusOK, r.StatusCode)
-		var health map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		_, ok := health["unhealthy_reason"]
-		require.False(t, ok)
-	})
-}
-
-func TestDebugHealthManualHealthyOverride(t *testing.T) {
-	server, doHTTP := createServer(t)
+	assertHealth(http.StatusOK, "")
 
 	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(false)
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusBadGateway, r.StatusCode)
-	})
+	assertHealth(http.StatusBadGateway, "namespace manager is not ready")
 
 	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
 		reader: bytes.NewBufferString(`{"healthy":true,"reason":"manual-restore"}`),
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusOK, r.StatusCode)
-		var health map[string]any
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		_, ok := health["unhealthy_reason"]
-		require.False(t, ok)
-	})
+	assertHealth(http.StatusOK, "")
 
 	doHTTP(t, http.MethodDelete, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
-		require.Equal(t, http.StatusBadGateway, r.StatusCode)
-	})
+	assertHealth(http.StatusBadGateway, "namespace manager is not ready")
 }

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -54,7 +54,7 @@ func TestDebugHealthManualUnhealthy(t *testing.T) {
 	})
 
 	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
-		reader: bytes.NewBufferString(`{"status":"unhealthy","reason":"graceful-shutdown"}`),
+		reader: bytes.NewBufferString(`{"healthy":false,"reason":"graceful-shutdown"}`),
 	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
@@ -74,5 +74,34 @@ func TestDebugHealthManualUnhealthy(t *testing.T) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
 		_, ok := health["unhealthy_reason"]
 		require.False(t, ok)
+	})
+}
+
+func TestDebugHealthManualHealthyOverride(t *testing.T) {
+	server, doHTTP := createServer(t)
+
+	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(false)
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
+	})
+
+	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
+		reader: bytes.NewBufferString(`{"healthy":true,"reason":"manual-restore"}`),
+	}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		var health map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
+		_, ok := health["unhealthy_reason"]
+		require.False(t, ok)
+	})
+
+	doHTTP(t, http.MethodDelete, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+	})
+	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 	})
 }

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -52,18 +53,19 @@ func TestDebugHealthManualUnhealthy(t *testing.T) {
 		require.False(t, ok)
 	})
 
-	doHTTP(t, http.MethodPost, "/api/debug/health/unhealthy", httpOpts{}, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
+		reader: bytes.NewBufferString(`{"status":"unhealthy","reason":"graceful-shutdown"}`),
+	}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 		var health map[string]any
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		_, ok := health["unhealthy_reason"]
-		require.False(t, ok)
+		require.Equal(t, "graceful-shutdown", health["unhealthy_reason"])
 	})
 
-	doHTTP(t, http.MethodDelete, "/api/debug/health/unhealthy", httpOpts{}, func(t *testing.T, r *http.Response) {
+	doHTTP(t, http.MethodDelete, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
 	doHTTP(t, http.MethodGet, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {

--- a/pkg/server/api/debug_test.go
+++ b/pkg/server/api/debug_test.go
@@ -31,7 +31,7 @@ func TestDebug(t *testing.T) {
 		require.Equal(t, http.StatusBadGateway, r.StatusCode)
 		var health map[string]any
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&health))
-		require.Equal(t, "namespace manager is not ready", health["unhealthy_reason"])
+		require.Equal(t, "server is not ready", health["unhealthy_reason"])
 	})
 
 	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(true)
@@ -79,7 +79,7 @@ func TestDebugHealthManualOverride(t *testing.T) {
 	assertHealth(http.StatusOK, "")
 
 	server.mgr.NsMgr.(*mockNamespaceManager).success.Store(false)
-	assertHealth(http.StatusBadGateway, "namespace manager is not ready")
+	assertHealth(http.StatusBadGateway, "server is not ready")
 
 	doHTTP(t, http.MethodPut, "/api/debug/health", httpOpts{
 		reader: bytes.NewBufferString(`{"healthy":true,"reason":"manual-restore"}`),
@@ -91,5 +91,5 @@ func TestDebugHealthManualOverride(t *testing.T) {
 	doHTTP(t, http.MethodDelete, "/api/debug/health", httpOpts{}, func(t *testing.T, r *http.Response) {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 	})
-	assertHealth(http.StatusBadGateway, "namespace manager is not ready")
+	assertHealth(http.StatusBadGateway, "server is not ready")
 }

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -68,7 +68,9 @@ type Server struct {
 	lg        *zap.Logger
 	grpc      *grpc.Server
 	isClosing atomic.Bool
-	mgr       Managers
+	// unhealthyMark makes the health endpoint return unhealthy so that the external LB stops routing new traffic to this TiProxy.
+	unhealthyMark atomic.Bool
+	mgr           Managers
 }
 
 func NewServer(cfg config.API, lg *zap.Logger, mgr Managers, handler HTTPHandler, ready *atomic.Bool) (*Server, error) {

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -68,10 +68,9 @@ type Server struct {
 	lg        *zap.Logger
 	grpc      *grpc.Server
 	isClosing atomic.Bool
-	// unhealthyMark makes the health endpoint return unhealthy so that the external LB stops routing new traffic to this TiProxy.
-	unhealthyMark   atomic.Bool
-	unhealthyReason atomic.String
-	mgr             Managers
+	// manualHealthOverride is nil unless the debug API forces the health endpoint response.
+	manualHealthOverride atomic.Pointer[manualHealthOverride]
+	mgr                  Managers
 }
 
 func NewServer(cfg config.API, lg *zap.Logger, mgr Managers, handler HTTPHandler, ready *atomic.Bool) (*Server, error) {

--- a/pkg/server/api/server.go
+++ b/pkg/server/api/server.go
@@ -69,8 +69,9 @@ type Server struct {
 	grpc      *grpc.Server
 	isClosing atomic.Bool
 	// unhealthyMark makes the health endpoint return unhealthy so that the external LB stops routing new traffic to this TiProxy.
-	unhealthyMark atomic.Bool
-	mgr           Managers
+	unhealthyMark   atomic.Bool
+	unhealthyReason atomic.String
+	mgr             Managers
 }
 
 func NewServer(cfg config.API, lg *zap.Logger, mgr Managers, handler HTTPHandler, ready *atomic.Bool) (*Server, error) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #1140

Problem Summary:

For the LB from cloud provider, once the Pod enters `terminating` status, the connection will persist at most 15min (for aliyun) and 1h (for AWS). However, for `unhealthy`, the connection can be persisted for a very long time: 100h for AWS and not limited for Aliyun (I've only tested for 1h, and I'll try 24h tests later).

What is changed and how it works:

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
