### PR TITLE
replay: filter audit logs by table name suffixes in the replayer

### DIFF
--- a/cmd/replayer/main.go
+++ b/cmd/replayer/main.go
@@ -62,6 +62,7 @@ func main() {
 	startTime := rootCmd.PersistentFlags().Time("start-time", time.Now(), []string{time.RFC3339, time.RFC3339Nano}, "the time to start the replay. Format is RFC3339. Default is the current time.")
 	filterCommandWithRetry := rootCmd.PersistentFlags().Bool("filter-command-with-retry", false, "filter out commands that are retries according to the audit log.")
 	userAllowlist := rootCmd.PersistentFlags().StringSlice("user-allowlist", nil, "for audit log format only: USER values to replay (case-insensitive, normalized to lowercase); if set, lines whose [USER=...] is not listed are skipped (repeat flag or use comma-separated values).")
+	tableSuffixList := rootCmd.PersistentFlags().StringSlice("table-suffix-list", nil, "for audit log format only: replay GENERAL/TABLE_ACCESS SQL only when [TABLES=...] is non-empty and every table name ends with _<digits> and each digit string is in this list (repeat flag or comma-separated).")
 	waitOnEOF := rootCmd.PersistentFlags().Bool("wait-on-eof", false, "wait for the next file when all the files are read.")
 
 	rootCmd.RunE = func(cmd *cobra.Command, _ []string) error {
@@ -152,6 +153,7 @@ func main() {
 				OutputPath:             *outputPath,
 				FilterCommandWithRetry: *filterCommandWithRetry,
 				UserAllowlist:          *userAllowlist,
+				TableSuffixList:        *tableSuffixList,
 				WaitOnEOF:              *waitOnEOF,
 			}
 			if err := r.StartReplay(replayCfg); err != nil {

--- a/pkg/server/api/traffic.go
+++ b/pkg/server/api/traffic.go
@@ -164,6 +164,13 @@ func (h *Server) TrafficReplay(c *gin.Context) {
 			}
 		}
 	}
+	if tsl := strings.TrimSpace(c.PostForm("table-suffix-list")); tsl != "" {
+		for _, part := range strings.Split(tsl, ",") {
+			if s := strings.TrimSpace(part); s != "" {
+				cfg.TableSuffixList = append(cfg.TableSuffixList, s)
+			}
+		}
+	}
 	cfg.WaitOnEOF = strings.EqualFold(c.PostForm("wait-on-eof"), "true")
 	h.lg.Info("request: traffic replay", zap.Any("cfg", cfg))
 

--- a/pkg/server/api/traffic_test.go
+++ b/pkg/server/api/traffic_test.go
@@ -132,6 +132,17 @@ func TestTraffic(t *testing.T) {
 		require.Equal(t, "", mgr.curJob)
 		require.Equal(t, manager.CancelConfig{Type: manager.Replay, Graceful: true}, mgr.cancelCfg)
 	})
+	// replay with table-suffix-list
+	doHTTP(t, http.MethodPost, "/api/traffic/replay", httpOpts{
+		reader: cli.GetFormReader(map[string]string{"input": "/tmp2", "speed": "1.0", "username": "u2", "password": "p2", "table-suffix-list": "123, 456"}),
+		header: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
+	}, func(t *testing.T, r *http.Response) {
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		startTime := mgr.replayCfg.StartTime
+		require.False(t, startTime.IsZero())
+		require.Equal(t, replay.ReplayConfig{Input: "/tmp2", Username: "u2", Password: "p2", Speed: 1.0, StartTime: startTime, PSCloseStrategy: cmd.PSCloseStrategyDirected, TableSuffixList: []string{"123", "456"}}, mgr.replayCfg)
+	})
+	cancelJob(t, doHTTP)
 }
 
 func cancelJob(t *testing.T, doHTTP doHTTPFunc) {

--- a/pkg/sqlreplay/cmd/audit_log_plugin.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin.go
@@ -31,6 +31,7 @@ const (
 	auditPluginKeyPreparedStmtID = "PREPARED_STMT_ID"
 	auditPluginKeyRetry          = "RETRY"
 	auditPluginKeyUser           = "USER"
+	auditPluginKeyTables         = "TABLES"
 
 	auditPluginClassGeneral     = "GENERAL"
 	auditPluginClassTableAccess = "TABLE_ACCESS"
@@ -108,9 +109,12 @@ type AuditLogPluginDecoder struct {
 	filterCommandWithRetry bool
 	// userAllowlist, when non-empty, causes Decode to skip lines whose [USER=...] is not in the set.
 	userAllowlist map[string]struct{}
-	idAllocator   *ConnIDAllocator
-	dedup         *DeDup
-	lg            *zap.Logger
+	// tableSuffixAllowlist, when non-empty, causes Decode to skip GENERAL/TABLE_ACCESS lines unless
+	// every table in [TABLES=...] ends with _<digits> and each digit string is in this set.
+	tableSuffixAllowlist map[string]struct{}
+	idAllocator          *ConnIDAllocator
+	dedup                *DeDup
+	lg                   *zap.Logger
 }
 
 // ConnIDAllocator allocates connection IDs for new connections.
@@ -181,6 +185,16 @@ func (decoder *AuditLogPluginDecoder) Decode(reader LineReader) (*Command, error
 			}
 		}
 
+		eventClass := kvs[auditPluginKeyClass]
+		if decoder.tableSuffixAllowlist != nil {
+			switch eventClass {
+			case auditPluginClassGeneral, auditPluginClassTableAccess:
+				if !tablesFieldMatchesSuffixAllowlist(kvs[auditPluginKeyTables], decoder.tableSuffixAllowlist) {
+					continue
+				}
+			}
+		}
+
 		var connID uint64
 		if connCtx, ok := decoder.connInfo[upstreamConnID]; ok {
 			connID = connCtx.connID
@@ -196,7 +210,6 @@ func (decoder *AuditLogPluginDecoder) Decode(reader LineReader) (*Command, error
 		}
 
 		var cmds []*Command
-		eventClass := kvs[auditPluginKeyClass]
 		switch eventClass {
 		case auditPluginClassGeneral, auditPluginClassTableAccess:
 			cmds, err = decoder.parseGeneralEvent(kvs, startTs, endTs, upstreamConnID)
@@ -667,6 +680,73 @@ func (decoder *AuditLogPluginDecoder) EnableFilterCommandWithRetry() {
 	decoder.filterCommandWithRetry = true
 }
 
+// parseAuditTablesField parses the audit log TABLES value, e.g. `"[t1,t2]"` or `[t1,t2]`.
+func parseAuditTablesField(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	if raw[0] == '"' {
+		u, err := strconv.Unquote(raw)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unquote TABLES field")
+		}
+		raw = strings.TrimSpace(u)
+	}
+	if raw == "" {
+		return nil, nil
+	}
+	if raw[0] == '[' && raw[len(raw)-1] == ']' {
+		raw = strings.TrimSpace(raw[1 : len(raw)-1])
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// tableUnderscoreDigitSuffix reports whether name ends with '_' followed only by ASCII digits,
+// and returns that digit string (e.g. t_123 -> 123).
+func tableUnderscoreDigitSuffix(name string) (digits string, ok bool) {
+	idx := strings.LastIndexByte(name, '_')
+	if idx < 0 || idx == len(name)-1 {
+		return "", false
+	}
+	suf := name[idx+1:]
+	for i := 0; i < len(suf); i++ {
+		if suf[i] < '0' || suf[i] > '9' {
+			return "", false
+		}
+	}
+	return suf, true
+}
+
+func tablesFieldMatchesSuffixAllowlist(rawTables string, allow map[string]struct{}) bool {
+	if len(allow) == 0 {
+		return true
+	}
+	names, err := parseAuditTablesField(rawTables)
+	if err != nil || len(names) == 0 {
+		return false
+	}
+	for _, name := range names {
+		dig, ok := tableUnderscoreDigitSuffix(name)
+		if !ok {
+			return false
+		}
+		if _, ok := allow[dig]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // SetUserAllowlist restricts decoding to audit log lines whose USER field is in the list.
 // Matching is case-insensitive; names are stored in lowercase. Empty or all-blank entries are ignored.
 // When users is empty after trimming, filtering is disabled.
@@ -687,5 +767,28 @@ func (decoder *AuditLogPluginDecoder) SetUserAllowlist(users []string) {
 		decoder.userAllowlist = nil
 	} else {
 		decoder.userAllowlist = m
+	}
+}
+
+// SetTableSuffixAllowlist restricts decoding (GENERAL and TABLE_ACCESS only) to lines whose TABLES list
+// is non-empty and every table name ends with _<digits> where <digits> is in suffixes.
+// Empty or all-blank entries in suffixes are ignored. When no valid suffix remains, filtering is disabled.
+func (decoder *AuditLogPluginDecoder) SetTableSuffixAllowlist(suffixes []string) {
+	if len(suffixes) == 0 {
+		decoder.tableSuffixAllowlist = nil
+		return
+	}
+	m := make(map[string]struct{})
+	for _, s := range suffixes {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		m[s] = struct{}{}
+	}
+	if len(m) == 0 {
+		decoder.tableSuffixAllowlist = nil
+	} else {
+		decoder.tableSuffixAllowlist = m
 	}
 }

--- a/pkg/sqlreplay/cmd/audit_log_plugin_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin_test.go
@@ -728,6 +728,90 @@ func TestDecodeUserAllowlist(t *testing.T) {
 	})
 }
 
+func mkGeneralLine(tables, sql string, connID int) string {
+	return fmt.Sprintf(`[2025/09/08 21:16:29.585 +08:00] [INFO] [logger.go:77] [ID=17573373891] [TIMESTAMP=2025/09/06 16:16:29.585 +08:10] [EVENT_CLASS=GENERAL] [EVENT_SUBCLASS=] [STATUS_CODE=0] [COST_TIME=1057.834] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[]"] [TABLES=%s] [SQL_TEXT=%s] [ROWS=0] [CONNECTION_ID=%d] [CLIENT_PORT=52611] [PID=89967] [COMMAND=Query] [SQL_STATEMENTS=Select] [EXECUTE_PARAMS="[]"] [CURRENT_DB=] [EVENT=COMPLETED]`, tables, sql, connID)
+}
+
+func TestDecodeTableSuffixAllowlist(t *testing.T) {
+	t.Run("match replays", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"123", "456"})
+		line := mkGeneralLine(`"[t_123,n_456]"`, `"select 1"`, 1)
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Len(t, cmds, 1)
+		require.Contains(t, string(cmds[0].Payload), "select 1")
+	})
+
+	t.Run("wrong suffix skips", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"123"})
+		line := mkGeneralLine(`"[t_456]"`, `"select 1"`, 1)
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Empty(t, cmds)
+	})
+
+	t.Run("empty tables skips", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"123"})
+		line := mkGeneralLine(`"[]"`, `"select 1"`, 1)
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Empty(t, cmds)
+	})
+
+	t.Run("non digit suffix skips", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"123"})
+		line := mkGeneralLine(`"[t_12x]"`, `"select 1"`, 1)
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Empty(t, cmds)
+	})
+
+	t.Run("disconnect not filtered", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"999"})
+		lines := mkGeneralLine(`"[t_999]"`, `"select 1"`, 3552575510) + "\n" +
+			`[2025/09/08 21:16:35.621 +08:00] [INFO] [logger.go:77] [ID=17573373350] [TIMESTAMP=2025/09/08 21:16:35.621 +08:10] [EVENT_CLASS=CONNECTION] [EVENT_SUBCLASS=Disconnect] [STATUS_CODE=0] [COST_TIME=0] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[]"] [SQL_TEXT=] [ROWS=0] [CLIENT_PORT=49278] [CONNECTION_ID=3552575510] [CONNECTION_TYPE=SSL/TLS] [SERVER_ID=1] [SERVER_PORT=4000] [DURATION=22716.871792] [SERVER_OS_LOGIN_USER=test] [OS_VERSION=darwin.arm64] [CLIENT_VERSION=] [SERVER_VERSION=v9.0.0] [AUDIT_VERSION=] [SSL_VERSION=TLSv1.3] [PID=89967] [Reason=]` + "\n"
+		mr := mockReader{data: []byte(lines), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Len(t, cmds, 2)
+		require.Equal(t, pnet.ComQuit, cmds[1].Type)
+	})
+
+	t.Run("blank-only suffix disables filter", func(t *testing.T) {
+		decoder := NewAuditLogPluginDecoder(NewDeDup(), zap.NewNop())
+		decoder.SetPSCloseStrategy(PSCloseStrategyAlways)
+		decoder.SetTableSuffixAllowlist([]string{"", "  "})
+		line := mkGeneralLine(`"[]"`, `"select 9"`, 1)
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Len(t, cmds, 1)
+	})
+}
+
+func TestParseAuditTablesFieldAndSuffixMatch(t *testing.T) {
+	names, err := parseAuditTablesField(`"[t_123,n_456]"`)
+	require.NoError(t, err)
+	require.Equal(t, []string{"t_123", "n_456"}, names)
+	allow := map[string]struct{}{"123": {}, "456": {}}
+	require.True(t, tablesFieldMatchesSuffixAllowlist(`"[t_123,n_456]"`, allow))
+	require.False(t, tablesFieldMatchesSuffixAllowlist(`"[t_123,t_789]"`, allow))
+}
+
 func TestDecodeMultiLines(t *testing.T) {
 	tests := []struct {
 		lines string

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -128,6 +128,10 @@ type ReplayConfig struct {
 	// is not in this list are ignored (comma-separated in HTTP form; repeated or comma-separated CLI flag).
 	// Matching is case-insensitive; HTTP form values are stored lowercased, and the audit decoder lowercases for lookup.
 	UserAllowlist []string
+	// TableSuffixList is only used for audit log plugin format. When non-empty, GENERAL and TABLE_ACCESS lines
+	// are replayed only if TABLES is non-empty and every listed table name ends with _<digits> and each digit
+	// string appears in this list (comma-separated in HTTP form; repeated or comma-separated CLI flag).
+	TableSuffixList []string
 	// WaitOnEOF indicates whether the replayer waits for the next file when no more files.
 	WaitOnEOF bool
 	// the following fields are for testing
@@ -626,6 +630,9 @@ func (r *replay) constructDecoderForReader(ctx context.Context, reader cmd.LineR
 		}
 		if len(r.cfg.UserAllowlist) > 0 {
 			auditLogDecoder.SetUserAllowlist(r.cfg.UserAllowlist)
+		}
+		if len(r.cfg.TableSuffixList) > 0 {
+			auditLogDecoder.SetTableSuffixAllowlist(r.cfg.TableSuffixList)
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1159

Problem Summary:
In some workloads, the table name suffixes stand for tenant ID. We may need to only replay specific tenants.

What is changed and how it works:
Replay specific table name suffixes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
