### PR TITLE
replay: fix table name format for audit log extension

### DIFF
--- a/pkg/sqlreplay/cmd/audit_log_extension_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_extension_test.go
@@ -550,9 +550,38 @@ func TestParseExecuteParamsForExtension(t *testing.T) {
 }
 
 func auditExtensionLine(user, connID, event, sql, params string) string {
-	line := `[2026/01/08 19:44:11.099 +08:00] [INFO] [EVENT="[` + event + `]"] [USER=` + user + `] [ROLES="[]"] [CONNECTION_ID=` + connID + `] [SESSION_ALIAS=] [TABLES="[]"] [STATUS_CODE=1] [CURRENT_DB=test] [SQL_TEXT=` + sql + `]`
+	return auditExtensionLineWithTables(user, connID, event, `"[]"`, sql, params)
+}
+
+func auditExtensionLineWithTables(user, connID, event, tables, sql, params string) string {
+	line := `[2026/01/08 19:44:11.099 +08:00] [INFO] [EVENT="[` + event + `]"] [USER=` + user + `] [ROLES="[]"] [CONNECTION_ID=` + connID + `] [SESSION_ALIAS=] [TABLES=` + tables + `] [STATUS_CODE=1] [CURRENT_DB=test] [SQL_TEXT=` + sql + `]`
 	if params != "" {
 		line += ` [EXECUTE_PARAMS=` + params + `]`
 	}
 	return line
+}
+
+func TestDecodeTableSuffixAllowlistForExtension(t *testing.T) {
+	tables := `"[` + "`test`.`customer_123`,`test`.`warehouse_456`" + `]"`
+	t.Run("match replays", func(t *testing.T) {
+		decoder := NewAuditLogExtensionDecoder(zap.NewNop())
+		decoder.SetTableSuffixAllowlist([]string{"123", "456"})
+		line := auditExtensionLineWithTables("root", "1", "QUERY,QUERY_DML,SELECT", tables, `"select 1"`, "")
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Len(t, cmds, 1)
+		require.Contains(t, string(cmds[0].Payload), "select 1")
+	})
+
+	t.Run("wrong suffix skips", func(t *testing.T) {
+		decoder := NewAuditLogExtensionDecoder(zap.NewNop())
+		decoder.SetTableSuffixAllowlist([]string{"123"})
+		badTables := `"[` + "`test`.`customer_789`" + `]"`
+		line := auditExtensionLineWithTables("root", "1", "QUERY,QUERY_DML,SELECT", badTables, `"select 1"`, "")
+		mr := mockReader{data: []byte(line + "\n"), filename: "f"}
+		cmds, err := decodeCmds(decoder, &mr)
+		require.ErrorIs(t, err, io.EOF)
+		require.Empty(t, cmds)
+	})
 }

--- a/pkg/sqlreplay/cmd/audit_log_plugin.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin.go
@@ -702,7 +702,9 @@ func (decoder *AuditLogPluginDecoder) EnableFilterCommandWithRetry() {
 	decoder.filterCommandWithRetry = true
 }
 
-// parseAuditTablesField parses the audit log TABLES value, e.g. `"[t1,t2]"` or `[t1,t2]`.
+// parseAuditTablesField parses the audit log TABLES value.
+// Plugin format: `"[t1,t2]"` or `[t1,t2]`.
+// Extension format: `"[`db`.`table`,`db`.`table2`]"` (comma-separated backtick-qualified names).
 func parseAuditTablesField(raw string) ([]string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -721,16 +723,59 @@ func parseAuditTablesField(raw string) ([]string, error) {
 	if raw[0] == '[' && raw[len(raw)-1] == ']' {
 		raw = strings.TrimSpace(raw[1 : len(raw)-1])
 	}
-	parts := strings.Split(raw, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		out = append(out, p)
+	return splitAuditTablesList(raw), nil
+}
+
+// splitAuditTablesList splits a TABLES list on commas outside backtick-quoted identifiers.
+func splitAuditTablesList(inner string) []string {
+	inner = strings.TrimSpace(inner)
+	if inner == "" {
+		return nil
 	}
-	return out, nil
+	var (
+		parts      []string
+		b          strings.Builder
+		inBacktick bool
+	)
+	flush := func() {
+		if s := strings.TrimSpace(b.String()); s != "" {
+			parts = append(parts, s)
+		}
+		b.Reset()
+	}
+	for i := 0; i < len(inner); i++ {
+		switch inner[i] {
+		case '`':
+			inBacktick = !inBacktick
+			b.WriteByte('`')
+		case ',':
+			if inBacktick {
+				b.WriteByte(',')
+			} else {
+				flush()
+			}
+		default:
+			b.WriteByte(inner[i])
+		}
+	}
+	flush()
+	return parts
+}
+
+// auditTableNameForSuffix returns the table identifier used for _<digits> suffix matching.
+// Plugin format uses plain names (e.g. t_123) with no schema/db prefix.
+// Extension format uses backtick-qualified names (e.g. `db`.`table_123`).
+func auditTableNameForSuffix(name string) string {
+	name = strings.TrimSpace(name)
+	if !strings.Contains(name, "`") {
+		return name
+	}
+	name = strings.Trim(name, "`")
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		name = name[idx+1:]
+		name = strings.Trim(name, "`")
+	}
+	return name
 }
 
 // tableUnderscoreDigitSuffix reports whether name ends with '_' followed only by ASCII digits,
@@ -758,7 +803,7 @@ func tablesFieldMatchesSuffixAllowlist(rawTables string, allow map[string]struct
 		return false
 	}
 	for _, name := range names {
-		dig, ok := tableUnderscoreDigitSuffix(name)
+		dig, ok := tableUnderscoreDigitSuffix(auditTableNameForSuffix(name))
 		if !ok {
 			return false
 		}

--- a/pkg/sqlreplay/cmd/audit_log_plugin_test.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin_test.go
@@ -812,6 +812,18 @@ func TestParseAuditTablesFieldAndSuffixMatch(t *testing.T) {
 	allow := map[string]struct{}{"123": {}, "456": {}}
 	require.True(t, tablesFieldMatchesSuffixAllowlist(`"[t_123,n_456]"`, allow))
 	require.False(t, tablesFieldMatchesSuffixAllowlist(`"[t_123,t_789]"`, allow))
+
+	require.Equal(t, "t_123", auditTableNameForSuffix("t_123"))
+	require.Equal(t, "n_456", auditTableNameForSuffix("n_456"))
+
+	extTables := `"[` + "`test`.`customer_123`,`test`.`warehouse_456`" + `]"`
+	extNames, err := parseAuditTablesField(extTables)
+	require.NoError(t, err)
+	require.Equal(t, []string{"`test`.`customer_123`", "`test`.`warehouse_456`"}, extNames)
+	require.Equal(t, "customer_123", auditTableNameForSuffix("`test`.`customer_123`"))
+	require.True(t, tablesFieldMatchesSuffixAllowlist(extTables, allow))
+	require.False(t, tablesFieldMatchesSuffixAllowlist(
+		`"[`+"`test`.`customer_789`"+`]"`, allow))
 }
 
 func TestDecodeMultiLines(t *testing.T) {

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -124,7 +124,7 @@ type ReplayConfig struct {
 	// is not in this list are ignored (comma-separated in HTTP form; repeated or comma-separated CLI flag).
 	// Matching is case-insensitive; HTTP form values are stored lowercased, and the audit decoder lowercases for lookup.
 	UserAllowlist []string
-	// TableSuffixList is only used for audit log plugin format. When non-empty, GENERAL and TABLE_ACCESS lines
+	// TableSuffixList is used for audit log plugin and extension formats. When non-empty, lines
 	// are replayed only if TABLES is non-empty and every listed table name ends with _<digits> and each digit
 	// string appears in this list (comma-separated in HTTP form; repeated or comma-separated CLI flag).
 	TableSuffixList []string


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #1159 

Problem Summary:
The table field for audit log plugin is like `[TABLES="[t_123,n_456]"]`, while it's like `[TABLES="[`test`.`customer`,`test`.`warehouse`]"]` for audit log extension.

What is changed and how it works:
Support both formats.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
