### PR TITLE
sqlreplay: retry transient traffic file listing failures

### DIFF
--- a/pkg/sqlreplay/store/const.go
+++ b/pkg/sqlreplay/store/const.go
@@ -14,4 +14,7 @@ const (
 	fileSize            = 300 << 20
 	bufferSize          = 1 << 20
 	opTimeout           = 10 * time.Second
+	readerPollInterval  = time.Second
+	readerRetryInitial  = time.Second
+	readerRetryMax      = 30 * time.Second
 )

--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/cenkalti/backoff/v4"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiproxy/lib/util/errors"
@@ -169,6 +170,9 @@ type fileReader struct {
 	reader   storage.ExternalFileReader
 }
 
+type walkFileFunc func(context.Context, string, func(string, int64) (bool, error)) error
+type openFileFunc func(context.Context, string, *storage.ReaderOption) (storage.ExternalFileReader, error)
+
 type rotateReader struct {
 	cfg          ReaderCfg
 	absolutePath string
@@ -180,6 +184,7 @@ type rotateReader struct {
 	wg           waitgroup.WaitGroup
 	cancel       context.CancelFunc
 	eof          bool
+	terminalErr  error
 
 	// fileMetaCache and fileMetaCacheIdx are used to access and cache file metadata.
 	// The fileMeta in the cache should be sorted by file index in ascending order.
@@ -262,16 +267,30 @@ func (r *rotateReader) closeFile() error {
 }
 
 func (r *rotateReader) openFileLoop(ctx context.Context) error {
+	return r.openFileLoopWithWalker(ctx, r.walkFile)
+}
+
+func (r *rotateReader) openFileLoopWithWalker(ctx context.Context, walkFile walkFileFunc) error {
+	return r.openFileLoopWithStorage(ctx, walkFile, r.storage.Open)
+}
+
+func (r *rotateReader) openFileLoopWithStorage(ctx context.Context, walkFile walkFileFunc, openFile openFileFunc) error {
 	var curFileTime time.Time
 	var curFileName string
 	var err error
+	retryBackoff := backoff.NewExponentialBackOff()
+	retryBackoff.InitialInterval = readerRetryInitial
+	retryBackoff.MaxInterval = readerRetryMax
+	retryBackoff.MaxElapsedTime = 0
+	retryBackoff.Reset()
+fileLoop:
 	for ctx.Err() == nil {
 		var minFileTime time.Time
 		var minFileName string
 		fileNamePrefix := getFileNamePrefix(r.cfg.Format)
 		childCtx, cancel := context.WithTimeout(ctx, opTimeout)
 		startTime := time.Now()
-		err = r.walkFile(childCtx, curFileName,
+		err = walkFile(childCtx, curFileName,
 			func(name string, size int64) (bool, error) {
 				if !strings.HasPrefix(name, fileNamePrefix) {
 					return false, nil
@@ -296,11 +315,26 @@ func (r *rotateReader) openFileLoop(ctx context.Context) error {
 			})
 		cancel()
 		if err != nil {
-			break
+			if ctx.Err() != nil {
+				err = nil
+				break
+			}
+			if !r.cfg.WaitOnEOF {
+				break
+			}
+			if !r.waitForStorageRetry(ctx, retryBackoff, "list files", err) {
+				err = nil
+				break
+			}
+			continue
 		}
 		if minFileName == "" {
+			retryBackoff.Reset()
 			if r.cfg.WaitOnEOF {
-				time.Sleep(10 * time.Millisecond)
+				if !waitForContext(ctx, readerPollInterval) {
+					err = nil
+					break
+				}
 				continue
 			} else {
 				err = io.EOF
@@ -309,11 +343,25 @@ func (r *rotateReader) openFileLoop(ctx context.Context) error {
 		}
 		// storage.Open(ctx) stores the context internally for subsequent reads, so don't set a short timeout.
 		var fr storage.ExternalFileReader
-		fr, err = r.storage.Open(ctx, minFileName, &storage.ReaderOption{})
-		if err != nil {
+		for {
+			fr, err = openFile(ctx, minFileName, &storage.ReaderOption{})
+			if err == nil {
+				break
+			}
 			err = errors.WithStack(err)
-			break
+			if ctx.Err() != nil {
+				err = nil
+				break fileLoop
+			}
+			if !r.cfg.WaitOnEOF {
+				break fileLoop
+			}
+			if !r.waitForStorageRetry(ctx, retryBackoff, "open file", err) {
+				err = nil
+				break fileLoop
+			}
 		}
+		retryBackoff.Reset()
 		curFileTime = minFileTime
 		curFileName = minFileName
 		r.lg.Info("opening next file", zap.String("file", path.Join(r.storage.URI(), minFileName)),
@@ -322,15 +370,44 @@ func (r *rotateReader) openFileLoop(ctx context.Context) error {
 		select {
 		case r.fileCh <- fileReader{fileName: minFileName, reader: fr}:
 		case <-ctx.Done():
+			_ = fr.Close()
 		}
 	}
+	r.terminalErr = err
 	close(r.fileCh)
 	return err
+}
+
+func (r *rotateReader) waitForStorageRetry(ctx context.Context, retryBackoff backoff.BackOff, operation string, err error) bool {
+	retryAfter := retryBackoff.NextBackOff()
+	if retryAfter == backoff.Stop {
+		return false
+	}
+	r.lg.Warn("traffic storage operation failed, retrying",
+		zap.String("operation", operation),
+		zap.String("dir", r.cfg.Dir),
+		zap.Duration("retry_after", retryAfter),
+		zap.Error(err))
+	return waitForContext(ctx, retryAfter)
+}
+
+func waitForContext(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (r *rotateReader) nextReader() error {
 	fileReader, ok := <-r.fileCh
 	if !ok {
+		if r.terminalErr != nil {
+			return r.terminalErr
+		}
 		return io.EOF
 	}
 	r.reader = fileReader.reader

--- a/pkg/sqlreplay/store/rotate_test.go
+++ b/pkg/sqlreplay/store/rotate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/br/pkg/mock"
+	brstorage "github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/util/waitgroup"
@@ -291,6 +292,191 @@ func TestWaitOnEOF(t *testing.T) {
 	require.Equal(t, fileName, <-fileCh)
 	require.NoError(t, l.Close())
 	wg.Wait()
+}
+
+func TestWaitOnEOFRecoversFromWalkError(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	l := &rotateReader{
+		cfg: ReaderCfg{
+			Dir:       dir,
+			Format:    cmd.FormatAuditLogPlugin,
+			WaitOnEOF: true,
+		},
+		storage: storage,
+		lg:      zap.NewNop(),
+		fileCh:  make(chan fileReader, 1),
+	}
+	walkFailed := make(chan struct{})
+	firstAttempt := true
+	loopErr := startRotateReaderWithWalker(l, func(ctx context.Context, curFileName string, fn func(string, int64) (bool, error)) error {
+		if firstAttempt {
+			firstAttempt = false
+			close(walkFailed)
+			return context.DeadlineExceeded
+		}
+		return l.walkFile(ctx, curFileName, fn)
+	})
+
+	nextReaderErr := make(chan error, 1)
+	go func() {
+		nextReaderErr <- l.nextReader()
+	}()
+	select {
+	case <-walkFailed:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not encounter the injected storage error")
+	}
+
+	fileName := "tidb-audit-2025-09-10T17-01-56.073.log"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fileName), nil, 0666))
+	select {
+	case err := <-nextReaderErr:
+		require.NoError(t, err)
+		require.Equal(t, fileName, l.externalFile.fileName)
+	case <-time.After(3 * time.Second):
+		t.Fatal("reader did not recover after the storage error")
+	}
+	require.NoError(t, l.Close())
+	require.NoError(t, <-loopErr)
+}
+
+func TestRotateReaderPropagatesWalkError(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	l := &rotateReader{
+		cfg:     ReaderCfg{Dir: dir, Format: cmd.FormatAuditLogPlugin},
+		storage: storage,
+		lg:      zap.NewNop(),
+		fileCh:  make(chan fileReader, 1),
+	}
+	walkErr := errors.New("walk failed")
+	loopErr := startRotateReaderWithWalker(l, func(context.Context, string, func(string, int64) (bool, error)) error {
+		return walkErr
+	})
+	err = l.nextReader()
+	require.ErrorIs(t, err, walkErr)
+	require.NoError(t, l.Close())
+	require.ErrorIs(t, <-loopErr, walkErr)
+}
+
+func TestWaitOnEOFRetriesSameFileAfterOpenError(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	firstFile := "tidb-audit-2025-09-10T17-01-56.073.log"
+	secondFile := "tidb-audit-2025-09-10T17-02-56.073.log"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, firstFile), nil, 0666))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, secondFile), nil, 0666))
+	l := &rotateReader{
+		cfg: ReaderCfg{
+			Dir:       dir,
+			Format:    cmd.FormatAuditLogPlugin,
+			WaitOnEOF: true,
+		},
+		storage: storage,
+		lg:      zap.NewNop(),
+		fileCh:  make(chan fileReader, 1),
+	}
+	walkCount := 0
+	walkFile := func(_ context.Context, _ string, fn func(string, int64) (bool, error)) error {
+		fileName := firstFile
+		if walkCount > 0 {
+			fileName = secondFile
+		}
+		walkCount++
+		_, err := fn(fileName, 0)
+		return err
+	}
+	openCount := 0
+	openFile := func(ctx context.Context, name string, option *brstorage.ReaderOption) (brstorage.ExternalFileReader, error) {
+		openCount++
+		if openCount == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return storage.Open(ctx, name, option)
+	}
+	loopErr := startRotateReaderWithStorage(l, walkFile, openFile)
+
+	nextReaderErr := make(chan error, 1)
+	go func() {
+		nextReaderErr <- l.nextReader()
+	}()
+	select {
+	case err := <-nextReaderErr:
+		require.NoError(t, err)
+		require.Equal(t, firstFile, l.externalFile.fileName)
+	case <-time.After(3 * time.Second):
+		t.Fatal("reader did not recover from the open error")
+	}
+	require.NoError(t, l.Close())
+	require.NoError(t, <-loopErr)
+}
+
+func TestWaitOnEOFCloseInterruptsPoll(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+
+	l := &rotateReader{
+		cfg: ReaderCfg{
+			Dir:       dir,
+			Format:    cmd.FormatAuditLogPlugin,
+			WaitOnEOF: true,
+		},
+		storage: storage,
+		lg:      zap.NewNop(),
+		fileCh:  make(chan fileReader, 1),
+	}
+	walkDone := make(chan struct{}, 1)
+	loopErr := startRotateReaderWithWalker(l, func(ctx context.Context, curFileName string, fn func(string, int64) (bool, error)) error {
+		err := l.walkFile(ctx, curFileName, fn)
+		select {
+		case walkDone <- struct{}{}:
+		default:
+		}
+		return err
+	})
+	select {
+	case <-walkDone:
+	case <-time.After(time.Second):
+		t.Fatal("reader did not finish the initial file listing")
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- l.Close()
+	}()
+	select {
+	case err := <-closed:
+		require.NoError(t, err)
+	case <-time.After(readerPollInterval / 2):
+		t.Fatal("reader close did not interrupt the poll interval")
+	}
+	require.NoError(t, <-loopErr)
+}
+
+func startRotateReaderWithWalker(l *rotateReader, walkFile walkFileFunc) <-chan error {
+	return startRotateReaderWithStorage(l, walkFile, l.storage.Open)
+}
+
+func startRotateReaderWithStorage(l *rotateReader, walkFile walkFileFunc, openFile openFileFunc) <-chan error {
+	ctx, cancel := context.WithCancel(context.Background())
+	l.cancel = cancel
+	loopErr := make(chan error, 1)
+	l.wg.Run(func() {
+		loopErr <- l.openFileLoopWithStorage(ctx, walkFile, openFile)
+	}, l.lg)
+	return loopErr
 }
 
 func TestReadGZip(t *testing.T) {


### PR DESCRIPTION
## Problem

In dynamic replay with `WaitOnEOF`, a transient S3 `ListObjects` timeout caused the per-directory rotate reader to exit and close its file channel. The merge decoder then observed EOF and permanently removed that input while the directory watcher still considered the directory registered.

This made replay QPS fall as more readers timed out. The previous 10ms empty-tail polling also generated excessive S3 list requests.

## Changes

- Retry file listing failures at a 1s interval only when `WaitOnEOF` is enabled.
- Keep the existing 10s deadline for each file listing attempt.
- Change empty-tail polling from an unconditional 10ms sleep to a context-aware 1s wait.
- Preserve the existing behavior for file open failures and non-live replay.
- Add one regression test that injects `context deadline exceeded` and verifies that the same reader recovers and reads the next file.

## Tests

- `go test -p=1 ./pkg/sqlreplay/store -count=1`
- `go test -p=1 -race ./pkg/sqlreplay/store -run TestWaitOnEOFRecoversFromWalkError -count=1`
- `go test -p=1 ./pkg/sqlreplay/replay -run 'TestDynamicInput|TestMergeDecoder' -count=1`\n\nFull-repository lint was not run due to the available memory limit.