### PR TITLE
sqlreplay: add more debug logs for traffic replay

### DIFF
--- a/pkg/sqlreplay/cmd/audit_log_extension.go
+++ b/pkg/sqlreplay/cmd/audit_log_extension.go
@@ -63,6 +63,10 @@ func (decoder *AuditLogExtensionDecoder) SetUserAllowlist(users []string) {
 
 // SetCommandEndTime implements [AuditLogDecoder].
 func (decoder *AuditLogExtensionDecoder) SetCommandEndTime(t time.Time) {
+	if t.IsZero() {
+		// The command end time may not be set.
+		return
+	}
 	decoder.commandEndTime = t
 }
 
@@ -79,7 +83,7 @@ func (decoder *AuditLogExtensionDecoder) SetPSCloseStrategy(s PSCloseStrategy) {
 // SetCommandStartTime implements [AuditLogDecoder].
 func (decoder *AuditLogExtensionDecoder) SetCommandStartTime(t time.Time) {
 	// commandStartTime is not supported for extension decoder, use commandEndTime instead.
-	decoder.commandEndTime = t
+	decoder.SetCommandEndTime(t)
 }
 
 func (decoder *AuditLogExtensionDecoder) Decode(reader LineReader) (retCmd *Command, err error) {

--- a/pkg/sqlreplay/conn/conn.go
+++ b/pkg/sqlreplay/conn/conn.go
@@ -46,6 +46,8 @@ type ReplayStats struct {
 	CurCmdEndTs atomic.Int64
 	// The number of exception commands.
 	ExceptionCmds atomic.Uint64
+	// Disconnects is the number of backend disconnections during replay.
+	Disconnects atomic.Uint64
 }
 
 type ExecInfo struct {
@@ -82,6 +84,7 @@ type conn struct {
 	exceptionCh     chan<- Exception
 	closeCh         chan<- uint64
 	execInfoCh      chan<- ExecInfo
+	onCmdDone       func(fileName string)
 	lg              *zap.Logger
 	backendConn     BackendConn
 	connID          uint64 // logical connection ID, not replay ID and also not capture ID. It's the same with the `ConnID` of the first command.
@@ -103,6 +106,7 @@ type ConnOpts struct {
 	ExceptionCh      chan<- Exception
 	CloseCh          chan<- uint64
 	ExecInfoCh       chan<- ExecInfo
+	OnCmdDone        func(fileName string)
 	ReplayStats      *ReplayStats
 	Readonly         bool
 }
@@ -121,6 +125,7 @@ func NewConn(lg *zap.Logger, opts ConnOpts) *conn {
 		psIDMapping:    make(map[uint32]uint32),
 		exceptionCh:    opts.ExceptionCh,
 		closeCh:        opts.CloseCh,
+		onCmdDone:      opts.OnCmdDone,
 		backendConn:    NewBackendConn(lg.Named("be"), backendConnID, opts.HsHandler, opts.BcConfig, opts.BackendTLSConfig, opts.Username, opts.Password),
 		replayStats:    opts.ReplayStats,
 		readonly:       opts.Readonly,
@@ -158,6 +163,7 @@ func (c *conn) Run(ctx context.Context) {
 			if command == nil {
 				break
 			}
+			c.notifyCmdDone(command.Value)
 			if c.readonly && !c.isReadOnly(command.Value) {
 				c.replayStats.FilteredCmds.Add(1)
 				continue
@@ -336,6 +342,7 @@ func (c *conn) updateExecuteStmt(ctx context.Context, command *cmd.Command) erro
 }
 
 func (c *conn) onDisconnected(err error) {
+	c.replayStats.Disconnects.Add(1)
 	c.replayStats.ExceptionCmds.Add(1)
 	// Reporting should not block replaying.
 	select {
@@ -383,10 +390,19 @@ func (c *conn) updatePendingCmds(pendingCmds int) {
 	}
 }
 
+func (c *conn) notifyCmdDone(command *cmd.Command) {
+	if c.onCmdDone != nil && command != nil && command.FileName != "" {
+		c.onCmdDone(command.FileName)
+	}
+}
+
 func (c *conn) close() {
 	c.cmdLock.Lock()
 	if c.cmdList.Len() > 0 {
 		c.lg.Debug("backend connection closed while there are still pending commands", zap.Int("pending_cmds", c.cmdList.Len()))
+		for command := c.cmdList.Front(); command != nil; command = command.Next() {
+			c.notifyCmdDone(command.Value)
+		}
 	}
 	c.updatePendingCmds(0)
 	c.cmdLock.Unlock()

--- a/pkg/sqlreplay/replay/dry_run.go
+++ b/pkg/sqlreplay/replay/dry_run.go
@@ -22,11 +22,8 @@ type nopConn struct {
 
 func (c *nopConn) ExecuteCmd(command *cmd.Command) {
 	c.stats.ReplayedCmds.Add(1)
-	select {
-	case c.execInfoCh <- conn.ExecInfo{
+	c.execInfoCh <- conn.ExecInfo{
 		Command: command,
-	}:
-	default:
 	}
 	if c.onCmdDone != nil && command != nil && command.FileName != "" {
 		c.onCmdDone(command.FileName)

--- a/pkg/sqlreplay/replay/dry_run.go
+++ b/pkg/sqlreplay/replay/dry_run.go
@@ -17,12 +17,19 @@ type nopConn struct {
 	execInfoCh chan<- conn.ExecInfo
 	connID     uint64
 	stats      *conn.ReplayStats
+	onCmdDone  func(fileName string)
 }
 
 func (c *nopConn) ExecuteCmd(command *cmd.Command) {
 	c.stats.ReplayedCmds.Add(1)
-	c.execInfoCh <- conn.ExecInfo{
+	select {
+	case c.execInfoCh <- conn.ExecInfo{
 		Command: command,
+	}:
+	default:
+	}
+	if c.onCmdDone != nil && command != nil && command.FileName != "" {
+		c.onCmdDone(command.FileName)
 	}
 }
 

--- a/pkg/sqlreplay/replay/file_tracker.go
+++ b/pkg/sqlreplay/replay/file_tracker.go
@@ -1,0 +1,73 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+type fileExecTracker struct {
+	lg         *zap.Logger
+	mu         sync.Mutex
+	pending    map[string]int // decoded but not yet executed
+	decodeDone map[string]bool
+}
+
+func newFileExecTracker(lg *zap.Logger) *fileExecTracker {
+	return &fileExecTracker{
+		lg:         lg,
+		pending:    make(map[string]int),
+		decodeDone: make(map[string]bool),
+	}
+}
+
+// onDecoded is called when singleDecoder produces a command from `file`.
+func (t *fileExecTracker) onDecoded(file string) {
+	if t == nil || file == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending[file]++
+}
+
+// markDecodeDone is called when a singleDecoder has finished producing commands
+// from `file` (FileName switch or EOF). It is safe to call before the buffered
+// commands are executed: the pending counter protects against premature finish.
+func (t *fileExecTracker) markDecodeDone(file string) {
+	if t == nil || file == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.decodeDone[file] = true
+	t.tryFinishLocked(file)
+	t.lg.Info("finished decoding replay file", zap.String("file", file))
+}
+
+// onExecuted is called when a connection has finished processing a command
+// (executed, filtered, or drained on close).
+func (t *fileExecTracker) onExecuted(file string) {
+	if t == nil || file == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending[file]--
+	t.tryFinishLocked(file)
+}
+
+func (t *fileExecTracker) tryFinishLocked(file string) {
+	if !t.decodeDone[file] {
+		return
+	}
+	if t.pending[file] > 0 {
+		return
+	}
+	delete(t.pending, file)
+	delete(t.decodeDone, file)
+	t.lg.Info("finished executing replay file", zap.String("file", file))
+}

--- a/pkg/sqlreplay/replay/file_tracker.go
+++ b/pkg/sqlreplay/replay/file_tracker.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package replay

--- a/pkg/sqlreplay/replay/file_tracker_test.go
+++ b/pkg/sqlreplay/replay/file_tracker_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 PingCAP, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestFileExecTracker(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	tracker := newFileExecTracker(zap.New(core))
+	const file1 = "/data/tidb-audit-1.log"
+	const file2 = "/data/tidb-audit-2.log"
+
+	tracker.onDecoded(file1)
+	tracker.onDecoded(file1)
+	tracker.onExecuted(file1)
+	require.Empty(t, observed.FilterMessage("finished executing replay file").All())
+
+	tracker.markDecodeDone(file1)
+	require.Empty(t, observed.FilterMessage("finished executing replay file").All())
+
+	tracker.onExecuted(file1)
+	entries := observed.FilterMessage("finished executing replay file").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, file1, entries[0].ContextMap()["file"])
+
+	tracker.onDecoded(file2)
+	tracker.onExecuted(file2)
+	require.Len(t, observed.FilterMessage("finished executing replay file").All(), 1)
+
+	tracker.markDecodeDone(file2)
+	entries = observed.FilterMessage("finished executing replay file").All()
+	require.Len(t, entries, 2)
+	require.Equal(t, file2, entries[1].ContextMap()["file"])
+}
+
+func TestFileExecTrackerDecodeDoneBeforeExecute(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	tracker := newFileExecTracker(zap.New(core))
+	const file = "/data/tidb-audit-1.log"
+
+	tracker.onDecoded(file)
+	tracker.onExecuted(file)
+	tracker.markDecodeDone(file)
+	require.Len(t, observed.FilterMessage("finished executing replay file").All(), 1)
+}
+
+// Simulates the bufferedDecoder race: markDecodeDone fires from the fillBuffer
+// goroutine while some decoded commands are still buffered (onDecoded called,
+// but not yet onExecuted). Must not log prematurely.
+func TestFileExecTrackerMarkDecodeDoneWhileBuffered(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	tracker := newFileExecTracker(zap.New(core))
+	const file = "/data/tidb-audit-1.log"
+
+	tracker.onDecoded(file)
+	tracker.onDecoded(file)
+	// singleDecoder sees FileName switch -> markDecodeDone fires now,
+	// but the two decoded commands are still in the channel buffer.
+	tracker.markDecodeDone(file)
+	require.Empty(t, observed.FilterMessage("finished executing replay file").All())
+
+	tracker.onExecuted(file)
+	require.Empty(t, observed.FilterMessage("finished executing replay file").All())
+
+	tracker.onExecuted(file)
+	require.Len(t, observed.FilterMessage("finished executing replay file").All(), 1)
+}

--- a/pkg/sqlreplay/replay/file_tracker_test.go
+++ b/pkg/sqlreplay/replay/file_tracker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 package replay

--- a/pkg/sqlreplay/replay/merge_decoder.go
+++ b/pkg/sqlreplay/replay/merge_decoder.go
@@ -4,10 +4,13 @@
 package replay
 
 import (
+	"errors"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
+	"go.uber.org/zap"
 )
 
 // decoder is used to decode commands from one or multiple readers.
@@ -89,19 +92,88 @@ func (d *mergeDecoder) AddDecoder(decoder decoder) {
 	d.buf[decoder] = nil
 }
 
+type fileCallback func(fileName string)
+
 type singleDecoder struct {
-	decoder cmd.CmdDecoder
-	reader  cmd.LineReader
+	decoder       cmd.CmdDecoder
+	reader        cmd.LineReader
+	lg            *zap.Logger
+	onDecoded     fileCallback
+	markDecodeDone fileCallback
+	curFile       string
+	curEnd        time.Time
 }
 
-func newSingleDecoder(decoder cmd.CmdDecoder, reader cmd.LineReader) *singleDecoder {
+func newSingleDecoder(decoder cmd.CmdDecoder, reader cmd.LineReader, lg *zap.Logger, onDecoded, markDecodeDone fileCallback) *singleDecoder {
 	return &singleDecoder{
-		decoder: decoder,
-		reader:  reader,
+		decoder:        decoder,
+		reader:         reader,
+		lg:             lg,
+		onDecoded:      onDecoded,
+		markDecodeDone: markDecodeDone,
 	}
 }
 
-// Decode decodes a command from the single reader.
+// Decode decodes a command from the single reader. FileName switches here are per-reader,
+// so they genuinely mean the previous file of this reader is fully decoded.
 func (d *singleDecoder) Decode() (*cmd.Command, error) {
-	return d.decoder.Decode(d.reader)
+	cmd, err := d.decoder.Decode(d.reader)
+	if err != nil {
+		// EOF: the last file of this reader is done.
+		if errors.Is(err, io.EOF) && d.curFile != "" && d.markDecodeDone != nil {
+			d.markDecodeDone(d.curFile)
+			d.curFile = ""
+			d.curEnd = time.Time{}
+		}
+		return cmd, err
+	}
+	if cmd == nil || cmd.FileName == "" || cmd.StartTs.IsZero() {
+		return cmd, err
+	}
+
+	endTs := cmd.StartTs
+	if !cmd.EndTs.IsZero() {
+		endTs = cmd.EndTs
+	}
+
+	if d.curFile == "" {
+		d.curFile = cmd.FileName
+		d.curEnd = endTs
+		if d.onDecoded != nil {
+			d.onDecoded(cmd.FileName)
+		}
+		return cmd, nil
+	}
+
+	if cmd.FileName == d.curFile {
+		if endTs.After(d.curEnd) {
+			d.curEnd = endTs
+		}
+		if d.onDecoded != nil {
+			d.onDecoded(cmd.FileName)
+		}
+		return cmd, nil
+	}
+
+	if overlap := d.curEnd.Sub(cmd.StartTs); overlap > time.Minute {
+		d.lg.Warn("consecutive replay files have overlapping SQL timestamps",
+			zap.String("prev_file", d.curFile),
+			zap.String("cur_file", cmd.FileName),
+			zap.Duration("overlap", overlap),
+			zap.Time("prev_end", d.curEnd),
+			zap.Time("cur_start", cmd.StartTs),
+		)
+	}
+
+	// The previous file of this reader is fully decoded.
+	prevFile := d.curFile
+	d.curFile = cmd.FileName
+	d.curEnd = endTs
+	if d.markDecodeDone != nil {
+		d.markDecodeDone(prevFile)
+	}
+	if d.onDecoded != nil {
+		d.onDecoded(cmd.FileName)
+	}
+	return cmd, nil
 }

--- a/pkg/sqlreplay/replay/merge_decoder.go
+++ b/pkg/sqlreplay/replay/merge_decoder.go
@@ -95,13 +95,13 @@ func (d *mergeDecoder) AddDecoder(decoder decoder) {
 type fileCallback func(fileName string)
 
 type singleDecoder struct {
-	decoder       cmd.CmdDecoder
-	reader        cmd.LineReader
-	lg            *zap.Logger
-	onDecoded     fileCallback
+	decoder        cmd.CmdDecoder
+	reader         cmd.LineReader
+	lg             *zap.Logger
+	onDecoded      fileCallback
 	markDecodeDone fileCallback
-	curFile       string
-	curEnd        time.Time
+	curFile        string
+	curEnd         time.Time
 }
 
 func newSingleDecoder(decoder cmd.CmdDecoder, reader cmd.LineReader, lg *zap.Logger, onDecoded, markDecodeDone fileCallback) *singleDecoder {

--- a/pkg/sqlreplay/replay/merge_decoder_test.go
+++ b/pkg/sqlreplay/replay/merge_decoder_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type mockDecoder struct {
@@ -158,4 +160,73 @@ func TestMergeDecoderEmptyDecoders(t *testing.T) {
 	// Should return EOF immediately
 	_, err := merger.Decode()
 	require.Equal(t, io.EOF, err)
+}
+
+type mockCmdDecoder struct {
+	commands []*cmd.Command
+	index    int
+}
+
+func (d *mockCmdDecoder) Decode(_ cmd.LineReader) (*cmd.Command, error) {
+	if d.index >= len(d.commands) {
+		return nil, io.EOF
+	}
+	cmd := d.commands[d.index]
+	d.index++
+	return cmd, nil
+}
+
+func (d *mockCmdDecoder) SetCommandStartTime(time.Time) {}
+
+func TestSingleDecoderFileOverlapWarn(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	base := time.Date(2025, 9, 10, 10, 0, 0, 0, time.UTC)
+	decoder := newSingleDecoder(&mockCmdDecoder{commands: []*cmd.Command{
+		{FileName: "/data/tidb-audit-1.log", StartTs: base, EndTs: base.Add(5 * time.Minute)},
+		{FileName: "/data/tidb-audit-2.log", StartTs: base.Add(3 * time.Minute), EndTs: base.Add(8 * time.Minute)},
+	}}, nil, zap.New(core), nil, nil)
+
+	for range 2 {
+		_, err := decoder.Decode()
+		require.NoError(t, err)
+	}
+
+	entries := observed.FilterMessage("consecutive replay files have overlapping SQL timestamps").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, 2*time.Minute, entries[0].ContextMap()["overlap"].(time.Duration))
+}
+
+func TestSingleDecoderFileOverlapNoWarnWithinThreshold(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	base := time.Date(2025, 9, 10, 10, 0, 0, 0, time.UTC)
+	decoder := newSingleDecoder(&mockCmdDecoder{commands: []*cmd.Command{
+		{FileName: "/data/tidb-audit-1.log", StartTs: base, EndTs: base.Add(5 * time.Minute)},
+		{FileName: "/data/tidb-audit-2.log", StartTs: base.Add(4*time.Minute + 30*time.Second), EndTs: base.Add(8 * time.Minute)},
+	}}, nil, zap.New(core), nil, nil)
+
+	for range 2 {
+		_, err := decoder.Decode()
+		require.NoError(t, err)
+	}
+
+	require.Empty(t, observed.All())
+}
+
+func TestSingleDecoderFileOverlapUsesLastEndTs(t *testing.T) {
+	core, observed := observer.New(zap.WarnLevel)
+	base := time.Date(2025, 9, 10, 10, 0, 0, 0, time.UTC)
+	decoder := newSingleDecoder(&mockCmdDecoder{commands: []*cmd.Command{
+		{FileName: "/data/tidb-audit-1.log", StartTs: base, EndTs: base.Add(3 * time.Minute)},
+		{FileName: "/data/tidb-audit-1.log", StartTs: base.Add(2 * time.Minute), EndTs: base.Add(6 * time.Minute)},
+		{FileName: "/data/tidb-audit-2.log", StartTs: base.Add(4 * time.Minute)},
+	}}, nil, zap.New(core), nil, nil)
+
+	for range 3 {
+		_, err := decoder.Decode()
+		require.NoError(t, err)
+	}
+
+	entries := observed.FilterMessage("consecutive replay files have overlapping SQL timestamps").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, 2*time.Minute, entries[0].ContextMap()["overlap"].(time.Duration))
 }

--- a/pkg/sqlreplay/replay/replay.go
+++ b/pkg/sqlreplay/replay/replay.go
@@ -284,6 +284,7 @@ type replay struct {
 	exceptionCh      chan conn.Exception
 	closeConnCh      chan uint64
 	execInfoCh       chan conn.ExecInfo
+	fileExecTracker  *fileExecTracker
 	decodeCtx        context.Context
 	decodeCancel     context.CancelFunc
 	wg               waitgroup.WaitGroup
@@ -335,6 +336,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 	r.exceptionCh = make(chan conn.Exception, maxPendingExceptions)
 	r.closeConnCh = make(chan uint64, maxPendingCloseRequests)
 	r.execInfoCh = make(chan conn.ExecInfo, maxPendingExecInfo)
+	r.fileExecTracker = newFileExecTracker(r.lg)
 	key, err := store.LoadEncryptionKey(r.meta.EncryptMethod, cfg.KeyFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load encryption key")
@@ -350,6 +352,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 					connID:     connID,
 					closeCh:    r.closeConnCh,
 					execInfoCh: r.execInfoCh,
+					onCmdDone:  r.fileExecTracker.onExecuted,
 					stats:      &r.replayStats,
 				}
 			}
@@ -367,6 +370,7 @@ func (r *replay) Start(cfg ReplayConfig, backendTLSConfig *tls.Config, hsHandler
 					ExceptionCh:      r.exceptionCh,
 					CloseCh:          r.closeConnCh,
 					ExecInfoCh:       r.execInfoCh,
+					OnCmdDone:        r.fileExecTracker.onExecuted,
 					ReplayStats:      &r.replayStats,
 					Readonly:         cfg.ReadOnly,
 				})
@@ -639,7 +643,7 @@ func (r *replay) constructDecoderForReader(ctx context.Context, reader cmd.LineR
 	}
 
 	var decoder decoder
-	decoder = newSingleDecoder(cmdDecoder, reader)
+	decoder = newSingleDecoder(cmdDecoder, reader, r.lg, r.fileExecTracker.onDecoded, r.fileExecTracker.markDecodeDone)
 	if chanBufForEachDecoder > 0 {
 		decoder = newBufferedDecoder(ctx, decoder, chanBufForEachDecoder, r.cfg.IgnoreErrs)
 	}
@@ -1025,6 +1029,7 @@ func (r *replay) commonFields() []zap.Field {
 		zap.Uint64("filtered_cmds", r.replayStats.FilteredCmds.Load()),
 		zap.Uint64("decoded_cmds", r.decodedCmds.Load()),
 		zap.Uint64("exceptions", r.replayStats.ExceptionCmds.Load()),
+		zap.Uint64("disconnects", r.replayStats.Disconnects.Load()),
 		zap.Duration("total_wait_time", time.Duration(r.replayStats.TotalWaitTime.Load())), // if too short, decode is low
 		zap.Duration("extra_wait_time", time.Duration(r.replayStats.ExtraWaitTime.Load())), // if non-zero, replay is slow
 		zap.Duration("replay_elapsed", time.Since(r.startTime)),


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1194 

Problem Summary:
- Setting command-start-time doesn't work for audit log v2.
- Debug logs are not enough to troubleshoot.

What is changed and how it works:
- Fix command-end-time may be cleared in audit log v2
- Add logs for disconnections
- Add logs for audit log file overlap, which may cause QPS peaks
- Add logs for finishing decoding commands and executing commands, which helps to judge replay delay

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
