### PR TITLE
sqlreplay: fix time unit for replay exec info

### DIFF
--- a/pkg/sqlreplay/replay/execinfo/file_sink.go
+++ b/pkg/sqlreplay/replay/execinfo/file_sink.go
@@ -34,7 +34,7 @@ func (s *fileSink) Write(rec Record) error {
 	s.lg.Info("exec info",
 		zap.String("sql", rec.SQL),
 		zap.String("db", rec.DB),
-		zap.String("cost", rec.Cost),
+		zap.Int64("cost", rec.Cost),
 		zap.String("ex_time", rec.ExTime))
 	return nil
 }

--- a/pkg/sqlreplay/replay/execinfo/kafka_sink_test.go
+++ b/pkg/sqlreplay/replay/execinfo/kafka_sink_test.go
@@ -31,7 +31,7 @@ func TestKafkaSinkWrite(t *testing.T) {
 	rec := Record{
 		SQL:    "select ?",
 		DB:     "db1",
-		Cost:   "1.000",
+		Cost:   1000,
 		ExTime: "20250906 17:03:50.222",
 	}
 	require.NoError(t, sink.Write(rec))

--- a/pkg/sqlreplay/replay/execinfo/record.go
+++ b/pkg/sqlreplay/replay/execinfo/record.go
@@ -4,8 +4,6 @@
 package execinfo
 
 import (
-	"strconv"
-
 	"github.com/pingcap/tidb/pkg/parser"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
@@ -13,13 +11,13 @@ import (
 	"github.com/siddontang/go/hack"
 )
 
-const outputTimeFormat = "20060102 15:04:05.999"
+const outputTimeFormat = "20060102 15:04:05"
 
 // Record is the JSON payload written for each executed SQL.
 type Record struct {
 	SQL    string `json:"sql"`
 	DB     string `json:"db"`
-	Cost   string `json:"cost"`
+	Cost   int64  `json:"cost"`
 	ExTime string `json:"ex_time"`
 }
 
@@ -33,7 +31,7 @@ func NewRecord(info conn.ExecInfo) (Record, bool) {
 	return Record{
 		SQL:    sql,
 		DB:     info.Command.CurDB,
-		Cost:   strconv.FormatFloat(float64(info.CostTime)/1000000.0, 'f', 3, 64),
+		Cost:   int64(info.CostTime) / 1000,
 		ExTime: info.StartTime.Format(outputTimeFormat),
 	}, true
 }

--- a/pkg/sqlreplay/replay/execinfo/record_test.go
+++ b/pkg/sqlreplay/replay/execinfo/record_test.go
@@ -28,8 +28,8 @@ func TestNewRecord(t *testing.T) {
 	require.Equal(t, Record{
 		SQL:    "select ?",
 		DB:     "db1",
-		Cost:   1000,
-		ExTime: "20250906 17:03:50.222",
+		Cost:   1000000,
+		ExTime: "20250906 17:03:50",
 	}, rec)
 
 	_, ok = NewRecord(conn.ExecInfo{

--- a/pkg/sqlreplay/replay/execinfo/record_test.go
+++ b/pkg/sqlreplay/replay/execinfo/record_test.go
@@ -28,7 +28,7 @@ func TestNewRecord(t *testing.T) {
 	require.Equal(t, Record{
 		SQL:    "select ?",
 		DB:     "db1",
-		Cost:   "1000.000",
+		Cost:   1000,
 		ExTime: "20250906 17:03:50.222",
 	}, rec)
 

--- a/pkg/sqlreplay/replay/replay_test.go
+++ b/pkg/sqlreplay/replay/replay_test.go
@@ -912,7 +912,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: time.Second,
 			},
-			log: "{\"sql\":\"select ?\",\"db\":\"db1\",\"cost\":\"1000.000\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"select ?\",\"db\":\"db1\",\"cost\":1000000,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{
@@ -923,7 +923,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: time.Millisecond,
 			},
-			log: "{\"sql\":\"insert into `t` values ( ? )\",\"db\":\"db1\",\"cost\":\"1.000\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"insert into `t` values ( ? )\",\"db\":\"db1\",\"cost\":1000,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{
@@ -934,7 +934,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: 1234567,
 			},
-			log: "{\"sql\":\"insert into `t` values ( ... )\",\"db\":\"db1\",\"cost\":\"1.235\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"insert into `t` values ( ... )\",\"db\":\"db1\",\"cost\":1234,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{
@@ -945,7 +945,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: 1234567,
 			},
-			log: "{\"sql\":\"select * from where `id` in ( ... )\",\"db\":\"db1\",\"cost\":\"1.235\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"select * from where `id` in ( ... )\",\"db\":\"db1\",\"cost\":1234,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{
@@ -955,7 +955,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: 9999 * time.Microsecond,
 			},
-			log: "{\"sql\":\"select ?\",\"db\":\"\",\"cost\":\"9.999\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"select ?\",\"db\":\"\",\"cost\":9999,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{
@@ -965,7 +965,7 @@ func TestRecordExecInfoLoop(t *testing.T) {
 				},
 				CostTime: 9999 * time.Microsecond,
 			},
-			log: "{\"sql\":\"select \\n\\\"\\\"\",\"db\":\"\",\"cost\":\"9.999\",\"ex_time\":\"20250906 17:03:50.222\"}\n",
+			log: "{\"sql\":\"select \\n\\\"\\\"\",\"db\":\"\",\"cost\":9999,\"ex_time\":\"20250906 17:03:50\"}\n",
 		},
 		{
 			execInfo: conn.ExecInfo{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #1161

Problem Summary:
The time unit is changed.

What is changed and how it works:
Update time unit from ms to us.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
