### PR TITLE
balance: use `tidb_tikvclient_request_seconds_count` to be compatible with the latest tidb

### DIFF
--- a/pkg/balance/factor/factor_health.go
+++ b/pkg/balance/factor/factor_health.go
@@ -109,12 +109,12 @@ var (
 				Range2Value: generalRange2Value,
 				ResultType:  model.ValVector,
 			},
-			totalPromQL: `sum(increase(tidb_tikvclient_request_counter[2m])) by (instance)`,
+			totalPromQL: `sum(increase(tidb_tikvclient_request_seconds_count[2m])) by (instance)`,
 			queryTotalRule: metricsreader.QueryRule{
-				Names:     []string{"tidb_tikvclient_request_counter"},
+				Names:     []string{"tidb_tikvclient_request_seconds_count"},
 				Retention: 2 * time.Minute,
 				Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
-					return generalMetric2Value(mfs, "tidb_tikvclient_request_counter", "")
+					return generalMetric2Value(mfs, "tidb_tikvclient_request_seconds_count", "")
 				},
 				Range2Value: generalRange2Value,
 				ResultType:  model.ValVector,

--- a/pkg/balance/factor/factor_health_test.go
+++ b/pkg/balance/factor/factor_health_test.go
@@ -355,10 +355,10 @@ func TestHealthQueryRule(t *testing.T) {
 tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 10
 pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 10
 pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 100
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 20
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 30
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 20
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 30
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 20
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 30
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 20
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 30
 `,
 			curValue:   []model.SampleValue{10, 100, 0, 100},
 			finalValue: []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), model.SampleValue(math.NaN())},
@@ -369,10 +369,10 @@ tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 20
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 100
 pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 20
 pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 200
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 50
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 50
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 50
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 50
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 50
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 50
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 50
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 50
 `,
 			curValue:   []model.SampleValue{20, 200, 100, 200},
 			finalValue: []model.SampleValue{10, 100, 100, 100},
@@ -383,10 +383,10 @@ tidb_tikvclient_backoff_seconds_count{type="pdRPC"} 20
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 150
 pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 20
 pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 300
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 100
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="Get"} 100
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="BatchGet"} 100
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type="BatchGet"} 100
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 100
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="Get"} 100
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="BatchGet"} 100
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="2",type="BatchGet"} 100
 `,
 			curValue:   []model.SampleValue{20, 300, 150, 400},
 			finalValue: []model.SampleValue{10, 200, 150, 300},
@@ -396,7 +396,7 @@ tidb_tikvclient_request_counter{scope="false",stale_read="false",store="2",type=
 tidb_tikvclient_backoff_seconds_count{type="tikvRPC"} 10
 pd_client_cmd_handle_failed_cmds_duration_seconds_count{type="tso"} 5
 pd_client_cmd_handle_cmds_duration_seconds_count{type="tso"} 50
-tidb_tikvclient_request_counter{scope="false",stale_read="false",store="1",type="Get"} 50
+tidb_tikvclient_request_seconds_count{scope="false",stale_read="false",store="1",type="Get"} 50
 `,
 			curValue:   []model.SampleValue{5, 50, 10, 50},
 			finalValue: []model.SampleValue{model.SampleValue(math.NaN()), model.SampleValue(math.NaN()), 10, model.SampleValue(math.NaN())},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1110

Problem Summary:
The PR https://github.com/tikv/client-go/pull/1556/changes renames tidb_tikvclient_request_counter to tidb_tikvclient_source_request_seconds_count, so TiProxy needs to be compatible with both old and new client-go versions.
We can use tidb_tikvclient_request_seconds_count.

What is changed and how it works:
- Replace `tidb_tikvclient_request_counter` to `tidb_tikvclient_request_seconds_count` so it's compatible with all tidb versions.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Use `tidb_tikvclient_request_seconds_count` in the balance to be compatible with the latest TiDB
```
