### PR TITLE
replay: support command start time for audit log extension

### DIFF
--- a/pkg/sqlreplay/cmd/audit_log_extension.go
+++ b/pkg/sqlreplay/cmd/audit_log_extension.go
@@ -78,7 +78,8 @@ func (decoder *AuditLogExtensionDecoder) SetPSCloseStrategy(s PSCloseStrategy) {
 
 // SetCommandStartTime implements [AuditLogDecoder].
 func (decoder *AuditLogExtensionDecoder) SetCommandStartTime(t time.Time) {
-	// do nothing for extension decoder
+	// commandStartTime is not supported for extension decoder, use commandEndTime instead.
+	decoder.commandEndTime = t
 }
 
 func (decoder *AuditLogExtensionDecoder) Decode(reader LineReader) (retCmd *Command, err error) {

--- a/pkg/sqlreplay/cmd/audit_log_extension_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_extension_test.go
@@ -377,6 +377,31 @@ func TestDecodeAuditExtensionInNeverMode(t *testing.T) {
 	}
 }
 
+func TestDecodeAuditExtensionWithCommandStartTime(t *testing.T) {
+	lines := `[2026/01/08 19:44:11.099 +08:00] [INFO] [ID=f1c681c2-8d80-4677-9dd4-6b7222610aa8-0009] [EVENT="[QUERY,QUERY_DDL]"] [USER=root] [ROLES="[]"] [CONNECTION_ID=260047062] [SESSION_ALIAS=] [TABLES="[]"] [STATUS_CODE=1] [CURRENT_DB=test] [SQL_TEXT="CREATE TABLE t (id INT)"]
+[2026/01/08 19:44:11.110 +08:00] [INFO] [ID=f1c681c2-8d80-4677-9dd4-6b7222610aa8-000a] [EVENT="[QUERY,QUERY_DML,INSERT]"] [USER=root] [ROLES="[]"] [CONNECTION_ID=260047062] [SESSION_ALIAS=] [TABLES="[]"] [STATUS_CODE=1] [CURRENT_DB=test] [SQL_TEXT="INSERT INTO t VALUES (1)"]`
+
+	commandStartTime := time.Date(2026, 1, 8, 19, 44, 11, 110000000, time.Local)
+	decoder := NewAuditLogExtensionDecoder(zap.NewNop())
+	decoder.SetCommandStartTime(commandStartTime)
+	mr := mockReader{data: append([]byte(lines), '\n')}
+	cmds, err := decodeCmds(decoder, &mr)
+	require.ErrorContains(t, err, "EOF")
+	require.Equal(t, []*Command{
+		{
+			CurDB:          "test",
+			StartTs:        time.Date(2026, 1, 8, 19, 44, 11, 110000000, time.Local),
+			EndTs:          time.Date(2026, 1, 8, 19, 44, 11, 110000000, time.Local),
+			ConnID:         260047062,
+			UpstreamConnID: 260047062,
+			Type:           pnet.ComQuery,
+			Payload:        append([]byte{pnet.ComQuery.Byte()}, []byte("INSERT INTO t VALUES (1)")...),
+			Line:           2,
+			Success:        true,
+		},
+	}, cmds)
+}
+
 func TestDecodeAuditExtensionUserAllowlist(t *testing.T) {
 	decoder := NewAuditLogExtensionDecoder(zap.NewNop())
 	decoder.SetUserAllowlist([]string{" ROOT "})

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -218,9 +218,6 @@ func (cfg *ReplayConfig) Validate() ([]storage.ExternalStorage, error) {
 		if cfg.FilterCommandWithRetry {
 			return storages, errors.New("filtering commands with retry is not supported for audit log plugin v2 format")
 		}
-		if !cfg.CommandStartTime.IsZero() {
-			return storages, errors.New("command start time filter is not supported for audit log plugin v2 format")
-		}
 	}
 
 	if cfg.DynamicInput {


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #1056

Problem Summary:
- Users should prefer `--command-start-time`.
- Using a checkpoint reports error because the commandStartTime is set.

What is changed and how it works:
Treat commandStartTime as commandEndTime. Users actually don't care about the difference.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
