### PR TITLE
vip: switch VIP when the owner rejects connections

### DIFF
--- a/pkg/manager/health/health.go
+++ b/pkg/manager/health/health.go
@@ -52,9 +52,10 @@ func (m *Manager) Healthy() (bool, string) {
 }
 
 // RejectConns reports whether new connections should be rejected and returns a
-// reason string. Used by the proxy server. It returns true only on memory
-// pressure; graceful shutdown does NOT reject here, because the proxy keeps
-// accepting until its listeners are closed.
+// reason string. Used by the proxy server and the VIP manager. It returns true
+// only on memory pressure; graceful shutdown does NOT reject here, because the
+// proxy keeps accepting until its listeners are closed. The VIP release on
+// graceful shutdown is handled by PreClose.
 func (m *Manager) RejectConns() (bool, string) {
 	if m.rejectCheck != nil {
 		if reject, reason := m.rejectCheck(); reject {

--- a/pkg/manager/vip/manager.go
+++ b/pkg/manager/vip/manager.go
@@ -31,10 +31,26 @@ const (
 	garpRefreshInterval = 1 * time.Second
 )
 
+// servingCheckInterval is how often the VIP manager re-evaluates whether the
+// instance is rejecting connections. It is a variable so tests can
+// shorten it to speed up the resign/recompete transitions.
+var servingCheckInterval = 1 * time.Second
+
 type VIPManager interface {
 	Start(context.Context, *clientv3.Client) error
+	// SetConnRejecter configures the checker that decides whether the instance is
+	// rejecting new connections. When it reports a rejection, the manager resigns
+	// the VIP owner so a healthy node takes over, and re-campaigns once it stops
+	// rejecting.
+	SetConnRejecter(ConnRejecter)
 	PreClose()
 	Close()
+}
+
+// ConnRejecter reports whether the instance is currently rejecting new
+// connections.
+type ConnRejecter interface {
+	RejectConns() (bool, string)
 }
 
 var _ VIPManager = (*vipManager)(nil)
@@ -52,6 +68,17 @@ type vipManager struct {
 	cfgGetter config.ConfigGetter
 	election  elect.Election
 	lg        *zap.Logger
+	// rejecter, when set, drives the resign/recompete loop. nil keeps the
+	// historical behavior of always competing for the VIP.
+	rejecter ConnRejecter
+	// newElection creates and starts a fresh election. It is set in Start,
+	// closing over the etcd client, election parameters, and the start context
+	// so they don't need to live as separate fields. Tests override it to avoid
+	// a real etcd server.
+	newElection func() elect.Election
+	startCtx    context.Context
+	startCancel context.CancelFunc
+	watchWG     waitgroup.WaitGroup
 }
 
 func NewVIPManager(lg *zap.Logger, cfgGetter config.ConfigGetter) (*vipManager, error) {
@@ -76,6 +103,14 @@ func NewVIPManager(lg *zap.Logger, cfgGetter config.ConfigGetter) (*vipManager, 
 	return vm, nil
 }
 
+// SetConnRejecter configures the checker that decides whether this instance is
+// rejecting new connections. It must be called before Start. When the checker
+// reports a rejection, the VIP manager resigns the owner so a healthy node
+// takes over, and re-campaigns once it stops rejecting.
+func (vm *vipManager) SetConnRejecter(r ConnRejecter) {
+	vm.rejecter = r
+}
+
 func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error {
 	vm.mu.Lock()
 	defer vm.mu.Unlock()
@@ -93,9 +128,81 @@ func (vm *vipManager) Start(ctx context.Context, etcdCli *clientv3.Client) error
 	id := net.JoinHostPort(ip, port)
 	electionCfg := elect.DefaultElectionConfig(sessionTTL)
 	key := fmt.Sprintf(vipKey, vm.operation.Addr())
-	vm.election = elect.NewElection(vm.lg.Named("elect"), etcdCli, electionCfg, id, key, vm)
-	vm.election.Start(ctx)
+	vm.startCtx, vm.startCancel = context.WithCancel(ctx)
+	startCtx := vm.startCtx
+	vm.newElection = func() elect.Election {
+		e := elect.NewElection(vm.lg.Named("elect"), etcdCli, electionCfg, id, key, vm)
+		e.Start(startCtx)
+		return e
+	}
+	vm.election = vm.newElection()
+
+	// The watcher is a no-op when there is no rejecter, preserving the
+	// historical always-compete behavior.
+	if vm.rejecter != nil {
+		watchCtx := vm.startCtx
+		vm.watchWG.RunWithRecover(func() {
+			vm.watchRejecter(watchCtx)
+		}, nil, vm.lg)
+	}
 	return nil
+}
+
+// resign drops the current election so the etcd lease is revoked and another
+// node can take over. election.Close retires this member, which removes the
+// VIP locally via OnRetired.
+func (vm *vipManager) resign() {
+	vm.mu.Lock()
+	if vm.closing || vm.election == nil {
+		vm.mu.Unlock()
+		return
+	}
+	election := vm.election
+	vm.election = nil
+	vm.mu.Unlock()
+	// election.Close synchronously invokes OnRetired, which needs vm.mu, so it
+	// must run outside the lock to avoid a self-deadlock.
+	vm.lg.Info("resign VIP owner because the instance rejects new connections")
+	election.Close()
+}
+
+// recompete creates a new election and starts campaigning after recovery.
+func (vm *vipManager) recompete() {
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	if vm.closing || vm.election != nil {
+		return
+	}
+	vm.lg.Info("recompete for VIP because the instance accepts new connections")
+	vm.election = vm.newElection()
+}
+
+// watchRejecter polls the rejecter and flips the VIP ownership on transitions.
+// Polling is intentional: the health signal is a simple boolean with no event
+// channel, and the interval is bounded by the election TTL so failover latency
+// stays comparable to an etcd session expiry. The instance never rejects at
+// startup, so the initial state is assumed to be not rejecting.
+func (vm *vipManager) watchRejecter(ctx context.Context) {
+	ticker := time.NewTicker(servingCheckInterval)
+	defer ticker.Stop()
+	wasRejecting := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reject, _ := vm.rejecter.RejectConns()
+			if reject == wasRejecting {
+				continue
+			}
+			wasRejecting = reject
+			if reject {
+				vm.resign()
+			} else {
+				vm.recompete()
+			}
+		}
+	}
 }
 
 func (vm *vipManager) OnElected() {
@@ -208,6 +315,7 @@ func (vm *vipManager) stopARPRefresh() {
 // shutdowns do not expose the VIP on two nodes at the same time.
 func (vm *vipManager) PreClose() {
 	election := vm.prepareForClose()
+	vm.watchWG.Wait()
 	if election != nil {
 		election.Close()
 	}
@@ -216,6 +324,7 @@ func (vm *vipManager) PreClose() {
 // Close resigns the owner and makes sure the VIP is removed locally.
 func (vm *vipManager) Close() {
 	election := vm.prepareForClose()
+	vm.watchWG.Wait()
 	if election != nil {
 		election.Close()
 	}
@@ -231,5 +340,14 @@ func (vm *vipManager) prepareForClose() elect.Election {
 	vm.closing = true
 	vm.stopARPRefresh()
 	vm.delVIP(context.Background())
-	return vm.election
+	// Cancel the start context so the rejecter watcher and any in-flight election
+	// campaign loop stop. watchWG is waited outside the lock to avoid deadlocking
+	// with a watcher callback that may be waiting for vm.mu.
+	if vm.startCancel != nil {
+		vm.startCancel()
+		vm.startCancel = nil
+	}
+	election := vm.election
+	vm.election = nil
+	return election
 }

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -329,9 +329,9 @@ func TestRejecterWatcherResignsAndRecompetes(t *testing.T) {
 	require.Eventually(t, func() bool { return operation.hasIP.Load() }, time.Second, 10*time.Millisecond)
 	require.EqualValues(t, 1, operation.addIPCnt.Load())
 
-	// Start the rejecter watcher. The instance is currently not rejecting.
-	watchCtx, watchCancel := context.WithCancel(context.Background())
-	vm.watchWG.RunWithRecover(func() { vm.watchRejecter(watchCtx) }, nil, vm.lg)
+	// Start the rejecter watcher, driven by vm.startCtx so that PreClose's
+	// cancellation of startCtx (and watchWG wait) is the shutdown path under test.
+	vm.watchWG.RunWithRecover(func() { vm.watchRejecter(vm.startCtx) }, nil, vm.lg)
 
 	// Flip to rejecting: the watcher resigns, which retires and drops the VIP.
 	rejecter.reject.Store(true)
@@ -344,7 +344,7 @@ func TestRejecterWatcherResignsAndRecompetes(t *testing.T) {
 	require.EqualValues(t, 2, operation.addIPCnt.Load())
 
 	// Shutdown: closing must release the VIP and stop the watcher without deadlock.
-	watchCancel()
+	// PreClose cancels vm.startCtx (stopping the watcher) and waits for watchWG.
 	vm.PreClose()
 	vm.Close()
 	require.False(t, operation.hasIP.Load())

--- a/pkg/manager/vip/manager_test.go
+++ b/pkg/manager/vip/manager_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/pingcap/tiproxy/lib/config"
 	"github.com/pingcap/tiproxy/lib/util/logger"
 	"github.com/pingcap/tiproxy/pkg/manager/cert"
+	"github.com/pingcap/tiproxy/pkg/manager/elect"
 	"github.com/pingcap/tiproxy/pkg/util/etcd"
 	"github.com/stretchr/testify/require"
 )
@@ -295,6 +298,58 @@ func TestStartAndClose(t *testing.T) {
 	}
 }
 
+func TestRejecterWatcherResignsAndRecompetes(t *testing.T) {
+	// Shorten the polling interval so transitions happen within the test window.
+	origInterval := servingCheckInterval
+	servingCheckInterval = 10 * time.Millisecond
+	defer func() { servingCheckInterval = origInterval }()
+
+	lg, _ := logger.CreateLoggerForTest(t)
+	operation := newMockNetworkOperation()
+	operation.hasIP.Store(false)
+	rejecter := &mockConnRejecter{}
+	rejecter.reject.Store(false)
+
+	vm := &vipManager{
+		lg:        lg,
+		cfgGetter: newMockConfigGetter(newMockConfig()),
+		operation: operation,
+		rejecter:  rejecter,
+	}
+	vm.newElection = func() elect.Election {
+		e := &autoElection{member: vm}
+		e.Start(vm.startCtx)
+		return e
+	}
+	vm.startCtx, vm.startCancel = context.WithCancel(context.Background())
+	// Start competing: the auto election wins immediately and binds the VIP.
+	vm.mu.Lock()
+	vm.election = vm.newElection()
+	vm.mu.Unlock()
+	require.Eventually(t, func() bool { return operation.hasIP.Load() }, time.Second, 10*time.Millisecond)
+	require.EqualValues(t, 1, operation.addIPCnt.Load())
+
+	// Start the rejecter watcher. The instance is currently not rejecting.
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+	vm.watchWG.RunWithRecover(func() { vm.watchRejecter(watchCtx) }, nil, vm.lg)
+
+	// Flip to rejecting: the watcher resigns, which retires and drops the VIP.
+	rejecter.reject.Store(true)
+	require.Eventually(t, func() bool { return !operation.hasIP.Load() }, 3*time.Second, 10*time.Millisecond)
+	require.EqualValues(t, 1, operation.delIPCnt.Load())
+
+	// Flip back to not rejecting: the watcher recompetes, wins, and rebinds the VIP.
+	rejecter.reject.Store(false)
+	require.Eventually(t, func() bool { return operation.hasIP.Load() }, 3*time.Second, 10*time.Millisecond)
+	require.EqualValues(t, 2, operation.addIPCnt.Load())
+
+	// Shutdown: closing must release the VIP and stop the watcher without deadlock.
+	watchCancel()
+	vm.PreClose()
+	vm.Close()
+	require.False(t, operation.hasIP.Load())
+}
+
 func TestMultiVIP(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		return
@@ -355,4 +410,44 @@ func (e *closeHookElection) Close() {
 	if e.closeFn != nil {
 		e.closeFn()
 	}
+}
+
+var _ elect.Election = (*autoElection)(nil)
+
+// autoElection calls OnElected on Start (simulating an immediate win) and
+// OnRetired on Close (simulating losing ownership). OnElected is delivered
+// asynchronously, like the real election, so callers that start the election
+// while holding the member's lock do not deadlock.
+type autoElection struct {
+	member  elect.Member
+	started atomic.Bool
+	closed  atomic.Bool
+	wg      sync.WaitGroup
+}
+
+func (e *autoElection) Start(context.Context) {
+	if e.started.Swap(true) {
+		return
+	}
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		e.member.OnElected()
+	}()
+}
+
+func (e *autoElection) ID() string {
+	return ""
+}
+
+func (e *autoElection) GetOwnerID(context.Context) (string, error) {
+	return "", nil
+}
+
+func (e *autoElection) Close() {
+	if !e.started.Load() || e.closed.Swap(true) {
+		return
+	}
+	e.wg.Wait()
+	e.member.OnRetired()
 }

--- a/pkg/manager/vip/mock_test.go
+++ b/pkg/manager/vip/mock_test.go
@@ -89,6 +89,19 @@ func (me *mockElection) Close() {
 	me.wg.Wait()
 }
 
+var _ ConnRejecter = (*mockConnRejecter)(nil)
+
+type mockConnRejecter struct {
+	reject atomic.Bool
+}
+
+func (m *mockConnRejecter) RejectConns() (bool, string) {
+	if m.reject.Load() {
+		return true, "mock reject"
+	}
+	return false, ""
+}
+
 var _ NetworkOperation = (*mockNetworkOperation)(nil)
 
 type mockNetworkOperation struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -217,6 +217,9 @@ func NewServer(ctx context.Context, sctx *sctx.Context) (srv *Server, err error)
 			return
 		}
 		if srv.vipManager != nil && !reflect.ValueOf(srv.vipManager).IsNil() {
+			// Release the VIP while this instance is rejecting connections (e.g. under
+			// memory pressure) so a healthy node takes over, and re-campaign on recovery.
+			srv.vipManager.SetConnRejecter(srv.healthMgr)
 			if vipEtcdCli != nil {
 				if err = srv.vipManager.Start(ctx, vipEtcdCli); err != nil {
 					return


### PR DESCRIPTION
<!--

Thank you for contributing to TiProxy!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close: #xxx" or "ref: #xxx".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #1200

Problem Summary:
When the VIP owner rejects connections because of high memory usage, the client can't connect to the database.

What is changed and how it works:
The vipManager reads from the healthManager periodically. When the instance rejects connections, resign the owner. When the instance accepts connections again, recompete the owner.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Mock the TiProxy code to test VIP. Logs:

```
21:26:22  adding VIP success                          # start process
21:28:17  resign VIP owner because the instance rejects new connections  # mock high memory
21:28:17  deleting VIP success                          # release VIP
21:30:17  recompete for VIP because the instance accepts new connections # mock low memory
21:30:17  adding VIP success                            # bind VIP again
21:31:31  deleting VIP success            # PreClose releases VIP
21:31:31  SQL server prepares for shutdown
21:31:31  SQL server is shutting down (conn_count=0)
21:31:31  force closing connections (conn_count=0)
21:31:31  HTTP closed
exit_code: 0   status: succeeded          # no errors
```

Notable changes

- [ ] Has configuration change
- [ ] Has HTTP API interfaces change
- [ ] Has tiproxyctl change
- [ ] Other user behavior changes

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VIP ownership now responds to connection rejection status.
  * When an instance begins rejecting connections, it releases the VIP so a healthy instance can take over.
  * VIP ownership is restored automatically after connection rejection clears.

* **Bug Fixes**
  * Improved shutdown handling to ensure VIP monitoring stops cleanly before election resources close.

* **Documentation**
  * Clarified connection-rejection and graceful-shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->