### PR TITLE
balance, proxy: fix TiDB CPU imbalance when balance.policy="resource"

### DIFF
--- a/pkg/balance/factor/factor_cpu.go
+++ b/pkg/balance/factor/factor_cpu.go
@@ -241,7 +241,7 @@ func (fc *FactorCPU) updateCpuPerConn() {
 // Estimate the current cpu usage by the latest CPU usage, the latest connection count, and the current connection count.
 func (fc *FactorCPU) getUsage(backend scoredBackend) (avgUsage, latestUsage float64) {
 	snapshot, ok := fc.snapshot[backend.ID()]
-	if !ok || snapshot.avgUsage < 0 || latestUsage < 0 {
+	if !ok || snapshot.avgUsage < 0 || snapshot.latestUsage < 0 {
 		// The metric has missed for minutes.
 		return 1, 1
 	}

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -445,14 +445,14 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time) {
 func (g *Group) removeConn(ce *glist.Element[*connWrapper]) {
 	backend := ce.Value.physicalOwner
 	if backend == nil {
-		g.lg.Error("unexpected nil physical owner for connection")
+		g.lg.Warn("unexpected nil physical owner for connection")
 		return
 	}
 	oldLen := backend.connList.Len()
 	backend.connList.Remove(ce)
 	newLen := backend.connList.Len()
 	if newLen != oldLen-1 {
-		g.lg.Error("the connection is not in the list", zap.String("backend", backend.id))
+		g.lg.Warn("the connection is not in the list", zap.String("backend", backend.id))
 	}
 	ce.Value.physicalOwner = nil
 	setBackendConnMetrics(backend.addr, newLen)
@@ -460,7 +460,7 @@ func (g *Group) removeConn(ce *glist.Element[*connWrapper]) {
 
 func (g *Group) addConn(backend *backendWrapper, conn *connWrapper) {
 	if conn.physicalOwner != nil {
-		g.lg.Error("unexpected non-nil physical owner for connection")
+		g.lg.Warn("unexpected non-nil physical owner for connection")
 	}
 	conn.physicalOwner = backend
 	ce := backend.connList.PushBack(conn)

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -395,6 +395,7 @@ func (g *Group) onCreateConn(backendInst BackendInst, conn RedirectableConn, suc
 	if succeed {
 		connWrapper := &connWrapper{
 			RedirectableConn: conn,
+			scoreOwner:       backend,
 			createTime:       time.Now(),
 			phase:            phaseNotRedirected,
 			forceClosing:     false,
@@ -437,12 +438,31 @@ func (g *Group) CloseTimedOutFailoverConnections(now time.Time) {
 	}
 }
 
-func (g *Group) removeConn(backend *backendWrapper, ce *glist.Element[*connWrapper]) {
+// removeConn removes the connection from the connList that actually contains it.
+// Always remove by `physicalOwner` instead of by the backend that the connection is physically on:
+// they differ when a redirect result has not been processed yet, and glist.Remove silently
+// does nothing if the element is not in the given list, which leaks the connection forever.
+func (g *Group) removeConn(ce *glist.Element[*connWrapper]) {
+	backend := ce.Value.physicalOwner
+	if backend == nil {
+		g.lg.Error("unexpected nil physical owner for connection")
+		return
+	}
+	oldLen := backend.connList.Len()
 	backend.connList.Remove(ce)
-	setBackendConnMetrics(backend.addr, backend.connList.Len())
+	newLen := backend.connList.Len()
+	if newLen != oldLen-1 {
+		g.lg.Error("the connection is not in the list", zap.String("backend", backend.id))
+	}
+	ce.Value.physicalOwner = nil
+	setBackendConnMetrics(backend.addr, newLen)
 }
 
 func (g *Group) addConn(backend *backendWrapper, conn *connWrapper) {
+	if conn.physicalOwner != nil {
+		g.lg.Error("unexpected non-nil physical owner for connection")
+	}
+	conn.physicalOwner = backend
 	ce := backend.connList.PushBack(conn)
 	setBackendConnMetrics(backend.addr, backend.connList.Len())
 	setConnWrapper(conn, ce)
@@ -513,39 +533,38 @@ func (g *Group) onRedirectFinished(from, to string, conn RedirectableConn, succe
 	fromBackend := g.ensureBackend(from)
 	toBackend := g.ensureBackend(to)
 	connWrapper := getConnWrapper(conn).Value
-	addMigrateMetrics(from, to, connWrapper.redirectReason, succeed, connWrapper.lastRedirect)
 	// The connection may be closed when this function is waiting for the lock.
 	if connWrapper.phase == phaseClosed {
 		return
 	}
 
+	addMigrateMetrics(fromBackend.addr, toBackend.addr, connWrapper.redirectReason, succeed, connWrapper.lastRedirect)
 	if succeed {
-		g.removeConn(fromBackend, getConnWrapper(conn))
+		g.removeConn(getConnWrapper(conn))
 		g.addConn(toBackend, connWrapper)
 		connWrapper.phase = phaseRedirectEnd
 	} else {
-		fromBackend.connScore++
-		toBackend.connScore--
+		connWrapper.transferScore(fromBackend)
 		connWrapper.phase = phaseRedirectFail
 	}
 }
 
 // OnConnClosed implements ConnEventReceiver.OnConnClosed interface.
-func (g *Group) OnConnClosed(backendID, redirectingBackendID string, conn RedirectableConn) error {
+func (g *Group) OnConnClosed(backendID string, conn RedirectableConn) error {
 	g.Lock()
 	defer g.Unlock()
-	backend := g.ensureBackend(backendID)
 	connWrapper := getConnWrapper(conn)
-	// If this connection has not redirected yet, decrease the score of the target backend.
-	if redirectingBackendID != "" {
-		redirectingBackend := g.ensureBackend(redirectingBackendID)
-		redirectingBackend.connScore--
-		metrics.PendingMigrateGuage.WithLabelValues(backendID, redirectingBackendID, connWrapper.Value.redirectReason).Dec()
-	} else {
-		backend.connScore--
+	cw := connWrapper.Value
+	// If the physical owner mismatches the score owner, it means the redirect result has not been processed yet.
+	if cw.physicalOwner != cw.scoreOwner && cw.physicalOwner != nil && cw.scoreOwner != nil {
+		addMigrateMetrics(cw.physicalOwner.addr, cw.scoreOwner.addr, cw.redirectReason, false, cw.lastRedirect)
 	}
-	g.removeConn(backend, connWrapper)
-	connWrapper.Value.phase = phaseClosed
+	cw.transferScore(nil)
+	// A redirect result may have not been processed yet, in which case the connection is still
+	// in the old backend's connList while `backendID` is the new backend, so remove the connection
+	// by its physicalOwner. onRedirectFinished won't touch the list once the phase is phaseClosed.
+	g.removeConn(connWrapper)
+	cw.phase = phaseClosed
 	return nil
 }
 
@@ -564,8 +583,7 @@ func (g *Group) redirectConn(conn *connWrapper, fromBackend *backendWrapper, toB
 	succeed := conn.Redirect(toBackend)
 	if succeed {
 		g.lg.Debug("begin redirect connection", fields...)
-		fromBackend.connScore--
-		toBackend.connScore++
+		conn.transferScore(toBackend)
 		conn.phase = phaseRedirectNotify
 		conn.redirectReason = reason
 		metrics.PendingMigrateGuage.WithLabelValues(fromBackend.addr, toBackend.addr, reason).Inc()

--- a/pkg/balance/router/group.go
+++ b/pkg/balance/router/group.go
@@ -182,16 +182,16 @@ func (g *Group) AddBackend(backendID string, backend *backendWrapper) {
 	backend.group = g
 }
 
-func (g *Group) RemoveBackend(backendID string) {
+// removeBackendIfIdle removes the backend from the group only if it has no connections and no
+// pending incoming/outgoing scores.
+func (g *Group) removeBackendIfIdle(backendID string, backend *backendWrapper) (removed, empty bool) {
 	g.Lock()
 	defer g.Unlock()
+	if backend.connList.Len() != 0 || backend.connScore > 0 {
+		return false, false
+	}
 	delete(g.backends, backendID)
-}
-
-func (g *Group) Empty() bool {
-	g.Lock()
-	defer g.Unlock()
-	return len(g.backends) == 0
+	return true, len(g.backends) == 0
 }
 
 func getConnWrapper(conn RedirectableConn) *glist.Element[*connWrapper] {

--- a/pkg/balance/router/router.go
+++ b/pkg/balance/router/router.go
@@ -25,7 +25,7 @@ var (
 type ConnEventReceiver interface {
 	OnRedirectSucceed(from, to string, conn RedirectableConn) error
 	OnRedirectFail(from, to string, conn RedirectableConn) error
-	OnConnClosed(backendID, redirectingBackendID string, conn RedirectableConn) error
+	OnConnClosed(backendID string, conn RedirectableConn) error
 }
 
 // Router routes client connections to backends.
@@ -271,6 +271,12 @@ func (b *backendWrapper) String() string {
 // connWrapper wraps RedirectableConn.
 type connWrapper struct {
 	RedirectableConn
+	// The backend whose connList contains this connection. It may differ from the backend that the
+	// connection is physically on when a redirect result is not processed yet, so removing the
+	// connection from the list must always go through `physicalOwner`.
+	physicalOwner *backendWrapper
+	// The backend whose connScore includes this connection.
+	scoreOwner *backendWrapper
 	// The reason why the redirection happens.
 	redirectReason string
 	// Last redirect start time of this connection.
@@ -278,6 +284,16 @@ type connWrapper struct {
 	createTime   time.Time
 	phase        connPhase
 	forceClosing bool
+}
+
+func (c *connWrapper) transferScore(to *backendWrapper) {
+	if c.scoreOwner != nil {
+		c.scoreOwner.connScore--
+	}
+	c.scoreOwner = to
+	if to != nil {
+		to.connScore++
+	}
 }
 
 func backendPodNameFromAddr(addr string) string {

--- a/pkg/balance/router/router_score.go
+++ b/pkg/balance/router/router_score.go
@@ -295,20 +295,25 @@ func (router *ScoreBasedRouter) rebuildPortConflictDetector() {
 // called in the lock.
 func (router *ScoreBasedRouter) updateGroups() {
 	for _, backend := range router.backends {
-		// If connList.Len() == 0, there won't be any outgoing connections.
-		// And if also connScore == 0, there won't be any incoming connections.
-		if !backend.ObservedHealthy() && backend.connList.Len() == 0 && backend.connScore <= 0 {
-			delete(router.backends, backend.id)
+		// An unhealthy backend can be removed once it has no connections. connList and connScore are
+		// protected by the group lock instead of the router lock, so read them through
+		// removeBackendIfIdle to avoid racing with connection events. A backend without a group has
+		// never been routed to, so it has no connections and can be removed directly.
+		if !backend.ObservedHealthy() {
+			removed, empty := true, false
 			if backend.group != nil {
-				backend.group.RemoveBackend(backend.id)
+				removed, empty = backend.group.removeBackendIfIdle(backend.id, backend)
+			}
+			if removed {
+				delete(router.backends, backend.id)
 				// remove empty groups
-				if backend.group.Empty() {
+				if backend.group != nil && empty {
 					router.groups = slices.DeleteFunc(router.groups, func(g *Group) bool {
 						return g == backend.group
 					})
 				}
+				continue
 			}
-			continue
 		}
 		// If the labels were correctly set, we won't update its group even if the labels change.
 		if backend.group != nil {

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -193,7 +193,7 @@ func (tester *routerTester) closeConnections(num int, redirecting bool) {
 		}
 	}
 	for _, conn := range conns {
-		err := tester.router.groups[0].OnConnClosed(conn.from.ID(), conn.GetRedirectingBackendID(), conn)
+		err := tester.router.groups[0].OnConnClosed(conn.from.ID(), conn)
 		require.NoError(tester.t, err)
 		delete(tester.conns, conn.connID)
 	}
@@ -280,6 +280,34 @@ func (tester *routerTester) checkBackendConnMetrics() {
 	require.EqualValues(tester.t, len(tester.conns), tester.router.ConnCount())
 }
 
+// checkNoConnLeak checks that no connection wrapper leaks in any connList and all connScores are 0
+// after all the connections are closed.
+func (tester *routerTester) checkNoConnLeak() {
+	for _, backend := range tester.router.backends {
+		require.Equal(tester.t, 0, backend.connList.Len(), "backend %s leaks connections in connList", backend.addr)
+		require.Equal(tester.t, 0, backend.connScore, "backend %s has a wrong connScore", backend.addr)
+	}
+}
+
+// prepareRedirectingConn creates one connection on backend "1" and makes it redirect to backend "2".
+func (tester *routerTester) prepareRedirectingConn() *mockRedirectableConn {
+	tester.addBackends(1)
+	tester.addConnections(1)
+	tester.addBackends(1)
+	// Make backend "1" unhealthy so that the connection is redirected to backend "2".
+	tester.updateBackendStatusByAddr("1", false)
+	tester.rebalance(1)
+	conn := tester.conns[1]
+	require.Equal(tester.t, "2", conn.GetRedirectingBackendID())
+	return conn
+}
+
+func (tester *routerTester) readPendingGauge(from, to, reason string) float64 {
+	val, err := metrics.ReadGauge(metrics.PendingMigrateGuage.WithLabelValues(from, to, reason))
+	require.NoError(tester.t, err)
+	return val
+}
+
 func (tester *routerTester) clear() {
 	tester.backendID = 0
 	tester.connID = 0
@@ -315,6 +343,114 @@ func TestRebalance(t *testing.T) {
 	// 50 not redirecting, 20 redirecting
 	tester.closeConnections(10, false)
 	tester.checkRedirectingNum(20)
+}
+
+// Test the race that the connection is closed after the redirection succeeds on the connection side
+// but before the router processes the redirect result. The connection must be removed from the
+// original backend's connList, otherwise it leaks in the connList forever, which inflates b_conn
+// metrics and distorts the balance.
+func TestCloseRaceWithRedirectSucceed(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	conn := tester.prepareRedirectingConn()
+	reason := getConnWrapper(conn).Value.redirectReason
+	pendingDuringRedirect := tester.readPendingGauge("1", "2", reason)
+
+	// The redirection succeeds on the connection side, and then the connection is closed
+	// before the router receives OnRedirectSucceed.
+	conn.redirectSucceed()
+	require.NoError(t, tester.router.groups[0].OnConnClosed(conn.from.ID(), conn))
+	delete(tester.conns, conn.connID)
+	// Now the router processes the redirect result.
+	require.NoError(t, tester.router.groups[0].OnRedirectSucceed("1", "2", conn))
+
+	tester.checkNoConnLeak()
+	tester.checkBackendConnMetrics()
+	require.Equal(t, pendingDuringRedirect-1, tester.readPendingGauge("1", "2", reason))
+}
+
+// Test the race that the connection is closed after the redirection fails on the connection side
+// but before the router processes the redirect result. The connScores moved by the redirection
+// must be moved back, otherwise they drift away permanently.
+func TestCloseRaceWithRedirectFail(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	conn := tester.prepareRedirectingConn()
+	reason := getConnWrapper(conn).Value.redirectReason
+	pendingDuringRedirect := tester.readPendingGauge("1", "2", reason)
+
+	// The redirection fails on the connection side, and then the connection is closed
+	// before the router receives OnRedirectFail.
+	conn.redirectFail()
+	require.NoError(t, tester.router.groups[0].OnConnClosed(conn.from.ID(), conn))
+	delete(tester.conns, conn.connID)
+	// Now the router processes the redirect result.
+	require.NoError(t, tester.router.groups[0].OnRedirectFail("1", "2", conn))
+
+	tester.checkNoConnLeak()
+	tester.checkBackendConnMetrics()
+	require.Equal(t, pendingDuringRedirect-1, tester.readPendingGauge("1", "2", reason))
+}
+
+// Test the race that the connection is closed before the connection side processes the redirect
+// signal. OnConnClosed reverts the redirection, and the aborted redirect result that arrives later
+// must not revert it again, otherwise the connScores and the pending gauge are decreased twice.
+func TestCloseRaceWithRedirectAborted(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	conn := tester.prepareRedirectingConn()
+	reason := getConnWrapper(conn).Value.redirectReason
+	pendingDuringRedirect := tester.readPendingGauge("1", "2", reason)
+
+	// The connection is closed before the redirect signal is processed on the connection side.
+	require.NoError(t, tester.router.groups[0].OnConnClosed(conn.from.ID(), conn))
+	delete(tester.conns, conn.connID)
+	// The aborted redirect result arrives later and must be a no-op.
+	require.NoError(t, tester.router.groups[0].OnRedirectFail("1", "2", conn))
+
+	tester.checkNoConnLeak()
+	tester.checkBackendConnMetrics()
+	require.Equal(t, pendingDuringRedirect-1, tester.readPendingGauge("1", "2", reason))
+}
+
+// Test that when the authenticator reconnects to another backend during the handshake,
+// the registration of the previous attempt is cleaned up.
+func TestReconnectDuringHandshake(t *testing.T) {
+	tester := newRouterTester(t, nil)
+	tester.addBackends(2)
+	conn := tester.createConn()
+	selector1 := tester.router.GetBackendSelector(ClientInfo{})
+	backend1, err := selector1.Next()
+	require.NoError(t, err)
+	require.False(t, backend1 == nil || reflect.ValueOf(backend1).IsNil())
+	selector1.Finish(conn, true)
+	// Simulate getBackendIO cleaning up before reconnecting to another backend.
+	require.NoError(t, tester.router.groups[0].OnConnClosed(backend1.ID(), conn))
+	selector2 := tester.router.GetBackendSelector(ClientInfo{})
+	var backend2 BackendInst
+	for {
+		backend2, err = selector2.Next()
+		require.NoError(t, err)
+		require.False(t, backend2 == nil || reflect.ValueOf(backend2).IsNil())
+		if backend2.ID() != backend1.ID() {
+			break
+		}
+		selector2.Finish(conn, false)
+	}
+	selector2.Finish(conn, true)
+	conn.from = backend2
+	tester.conns[conn.connID] = conn
+
+	// Only the registration of the second attempt remains.
+	totalConns, totalScore := 0, 0
+	for _, backend := range tester.router.backends {
+		totalConns += backend.connList.Len()
+		totalScore += backend.connScore
+	}
+	require.Equal(t, 1, totalConns)
+	require.Equal(t, 1, totalScore)
+	tester.checkBackendConnMetrics()
+
+	require.NoError(t, tester.router.groups[0].OnConnClosed(backend2.ID(), conn))
+	delete(tester.conns, conn.connID)
+	tester.checkNoConnLeak()
 }
 
 // Test that the connections are always balanced after rebalance and routing.
@@ -652,7 +788,7 @@ func TestConcurrency(t *testing.T) {
 						from, to := conn.getBackendIDs()
 						var err error
 						if i < 1 {
-							err = router.groups[0].OnConnClosed(from, conn.GetRedirectingBackendID(), conn)
+							err = router.groups[0].OnConnClosed(from, conn)
 							conn = nil
 						} else if i < 3 {
 							conn.redirectFail()
@@ -668,7 +804,7 @@ func TestConcurrency(t *testing.T) {
 						if i < 2 {
 							// The balancer may happen to redirect it concurrently - that's exactly what may happen.
 							from, _ := conn.getBackendIDs()
-							err := router.groups[0].OnConnClosed(from, conn.GetRedirectingBackendID(), conn)
+							err := router.groups[0].OnConnClosed(from, conn)
 							require.NoError(t, err)
 							conn = nil
 						}

--- a/pkg/balance/router/router_score_test.go
+++ b/pkg/balance/router/router_score_test.go
@@ -1418,6 +1418,8 @@ func TestNewGroupUsesLatestConfigGetter(t *testing.T) {
 	bo.addBackend(addr1, map[string]string{config.TiProxyPortLabelName: "10080"})
 	bo.notify(nil)
 	require.Eventually(t, func() bool {
+		router.Lock()
+		defer router.Unlock()
 		backend := router.backends[addr1]
 		return backend != nil && backend.Healthy()
 	}, 3*time.Second, 10*time.Millisecond)
@@ -1983,7 +1985,11 @@ func TestKeepExistingPortGroupWhenPortLabelChanges(t *testing.T) {
 	require.Eventually(t, func() bool {
 		router.Lock()
 		defer router.Unlock()
-		oldGroup = router.backends["backend-1"].group
+		backend := router.backends["backend-1"]
+		if backend == nil {
+			return false
+		}
+		oldGroup = backend.group
 		return oldGroup != nil && slices.Equal(oldGroup.values, []string{"cluster-a:10080"})
 	}, 3*time.Second, 10*time.Millisecond)
 
@@ -2005,7 +2011,8 @@ func TestKeepExistingPortGroupWhenPortLabelChanges(t *testing.T) {
 	require.Eventually(t, func() bool {
 		router.Lock()
 		defer router.Unlock()
-		return router.backends["backend-1"].group == oldGroup
+		backend := router.backends["backend-1"]
+		return backend != nil && backend.group == oldGroup
 	}, 3*time.Second, 10*time.Millisecond)
 	require.Eventually(t, func() bool {
 		return strings.Contains(text.String(), "backend routing values changed, keep the existing group until it is removed")

--- a/pkg/balance/router/router_static.go
+++ b/pkg/balance/router/router_static.go
@@ -74,7 +74,7 @@ func (r *StaticRouter) OnRedirectFail(from, to string, conn RedirectableConn) er
 	return nil
 }
 
-func (r *StaticRouter) OnConnClosed(backendID, redirectingBackendID string, conn RedirectableConn) error {
+func (r *StaticRouter) OnConnClosed(backendID string, conn RedirectableConn) error {
 	r.cnt--
 	return nil
 }

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -289,6 +289,7 @@ func (mgr *BackendConnManager) abandonRoutedBackend() {
 	}
 	// Clear the receiver so that Close() won't clean up again.
 	mgr.eventReceiver.Store(nil)
+	mgr.redirectInfo.Store(nil)
 }
 
 func (mgr *BackendConnManager) getBackendIO(ctx context.Context, cctx ConnContext, resp *pnet.HandshakeResp) (pnet.PacketIO, error) {
@@ -923,8 +924,10 @@ func (mgr *BackendConnManager) Close() error {
 	eventReceiver := mgr.getEventReceiver()
 	if eventReceiver != nil {
 		// Notify the receiver if there's any event.
-		if len(mgr.redirectResCh) > 0 {
-			mgr.notifyRedirectResult(context.Background(), <-mgr.redirectResCh)
+		select {
+		case rs := <-mgr.redirectResCh:
+			mgr.notifyRedirectResult(context.Background(), rs)
+		default:
 		}
 		// The connection may have just received the redirecting signal.
 		if mgr.curBackend != nil {

--- a/pkg/proxy/backend/backend_conn_mgr.go
+++ b/pkg/proxy/backend/backend_conn_mgr.go
@@ -276,7 +276,23 @@ func (mgr *BackendConnManager) newExponentialBackOff() *backoff.ExponentialBackO
 	return b
 }
 
+// abandonRoutedBackend removes the registration left by a previous successful dial during handshake.
+// It is called at the beginning of getBackendIO before routing to another backend.
+func (mgr *BackendConnManager) abandonRoutedBackend() {
+	receiver := mgr.getEventReceiver()
+	if receiver == nil || mgr.curBackend == nil {
+		return
+	}
+	if err := receiver.OnConnClosed(mgr.curBackend.ID(), mgr); err != nil {
+		mgr.logger.Warn("abandon routed backend failed", zap.String("backend_id", mgr.curBackend.ID()),
+			zap.String("backend_addr", mgr.curBackend.Addr()), zap.NamedError("notify_err", err))
+	}
+	// Clear the receiver so that Close() won't clean up again.
+	mgr.eventReceiver.Store(nil)
+}
+
 func (mgr *BackendConnManager) getBackendIO(ctx context.Context, cctx ConnContext, resp *pnet.HandshakeResp) (pnet.PacketIO, error) {
+	mgr.abandonRoutedBackend()
 	r, err := mgr.handshakeHandler.GetRouter(cctx, resp)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrProxyErr)
@@ -638,6 +654,7 @@ func (mgr *BackendConnManager) tryRedirect(ctx context.Context) {
 	}()
 	// Even if the connection is closing, the redirection result must still be sent to recover the connection scores.
 	if mgr.closeStatus.Load() >= statusNotifyClose || ctx.Err() != nil {
+		rs.err = ErrClosing
 		return
 	}
 	// It may have been too long since the redirection signal was sent, and the target backend may be unhealthy now.
@@ -911,13 +928,9 @@ func (mgr *BackendConnManager) Close() error {
 		}
 		// The connection may have just received the redirecting signal.
 		if mgr.curBackend != nil {
-			var redirectingBackendID string
-			if redirectingBackend := mgr.redirectInfo.Load(); redirectingBackend != nil {
-				redirectingBackendID = (*redirectingBackend).ID()
-			}
-			if err := eventReceiver.OnConnClosed(mgr.curBackend.ID(), redirectingBackendID, mgr); err != nil {
-				mgr.logger.Error("close connection error",
-					zap.String("backend_id", mgr.curBackend.ID()), zap.String("backend_addr", mgr.curBackend.Addr()), zap.NamedError("notify_err", err))
+			if err := eventReceiver.OnConnClosed(mgr.curBackend.ID(), mgr); err != nil {
+				mgr.logger.Error("close connection error", zap.String("backend_id", mgr.curBackend.ID()),
+					zap.String("backend_addr", mgr.curBackend.Addr()), zap.NamedError("notify_err", err))
 			}
 		}
 	}

--- a/pkg/proxy/backend/backend_conn_mgr_test.go
+++ b/pkg/proxy/backend/backend_conn_mgr_test.go
@@ -62,10 +62,9 @@ func (mer *mockEventReceiver) OnRedirectFail(from, to string, conn router.Redire
 	return nil
 }
 
-func (mer *mockEventReceiver) OnConnClosed(backendID, redirectingBackendID string, conn router.RedirectableConn) error {
+func (mer *mockEventReceiver) OnConnClosed(backendID string, conn router.RedirectableConn) error {
 	mer.eventCh <- event{
 		from:      backendID,
-		to:        redirectingBackendID,
 		eventName: eventClose,
 	}
 	return nil
@@ -886,6 +885,38 @@ func TestGracefulCloseWhenActive(t *testing.T) {
 		{
 			proxy: func(clientIO, backendIO pnet.PacketIO) error {
 				require.Equal(t, SrcProxyQuit, ts.mp.QuitSource())
+				return nil
+			},
+		},
+	}
+	ts.runTests(runners)
+}
+
+// Test that the redirection aborted by closing is reported as a failure instead of a success.
+// Otherwise, the router moves the connection to the target backend in the connList, which
+// leaks the connection in the list.
+func TestRedirectAbortedByCloseReportsFail(t *testing.T) {
+	ts := newBackendMgrTester(t)
+	runners := []runner{
+		// 1st handshake
+		{
+			client:  ts.mc.authenticate,
+			proxy:   ts.firstHandshake4Proxy,
+			backend: ts.handshake4Backend,
+		},
+		{
+			proxy: func(_, _ pnet.PacketIO) error {
+				// Simulate the race that the redirect signal is received but the connection
+				// starts closing before tryRedirect processes the signal.
+				backendInst := router.BackendInst(newMockBackendInst(ts))
+				ts.mp.redirectInfo.Store(&backendInst)
+				ts.mp.closeStatus.Store(statusNotifyClose)
+				ts.mp.processLock.Lock()
+				ts.mp.tryRedirect(context.Background())
+				ts.mp.processLock.Unlock()
+				// The aborted redirection must be reported as a failure, not a success.
+				ts.mp.getEventReceiver().(*mockEventReceiver).checkEvent(ts.t, eventFail)
+				ts.mp.closeStatus.Store(statusActive)
 				return nil
 			},
 		},


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1172

Problem Summary:
- When a connection is closing and migrating concurrently, the connection may be leaked, leading to wrong CPU scores.
- Data race in `ScoreBasedRoute.updateGroups()`.
- Other minor concurrency bugs.

What is changed and how it works:
- Add `physicalOwner` and `scoreOwner` to the `backendWrapper` so that it can always find the right backend.
- Remove `redirectingBackendID` because it's unnecessary now.
- Fix the non-atomic access of `BackendConnManager.redirectResCh`.
- Fix the redirect result is incorrectly set in `BackendConnManager.tryRedirect`.
- Other minor fixes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
