### PR TITLE
*: remove unsafe hack functions

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -256,7 +256,7 @@ func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []st
 
 		if info, ok := ownerMap[zone]; !ok || info.revision > kv.CreateRevision {
 			ownerMap[zone] = ownerInfo{
-				addr:     hack.String(kv.Value),
+				addr:     string(kv.Value),
 				revision: kv.CreateRevision,
 			}
 		}

--- a/pkg/manager/elect/election.go
+++ b/pkg/manager/elect/election.go
@@ -218,7 +218,7 @@ func (m *election) GetOwnerID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return hack.String(kv.Value), nil
+	return string(kv.Value), nil
 }
 
 func (m *election) getOwnerInfo(ctx context.Context) (*mvccpb.KeyValue, error) {

--- a/pkg/proxy/backend/cmd_processor_query.go
+++ b/pkg/proxy/backend/cmd_processor_query.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	pnet "github.com/pingcap/tiproxy/pkg/proxy/net"
-	"github.com/siddontang/go/hack"
 )
 
 // query is called when the proxy sends requests to the backend by itself,
@@ -88,7 +87,7 @@ func (cp *CmdProcessor) readResultColumns(packetIO pnet.PacketIO, result *mysql.
 		if err = result.Fields[fieldIndex].Parse(data); err != nil {
 			return errors.WithStack(err)
 		}
-		fieldName := hack.String(result.Fields[fieldIndex].Name)
+		fieldName := string(result.Fields[fieldIndex].Name)
 		result.FieldNames[fieldName] = fieldIndex
 		fieldIndex++
 	}

--- a/pkg/proxy/net/auth.go
+++ b/pkg/proxy/net/auth.go
@@ -52,7 +52,7 @@ func GenerateAuthResp(password, authPlugin string, salt []byte) ([]byte, error) 
 	case AuthMySQLClearPassword:
 		return append(hack.Slice(password), 0), nil
 	case AuthSocket:
-		return hack.Slice(password), nil
+		return []byte(password), nil
 	default:
 		return nil, errors.Errorf("unsupported auth plugin %s", authPlugin)
 	}

--- a/pkg/proxy/net/mysql.go
+++ b/pkg/proxy/net/mysql.go
@@ -436,7 +436,7 @@ func ParseChangeUser(data []byte, capability Capability) (*ChangeUserReq, error)
 	req := new(ChangeUserReq)
 	pos := 1
 	// username
-	req.User = hack.String(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
+	req.User = string(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
 	pos += len(req.User) + 1
 	// auth data
 	if capability&ClientSecureConnection > 0 {
@@ -449,7 +449,7 @@ func ParseChangeUser(data []byte, capability Capability) (*ChangeUserReq, error)
 		pos += len(req.AuthData) + 1
 	}
 	// db
-	req.DB = hack.String(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
+	req.DB = string(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
 	pos += len(req.DB) + 1
 	if pos >= len(data) {
 		return req, nil
@@ -459,7 +459,7 @@ func ParseChangeUser(data []byte, capability Capability) (*ChangeUserReq, error)
 	pos += 2
 	// auth plugin
 	if capability&ClientPluginAuth > 0 {
-		req.AuthPlugin = hack.String(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
+		req.AuthPlugin = string(data[pos : pos+bytes.IndexByte(data[pos:], 0)])
 		pos += len(req.AuthPlugin) + 1
 	}
 	// attrs
@@ -508,9 +508,9 @@ func ParseErrorPacket(data []byte) *gomysql.MyError {
 	e.Code = binary.LittleEndian.Uint16(data[pos:])
 	pos += 2
 	pos++
-	e.State = hack.String(data[pos : pos+5])
+	e.State = string(data[pos : pos+5])
 	pos += 5
-	e.Message = hack.String(data[pos:])
+	e.Message = string(data[pos:])
 	return e
 }
 
@@ -578,7 +578,7 @@ func ParseQueryPacket(data []byte) string {
 	if len(data) > 0 && data[len(data)-1] == 0 {
 		data = data[:len(data)-1]
 	}
-	return hack.String(data)
+	return string(data)
 }
 
 func MakeQueryPacket(stmt string) []byte {
@@ -864,7 +864,7 @@ func ParseExecuteStmtRequest(data []byte, paramNum int, paramTypes []byte) (stmt
 			if isNull {
 				args[i] = nil
 			} else {
-				args[i] = hack.String(v)
+				args[i] = string(v)
 			}
 			pos += n
 		default:

--- a/pkg/sqlreplay/capture/capture.go
+++ b/pkg/sqlreplay/capture/capture.go
@@ -375,7 +375,7 @@ func (c *capture) Capture(stmtInfo StmtInfo) {
 			if st.preparedStmtTexts == nil {
 				st.preparedStmtTexts = make(map[uint32]string)
 			}
-			st.preparedStmtTexts[stmtInfo.StmtID] = hack.String(command.Payload[1:])
+			st.preparedStmtTexts[stmtInfo.StmtID] = string(command.Payload[1:])
 			command.CapturedPsID = stmtInfo.StmtID
 		}
 	case pnet.ComStmtExecute:

--- a/pkg/sqlreplay/cmd/audit_log_plugin.go
+++ b/pkg/sqlreplay/cmd/audit_log_plugin.go
@@ -450,7 +450,7 @@ func parseSingleParam(value string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return hack.Slice(str), nil
+		return []byte(str), nil
 	case "KindMysqlDuration", "KindMysqlEnum", "KindInterface", "KindMinNotNull", "KindMaxValue", "KindRaw":
 		return nil, errors.Errorf("unsupported param type: %s", tpStr)
 	}

--- a/pkg/sqlreplay/cmd/cmd.go
+++ b/pkg/sqlreplay/cmd/cmd.go
@@ -149,7 +149,7 @@ func (c *Command) Digest() string {
 func (c *Command) QueryText() string {
 	switch c.Type {
 	case pnet.ComQuery, pnet.ComStmtPrepare:
-		return hack.String(c.Payload[1:])
+		return string(c.Payload[1:])
 	case pnet.ComStmtExecute:
 		return fmt.Sprintf("%s params=%v", c.PreparedStmt, c.Params)
 	case pnet.ComStmtClose, pnet.ComStmtSendLongData, pnet.ComStmtReset, pnet.ComStmtFetch:

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -250,7 +250,7 @@ func (c *conn) isReadOnly(command *cmd.Command) bool {
 func (c *conn) updatePreparedStmts(capturedPsID uint32, request []byte, resp ExecuteResp) {
 	switch request[0] {
 	case pnet.ComStmtPrepare.Byte():
-		stmt := hack.String(request[1:])
+		stmt := string(request[1:])
 		c.preparedStmts[resp.StmtID] = preparedStmt{text: stmt, paramNum: resp.ParamNum}
 		c.psIDMapping[capturedPsID] = resp.StmtID
 	case pnet.ComStmtExecute.Byte():


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1178 

Problem Summary:
Some hack.String or hack.Slice functions are unsafe. The referenced memory may be recycled after the function returns.

What is changed and how it works:
Replace some hack.String or hack.Slice with string() or []byte.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
