### PR TITLE
balance: lower the OOM risk level during TiDB bootstrap

### DIFF
--- a/pkg/balance/factor/factor_memory.go
+++ b/pkg/balance/factor/factor_memory.go
@@ -245,8 +245,11 @@ func calcMemUsage(usageHistory []model.SamplePair) (latestUsage float64, timeToO
 				continue
 			}
 			usageDiff := latestUsage - value
-			if usageDiff > 1e-4 {
+			if usageDiff > 1e-4 && latestUsage > 1e-4 {
 				timeToOOM = time.Duration(float64(timeDiff) * (oomMemoryUsage - latestUsage) / usageDiff)
+				// When the backend just starts, the memory usage usually bursts but is actually safe.
+				// Adjust timeToOOM so that the same growth rate is less urgent at lower memory usage.
+				timeToOOM = time.Duration(float64(timeToOOM) / latestUsage * 0.6)
 			}
 			break
 		}

--- a/pkg/balance/factor/factor_memory_test.go
+++ b/pkg/balance/factor/factor_memory_test.go
@@ -49,7 +49,7 @@ func TestMemoryScore(t *testing.T) {
 		},
 		{
 			memory: []float64{0, 0.1},
-			score:  1,
+			score:  0,
 		},
 		{
 			memory: []float64{1.0, 0.95},
@@ -121,13 +121,13 @@ func TestMemoryUsage(t *testing.T) {
 			memory:    []float64{0.2, 0.3},
 			ts:        []model.Time{model.Time(15000), model.Time(30000)},
 			lastUsage: 0.3,
-			timeToOOM: 90 * time.Second,
+			timeToOOM: 3 * time.Minute,
 		},
 		{
 			memory:    []float64{0.2, 0.3, 0.3},
 			ts:        []model.Time{model.Time(15000), model.Time(30000), model.Time(31000)},
 			lastUsage: 0.3,
-			timeToOOM: 96 * time.Second,
+			timeToOOM: 192 * time.Second,
 		},
 		{
 			memory:    []float64{0.3, 0.3},
@@ -165,7 +165,7 @@ func TestMemoryBalance(t *testing.T) {
 	}{
 		{
 			memory:   [][]float64{{0.2, 0.3}, {0.3, 0.4}},
-			scores:   []uint64{1, 1},
+			scores:   []uint64{0, 1},
 			balanced: true,
 		},
 		{
@@ -322,7 +322,7 @@ func TestMemoryBalanceCount(t *testing.T) {
 		case 1:
 			usage = []float64{0.8, 0.8}
 		case 2:
-			usage = []float64{0.1, 0.4}
+			usage = []float64{0.75, 0.88}
 		}
 		ts = ts.Add(time.Millisecond)
 		values := []*model.SampleStream{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #848 

Problem Summary:
When TiDB starts, the memory usually increases sharply, leading to fake OOM risk. This will cause unnecessary session migrations.

What is changed and how it works:
Adjust the `TimeToOOM` to `timeToOOM = time.Duration(float64(timeToOOM) / latestUsage * 0.6)`.
- `/latestUsage`: the lower the current usage is, the longer the timeToOOM is
- `* 0.6`: lower the `timeToOOM` so that the thresholds don't need to be changed

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
