### PR TITLE
sqlreplay: remove timeout for storage Open and WalkDir

### DIFF
--- a/pkg/sqlreplay/store/rotate.go
+++ b/pkg/sqlreplay/store/rotate.go
@@ -180,6 +180,9 @@ type rotateReader struct {
 	wg           waitgroup.WaitGroup
 	cancel       context.CancelFunc
 	eof          bool
+	// openFileErr is set by openFileLoop before closing fileCh so nextReader can
+	// return the real WalkDir/Open error instead of io.EOF.
+	openFileErr error
 
 	// fileMetaCache and fileMetaCacheIdx cache file metadata returned by WalkDir.
 	// Up to walkBatchSize entries are cached per batch so openFileLoop can pick the
@@ -198,7 +201,7 @@ func newRotateReader(lg *zap.Logger, store storeapi.Storage, cfg ReaderCfg) (*ro
 	childCtx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 	r.wg.Run(func() {
-		if err := r.openFileLoop(childCtx); err != nil && !errors.Is(err, io.EOF) {
+		if err := r.openFileLoop(childCtx); err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 			r.lg.Error("open file loop failed", zap.Error(err))
 		}
 	}, lg)
@@ -222,6 +225,8 @@ func (r *rotateReader) Read(data []byte) (int, error) {
 			return m, nil
 		}
 		if !errors.Is(err, io.EOF) {
+			// Readers other than GCS and Local FS retry internally. Retrying here requires
+			// reopening the object and seeking to the last raw read offset.
 			return m, errors.WithStack(err)
 		}
 		_ = r.closeFile()
@@ -251,6 +256,7 @@ func (r *rotateReader) Close() error {
 }
 
 func (r *rotateReader) closeFile() error {
+	r.reader = nil
 	if r.externalFile.reader != nil && !reflect.ValueOf(r.externalFile.reader).IsNil() {
 		if err := r.externalFile.reader.Close(); err != nil {
 			r.lg.Warn("failed to close file", zap.String("filename", r.externalFile.fileName), zap.Error(err))
@@ -263,16 +269,16 @@ func (r *rotateReader) closeFile() error {
 }
 
 func (r *rotateReader) openFileLoop(ctx context.Context) error {
+	defer close(r.fileCh)
+
 	var curFileTime time.Time
 	var curFileName string
-	var err error
 	for ctx.Err() == nil {
 		var minFileTime time.Time
 		var minFileName string
 		fileNamePrefix := getFileNamePrefix(r.cfg.Format)
-		childCtx, cancel := context.WithTimeout(ctx, opTimeout)
 		startTime := time.Now()
-		err = r.walkFile(childCtx, curFileName,
+		err := r.walkFile(ctx, curFileName,
 			func(name string, size int64) (bool, error) {
 				if !strings.HasPrefix(name, fileNamePrefix) {
 					return false, nil
@@ -295,25 +301,25 @@ func (r *rotateReader) openFileLoop(ctx context.Context) error {
 				}
 				return false, nil
 			})
-		cancel()
 		if err != nil {
-			break
+			r.openFileErr = err
+			return err
 		}
 		if minFileName == "" {
 			if r.cfg.WaitOnEOF {
 				time.Sleep(10 * time.Millisecond)
 				continue
-			} else {
-				err = io.EOF
-				break
 			}
+			return io.EOF
 		}
-		// storage.Open(ctx) stores the context internally for subsequent reads, so don't set a short timeout.
-		var fr objectio.Reader
-		fr, err = r.storage.Open(ctx, minFileName, &storeapi.ReaderOption{})
+		// Storage implementations handle retries and timeouts inside Open.
+		fr, err := r.storage.Open(ctx, minFileName, &storeapi.ReaderOption{})
 		if err != nil {
-			err = errors.WithStack(err)
-			break
+			if fr != nil {
+				_ = fr.Close()
+			}
+			r.openFileErr = errors.WithStack(err)
+			return r.openFileErr
 		}
 		curFileTime = minFileTime
 		curFileName = minFileName
@@ -323,15 +329,19 @@ func (r *rotateReader) openFileLoop(ctx context.Context) error {
 		select {
 		case r.fileCh <- fileReader{fileName: minFileName, reader: fr}:
 		case <-ctx.Done():
+			_ = fr.Close()
+			return ctx.Err()
 		}
 	}
-	close(r.fileCh)
-	return err
+	return ctx.Err()
 }
 
 func (r *rotateReader) nextReader() error {
 	fileReader, ok := <-r.fileCh
 	if !ok {
+		if r.openFileErr != nil {
+			return r.openFileErr
+		}
 		return io.EOF
 	}
 	r.reader = fileReader.reader
@@ -342,10 +352,14 @@ func (r *rotateReader) nextReader() error {
 	var err error
 	if strings.HasSuffix(fileReader.fileName, fileCompressFormat) {
 		if r.reader, err = newCompressReader(r.reader); err != nil {
+			_ = r.closeFile()
 			return err
 		}
 	}
 	r.reader, err = newReaderWithEncryptOpts(r.reader, r.cfg.EncryptionMethod, r.cfg.EncryptionKey)
+	if err != nil {
+		_ = r.closeFile()
+	}
 	return err
 }
 
@@ -427,6 +441,7 @@ func (r *rotateReader) walkFile(ctx context.Context, curfileName string, fn func
 	walkOpt := r.buildWalkOption(curfileName)
 	batch := make([]fileMeta, 0, walkBatchSize)
 	selectedIdx := -1
+	// Storage implementations handle retries and timeouts inside WalkDir.
 	err := r.storage.WalkDir(ctx, walkOpt, func(name string, size int64) error {
 		if size <= 0 && strings.HasSuffix(name, "/") {
 			return nil

--- a/pkg/sqlreplay/store/rotate_test.go
+++ b/pkg/sqlreplay/store/rotate_test.go
@@ -19,8 +19,10 @@ import (
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/tidb/pkg/objstore/objectio"
 	"github.com/pingcap/tidb/pkg/objstore/s3store"
 	s3mock "github.com/pingcap/tidb/pkg/objstore/s3store/mock"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/sqlreplay/cmd"
 	"github.com/pingcap/tiproxy/pkg/util/waitgroup"
@@ -571,4 +573,74 @@ func TestWalkS3(t *testing.T) {
 	// Batch caching should list S3 in pages instead of once per file.
 	require.LessOrEqual(t, selectedFileCount, 5)
 	require.Equal(t, "tidb-audit-2025-09-19T16-54-45.999.log", curFilename)
+}
+
+func TestBrokenFileReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "traffic-2025-09-10T17-01-56.073.log.gz"), []byte("not gzip"), 0666))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "traffic-2025-09-10T17-01-56.172.log"), []byte("hello"), 0666))
+
+	l, err := newRotateReader(zap.NewNop(), storage, ReaderCfg{Dir: dir})
+	require.NoError(t, err)
+	defer l.Close()
+
+	data := make([]byte, 5)
+	n, err := io.ReadFull(l, data)
+	require.Error(t, err)
+	require.Zero(t, n)
+}
+
+type hookStorage struct {
+	storeapi.Storage
+	walkErr error
+	openErr error
+}
+
+func (s *hookStorage) WalkDir(ctx context.Context, opt *storeapi.WalkOption, fn func(string, int64) error) error {
+	if s.walkErr != nil {
+		return s.walkErr
+	}
+	return s.Storage.WalkDir(ctx, opt, fn)
+}
+
+func (s *hookStorage) Open(ctx context.Context, path string, o *storeapi.ReaderOption) (objectio.Reader, error) {
+	if s.openErr != nil {
+		return nil, s.openErr
+	}
+	return s.Storage.Open(ctx, path, o)
+}
+
+func TestWalkDirErrorNotEOF(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "traffic-2025-09-10T17-01-56.073.log"), []byte("hello"), 0666))
+
+	listErr := fmt.Errorf("list objects failed")
+	l, err := newRotateReader(zap.NewNop(), &hookStorage{Storage: storage, walkErr: listErr}, ReaderCfg{Dir: dir})
+	require.NoError(t, err)
+	defer l.Close()
+
+	err = l.nextReader()
+	require.ErrorIs(t, err, listErr)
+}
+
+func TestOpenErrorNotEOF(t *testing.T) {
+	dir := t.TempDir()
+	storage, err := NewStorage(dir)
+	require.NoError(t, err)
+	defer storage.Close()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "traffic-2025-09-10T17-01-56.073.log"), []byte("hello"), 0666))
+
+	openErr := fmt.Errorf("open object failed")
+	l, err := newRotateReader(zap.NewNop(), &hookStorage{Storage: storage, openErr: openErr}, ReaderCfg{Dir: dir})
+	require.NoError(t, err)
+	defer l.Close()
+
+	err = l.nextReader()
+	require.ErrorIs(t, err, openErr)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1208

Problem Summary:
Object storage operations like `GetObject` and `ListObjects` retry internally, and the TiDB package has already passed the retryer in, e.g. https://github.com/pingcap/tidb/blob/v26.3.10/pkg/objstore/s3store/store.go#L83
The max retries is 20, and the intervals are `1 + random[0, 1) * 2^N` for the first 5 retries, and 32s for the remaining retries, so the total retry time will be around 7.5min to 8.5 min, while TiProxy sets a 10s timeout, which is too short. The TiDB callers of object storage, such as global sort, lightning, import into, BR, don't retry or set a timeout.

What is changed and how it works:
1. Do not set a timeout for `Open` and `WalkDir`
2. If `Open` or `WalkDir` fails, return the error in `Read`, instead of returning `EOF`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File rotation now reports storage, file access, and cancellation errors accurately instead of incorrectly returning end-of-file.
  - Improved cleanup prevents stale or partially opened readers from remaining active when cancellation or wrapping errors occur.
- **Tests**
  - Added coverage for corrupted compressed files and for propagating directory listing and file-opening errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->