### PR TITLE
balance: read metrics directly from backends when failing to query from owners

### DIFF
--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -216,6 +216,7 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 		}
 	}
 
+	// If the metrics of some backends are missing, read directly from the backends.
 	missingAddrs := br.findMissingBackendAddrs(addrsFromTopology(backends, nil))
 	if len(missingAddrs) > 0 {
 		br.lg.Info("some backend metrics are missing, reading them directly from backends", zap.Strings("addrs", missingAddrs))

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -349,7 +349,7 @@ func (br *BackendReader) readFromBackendAddrs(ctx context.Context, addrs []strin
 				}
 				resp, err := br.readBackendMetric(ctx, addr)
 				if err != nil {
-					br.lg.Debug("read metrics from backend failed", zap.String("addr", addr), zap.Error(err))
+					br.lg.Warn("read metrics from backend failed", zap.String("addr", addr), zap.Error(err))
 					return
 				}
 				text := filterMetrics(hack.String(resp), allNames)

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/errors"
 	"github.com/pingcap/tiproxy/pkg/manager/elect"
+	"github.com/pingcap/tiproxy/pkg/manager/infosync"
 	"github.com/pingcap/tiproxy/pkg/metrics"
 	"github.com/pingcap/tiproxy/pkg/util/etcd"
 	"github.com/pingcap/tiproxy/pkg/util/http"
@@ -182,14 +183,25 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 		return err
 	}
 
-	// If self is a owner, read the backends that are not read by any other owners.
+	// If self is a owner, read backends except excludeZones. The backends in those zones are read by other zonal owners.
+	//
+	// If the zone is not set, there is only one global owner, who queries all backends.
+	// If the zone is set, there are several zonal owners, who query the backends in the same zone.
+	// There are some exceptions:
+	// 1. In k8s, the zone is not set at startup and then is set by HTTP API, so there may temporarily exist both global and zonal owners.
+	// 2. Some backends may not be in the same zone with any owner. E.g. there are only 2 TiProxy in a 3-AZ cluster.
+	// In any way, the owner queries the backends that are not queried by other owners.
 	var errs []error
+	backends, topologyErr := br.fetchBackendTopology(ctx)
+	if topologyErr != nil {
+		errs = append(errs, topologyErr)
+	}
 	var backendLabels []string
-	if br.isOwner.Load() {
+	if br.isOwner.Load() && topologyErr == nil {
 		if idx := slices.Index(zones, zone); idx >= 0 {
 			zones = slices.Delete(zones, idx, idx+1)
 		}
-		backendLabels, err = br.readFromBackends(ctx, zones)
+		backendLabels, err = br.readFromBackendAddrs(ctx, addrsFromTopology(backends, zones))
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -200,6 +212,14 @@ func (br *BackendReader) ReadMetrics(ctx context.Context) error {
 			continue
 		}
 		if err = br.readFromOwner(ctx, owner); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	missingAddrs := br.findMissingBackendAddrs(addrsFromTopology(backends, nil))
+	if len(missingAddrs) > 0 {
+		br.lg.Info("some backend metrics are missing, reading them directly from backends", zap.Strings("addrs", missingAddrs))
+		if _, err = br.readFromBackendAddrs(ctx, missingAddrs); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -275,19 +295,40 @@ func (br *BackendReader) queryAllOwners(ctx context.Context) (zones, owners []st
 	return
 }
 
-// If self is a owner, read backends except excludeZones. The backends in those zones are read by other zonal owners.
-//
-// If the zone is not set, there is only one global owner, who queries all backends.
-// If the zone is set, there are several zonal owners, who query the backends in the same zone.
-// There are some exceptions:
-// 1. In k8s, the zone is not set at startup and then is set by HTTP API, so there may temporarily exist both global and zonal owners.
-// 2. Some backends may not be in the same zone with any owner. E.g. there are only 2 TiProxy in a 3-AZ cluster.
-// In any way, the owner queries the backends that are not queried by other owners.
-func (br *BackendReader) readFromBackends(ctx context.Context, excludeZones []string) ([]string, error) {
-	addrs, err := br.getBackendAddrs(ctx, excludeZones)
-	if err != nil {
-		return nil, err
+// findMissingBackendAddrs returns backends that have no metrics in any query rule.
+// If any rule already has Step2History for a backend, the owner query is considered successful.
+func (br *BackendReader) findMissingBackendAddrs(addrs []string) []string {
+	br.Lock()
+	defer br.Unlock()
+	if len(br.queryRules) == 0 || len(addrs) == 0 {
+		return nil
 	}
+	missing := make([]string, 0)
+	for _, addr := range addrs {
+		label := getLabel4Addr(addr)
+		if br.backendNeedsFallbackLocked(label) {
+			missing = append(missing, addr)
+		}
+	}
+	return missing
+}
+
+// If a backend has metrics in any query rule, it means the metrics are pulled.
+func (br *BackendReader) backendNeedsFallbackLocked(label string) bool {
+	for ruleKey := range br.queryRules {
+		ruleHistory, ok := br.history[ruleKey]
+		if !ok {
+			continue
+		}
+		beHistory, ok := ruleHistory[label]
+		if ok && len(beHistory.Step2History) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (br *BackendReader) readFromBackendAddrs(ctx context.Context, addrs []string) ([]string, error) {
 	if len(addrs) == 0 {
 		return nil, nil
 	}
@@ -323,6 +364,18 @@ func (br *BackendReader) readFromBackends(ctx context.Context, excludeZones []st
 	}
 	br.wgp.Wait()
 	return backendLabels, nil
+}
+
+func mergeBackendLabels(labels, more []string) []string {
+	if len(more) == 0 {
+		return labels
+	}
+	for _, label := range more {
+		if !slices.Contains(labels, label) {
+			labels = append(labels, label)
+		}
+	}
+	return labels
 }
 
 func (br *BackendReader) collectAllNames() []string {
@@ -556,13 +609,17 @@ func (br *BackendReader) marshalHistory(backends []string) error {
 	return nil
 }
 
-func (br *BackendReader) getBackendAddrs(ctx context.Context, excludeZones []string) ([]string, error) {
+func (br *BackendReader) fetchBackendTopology(ctx context.Context) (map[string]*infosync.TiDBTopologyInfo, error) {
 	backends, err := br.backendFetcher.GetTiDBTopology(ctx)
 	if err != nil {
 		br.lg.Error("failed to get backend addresses, stop reading metrics", zap.Error(err))
 		metrics.ServerErrCounter.WithLabelValues("backend_metrics").Inc()
 		return nil, err
 	}
+	return backends, nil
+}
+
+func addrsFromTopology(backends map[string]*infosync.TiDBTopologyInfo, excludeZones []string) []string {
 	addrs := make([]string, 0, len(backends))
 	for _, backend := range backends {
 		if len(excludeZones) > 0 {
@@ -572,7 +629,7 @@ func (br *BackendReader) getBackendAddrs(ctx context.Context, excludeZones []str
 		}
 		addrs = append(addrs, net.JoinHostPort(backend.IP, strconv.Itoa(int(backend.StatusPort))))
 	}
-	return addrs, nil
+	return addrs
 }
 
 func (br *BackendReader) PreClose() {

--- a/pkg/balance/metricsreader/backend_reader.go
+++ b/pkg/balance/metricsreader/backend_reader.go
@@ -367,18 +367,6 @@ func (br *BackendReader) readFromBackendAddrs(ctx context.Context, addrs []strin
 	return backendLabels, nil
 }
 
-func mergeBackendLabels(labels, more []string) []string {
-	if len(more) == 0 {
-		return labels
-	}
-	for _, label := range more {
-		if !slices.Contains(labels, label) {
-			labels = append(labels, label)
-		}
-	}
-	return labels
-}
-
 func (br *BackendReader) collectAllNames() []string {
 	br.Lock()
 	defer br.Unlock()

--- a/pkg/balance/metricsreader/backend_reader_test.go
+++ b/pkg/balance/metricsreader/backend_reader_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// test getBackendAddrs
+// test addrsFromTopology and fetchBackendTopology
 func TestGetBackendAddrs(t *testing.T) {
 	tests := []struct {
 		backends     map[string]*infosync.TiDBTopologyInfo
@@ -126,11 +126,11 @@ func TestGetBackendAddrs(t *testing.T) {
 		} else {
 			fetcher.err = nil
 		}
-		addrs, err := br.getBackendAddrs(context.Background(), test.excludeZones)
 		if test.hasErr {
+			_, err := br.fetchBackendTopology(context.Background())
 			require.Error(t, err, "case %d", i)
 		} else {
-			require.NoError(t, err, "case %d", i)
+			addrs := addrsFromTopology(test.backends, test.excludeZones)
 			slices.Sort(addrs)
 			require.Equal(t, test.expected, addrs, "case %d", i)
 		}
@@ -890,15 +890,21 @@ func TestQueryBackendConcurrently(t *testing.T) {
 	var wg waitgroup.WaitGroup
 	childCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	// fill the initial query result to ensure the result is always non-empty
-	backends, err := br.readFromBackends(childCtx, nil)
+	backends, err := br.fetchBackendTopology(childCtx)
 	require.NoError(t, err)
-	require.Len(t, backends, initialBackends)
+	addrs := addrsFromTopology(backends, nil)
+	_, err = br.readFromBackendAddrs(childCtx, addrs)
+	require.NoError(t, err)
+	require.Len(t, addrs, initialBackends)
 	br.history2QueryResult()
 	wg.Run(func() {
 		for childCtx.Err() == nil {
-			backends, err := br.readFromBackends(childCtx, nil)
+			backends, err := br.fetchBackendTopology(childCtx)
 			require.NoError(t, err)
-			require.Len(t, backends, initialBackends)
+			addrs := addrsFromTopology(backends, nil)
+			_, err = br.readFromBackendAddrs(childCtx, addrs)
+			require.NoError(t, err)
+			require.Len(t, addrs, initialBackends)
 			br.purgeHistory()
 		}
 	})
@@ -1363,4 +1369,149 @@ func TestQueryAllOwnersForNamedCluster(t *testing.T) {
 	slices.Sort(owners)
 	require.Equal(t, []string{"east"}, zones)
 	require.Equal(t, []string{"cluster-a-east-owner", "cluster-a-owner"}, owners)
+}
+
+func TestFindMissingBackendAddrs(t *testing.T) {
+	now := model.Time(time.Now().UnixMilli())
+	backendLabel := "127.0.0.1:10080"
+	infos := map[string]*infosync.TiDBTopologyInfo{
+		"127.0.0.1:4000": {
+			IP:         "127.0.0.1",
+			StatusPort: 10080,
+		},
+	}
+	tests := []struct {
+		history  map[string]map[string]backendHistory
+		rules    []string
+		expected []string
+	}{
+		{
+			rules:    []string{"rule1", "rule2"},
+			expected: []string{"127.0.0.1:10080"},
+		},
+		{
+			rules: []string{"rule1", "rule2"},
+			history: map[string]map[string]backendHistory{
+				"rule1": {
+					backendLabel: {
+						Step2History: []model.SamplePair{{Timestamp: now, Value: 1}},
+					},
+				},
+			},
+		},
+		{
+			rules: []string{"rule1"},
+			history: map[string]map[string]backendHistory{
+				"rule1": {
+					backendLabel: {
+						Step1History: []model.SamplePair{{Timestamp: now, Value: 1}},
+					},
+				},
+			},
+			expected: []string{"127.0.0.1:10080"},
+		},
+	}
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	healthCfg := newHealthCheckConfigForTest()
+	fetcher := newMockBackendFetcher(infos, nil)
+	br := NewBackendReader(lg, nil, nil, nil, fetcher, healthCfg)
+	for i, test := range tests {
+		br.history = test.history
+		br.queryRules = make(map[string]QueryRule, len(test.rules))
+		for _, rule := range test.rules {
+			br.queryRules[rule] = QueryRule{}
+		}
+		addrs := addrsFromTopology(infos, nil)
+		missing := br.findMissingBackendAddrs(addrs)
+		if len(test.expected) == 0 {
+			require.Empty(t, missing, "case %d", i)
+		} else {
+			require.Equal(t, test.expected, missing, "case %d", i)
+		}
+	}
+}
+
+func TestReadMetricsFallback(t *testing.T) {
+	now := model.Time(time.Now().UnixMilli())
+	backend1Handler := newMockHttpHandler(t)
+	backend1Handler.getRespBody.Store(ptrFunc(func(string) string { return "cpu 10.0\n" }))
+	backend1Port := backend1Handler.Start()
+	t.Cleanup(backend1Handler.Close)
+
+	backend2Handler := newMockHttpHandler(t)
+	backend2Handler.getRespBody.Store(ptrFunc(func(string) string { return "cpu 20.0\n" }))
+	backend2Port := backend2Handler.Start()
+	t.Cleanup(backend2Handler.Close)
+
+	backend1Key := net.JoinHostPort("127.0.0.1", strconv.Itoa(backend1Port))
+	history := map[string]map[string]backendHistory{
+		"rule_id1": {
+			backend1Key: {
+				Step1History: []model.SamplePair{{Timestamp: now, Value: 10.0}},
+				Step2History: []model.SamplePair{{Timestamp: now, Value: 10.0}},
+			},
+		},
+	}
+	historyText, err := json.Marshal(history)
+	require.NoError(t, err)
+
+	rule := QueryRule{
+		Names:     []string{"cpu"},
+		Retention: time.Minute,
+		Metric2Value: func(mfs map[string]*dto.MetricFamily) model.SampleValue {
+			return model.SampleValue(*mfs["cpu"].Metric[0].Untyped.Value)
+		},
+		Range2Value: func(pairs []model.SamplePair) model.SampleValue {
+			return pairs[len(pairs)-1].Value
+		},
+		ResultType: model.ValVector,
+	}
+
+	ownerHttpHandler := newMockHttpHandler(t)
+	ownerPort := ownerHttpHandler.Start()
+	ownerAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(ownerPort))
+	ownerHttpHandler.getRespBody.Store(ptrFunc(func(string) string { return string(historyText) }))
+	t.Cleanup(ownerHttpHandler.Close)
+
+	suite := newEtcdTestSuite(t)
+	t.Cleanup(suite.close)
+	ownerKey := fmt.Sprintf("%s/%s", readerOwnerKeyPrefixForCluster(""), readerOwnerKeySuffix)
+	suite.putKV(ownerKey, ownerAddr)
+	require.Eventually(t, func() bool {
+		kvs := suite.getKV(ownerKey)
+		return len(kvs) == 1 && string(kvs[0].Value) == ownerAddr
+	}, 3*time.Second, 10*time.Millisecond)
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	healthCfg := newHealthCheckConfigForTest()
+	cfg := config.NewConfig()
+	cfgGetter := newMockConfigGetter(cfg)
+	infos := map[string]*infosync.TiDBTopologyInfo{
+		"127.0.0.1:4000": {IP: "127.0.0.1", StatusPort: uint(backend1Port)},
+		"127.0.0.1:4001": {IP: "127.0.0.1", StatusPort: uint(backend2Port)},
+	}
+	fetcher := newMockBackendFetcher(infos, nil)
+	httpCli := httputil.NewHTTPClient(func() *tls.Config { return nil })
+	br := NewBackendReader(lg, cfgGetter, httpCli, suite.client, fetcher, healthCfg)
+	err = br.Start(context.Background())
+	require.NoError(t, err)
+	br.AddQueryRule("rule_id1", rule)
+	t.Cleanup(br.Close)
+
+	err = br.ReadMetrics(context.Background())
+	require.NoError(t, err)
+	qr := br.GetQueryResult("rule_id1")
+	require.False(t, qr.Empty())
+	vector := qr.Value.(model.Vector)
+	require.Len(t, vector, 2)
+	sort.Slice(vector, func(i, j int) bool {
+		return vector[i].Value < vector[j].Value
+	})
+	require.Equal(t, model.SampleValue(10.0), vector[0].Value)
+	require.Equal(t, model.SampleValue(20.0), vector[1].Value)
+}
+
+func ptrFunc(f func(string) string) *func(string) string {
+	return &f
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #768 

Problem Summary:
Some problems may cause TiProxy to fail to query some backend metrics:
- The owner is not the right owner
- Network between TiProxy and the owner
In such cases, the backend CPU usage may be imbalance.

What is changed and how it works:
If some backend metrics are missing, read directly from the backends.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
