### PR TITLE
util: Disable keepalive for HTTP connections in metrics reader and health check

### DIFF
--- a/pkg/util/http/http.go
+++ b/pkg/util/http/http.go
@@ -34,6 +34,9 @@ func NewHTTPClientWithDialContext(getTLSConfig func() *tls.Config, dialContext f
 			Transport: &http.Transport{
 				TLSClientConfig: getTLSConfig(),
 				DialContext:     dialContext,
+				// When all the TiProxy/backend instances restart at once, the DNS entries may not be updated immediately.
+				// TiProxy may keep using the wrong connection to any owner or backend, so we disable keep-alive to avoid this issue.
+				DisableKeepAlives: true,
 			},
 		},
 		getTLSConfig: getTLSConfig,

--- a/pkg/util/http/http_test.go
+++ b/pkg/util/http/http_test.go
@@ -6,6 +6,7 @@ package http
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -16,6 +17,59 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
+
+func TestNewHTTPClientDisableKeepAlives(t *testing.T) {
+	for name, newClient := range map[string]func() *Client{
+		"NewHTTPClient": func() *Client {
+			return NewHTTPClient(func() *tls.Config { return nil })
+		},
+		"NewHTTPClientWithDialContext": func() *Client {
+			return NewHTTPClientWithDialContext(func() *tls.Config { return nil }, nil)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := newClient()
+			transport, ok := client.cli.Transport.(*http.Transport)
+			require.True(t, ok)
+			require.True(t, transport.DisableKeepAlives)
+		})
+	}
+}
+
+func TestNewHTTPClientDisableKeepAlivesNoConnectionReuse(t *testing.T) {
+	dialCount := atomic.Int32{}
+	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialCount.Add(1)
+		var d net.Dialer
+		return d.DialContext(ctx, network, addr)
+	}
+
+	httpHandler := &mockHttpHandler{t: t}
+	httpHandler.setHTTPResp(true)
+	httpHandler.setHTTPRespBody("ok")
+	listener, addr := testkit.StartListener(t, "")
+	server := &http.Server{Addr: addr, Handler: httpHandler}
+	var wg waitgroup.WaitGroup
+	wg.Run(func() {
+		_ = server.Serve(listener)
+	})
+	defer func() {
+		require.NoError(t, server.Close())
+		wg.Wait()
+	}()
+
+	client := NewHTTPClientWithDialContext(func() *tls.Config { return nil }, dialContext)
+	b := backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 1), context.Background())
+
+	_, err := client.Get(addr, "", b, time.Second)
+	require.NoError(t, err)
+	first := dialCount.Load()
+
+	_, err = client.Get(addr, "", b, time.Second)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), dialCount.Load()-first)
+}
 
 func TestHTTPGet(t *testing.T) {
 	httpHandler := &mockHttpHandler{


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1176

Problem Summary:
When all TiProxy instances restart at once, the DNS may be delayed. In that chaotic moment, TiProxy may connect to the wrong metrics owner and can't get TiDB metrics. The HTTP connections have enabled keepalive, so the connections will never be reset.
This could also happen in many scenarios, such as health check, or routing to backends. Restarting all at once is still dangerous.

What is changed and how it works:
Disable keepalive in HTTP connections, especially in health check, metrics reading, backend cluster router. Given that the requests are not frequent, the overhead is minor.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
